### PR TITLE
Removing dereference for XML creation.

### DIFF
--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -11,7 +11,6 @@ from lxml import etree
 from lxml.etree import Element, SubElement
 
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.config.jinja2 import dereference
 from uwtools.config.validator import validate_yaml
 from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import log
@@ -348,7 +347,7 @@ class _RocotoXML:
             lines.insert(1, doctype)
         return "\n".join(lines)
 
-    def _set_and_render_jobname(self, config: dict, taskname: str) -> dict:
+    def _set_and_render_jobname(self, config: dict, taskname: str) -> None:
         """
         In the given config, ensure 'jobname' is set, then render {{ jobname }}.
 
@@ -357,9 +356,6 @@ class _RocotoXML:
         """
         if STR.jobname not in config:
             config[STR.jobname] = taskname
-        new = dereference(val=config, context={STR.jobname: config[STR.jobname]})
-        assert isinstance(new, dict)
-        return new
 
     def _set_attrs(self, e: Element, config: dict) -> None:
         """

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -406,14 +406,6 @@ class Test__RocotoXML:
             _doctype.return_value = None
             assert instance._insert_doctype("foo\nbaz\n") == "foo\nbaz\n"
 
-    def test__set_and_render_jobname(self, instance):
-        config = {"foo": "{{ jobname }}", "baz": "{{ qux }}"}
-        assert instance._set_and_render_jobname(config=config, taskname="bar") == {
-            "jobname": "bar",  # set
-            "foo": "bar",  # rendered
-            "baz": "{{ qux }}",  # ignored
-        }
-
     def test__setattrs(self, instance, root):
         config = {"attrs": {"foo": "1", "bar": "2"}}
         instance._set_attrs(e=root, config=config)


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Description**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

Removes dereferencing when transforming a YAML into Rocoto XML. This is meant as a stop-gap while reification is in place, so the test to support that feature was also removed.

**Type**

Select one or more:

- [x] Bug fix (corrects a known issue)


**Impact**

Select one:

- [x] This is a breaking change (changes existing functionality)

**Checklist**

Affirm:

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
