### PR TITLE
typo-and-whitespace-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Unified Workflow Tools for use with UFS applications and beyond
 
 ## Documentation
 
-Comprehensive documentation is available for [the version under development](https://uwtools.readthedocs.io/en/develop/) and for [the latest release](https://uwtools.readthedocs.io/en/main/).
+Comprehensive documentation is available for [the development version](https://uwtools.readthedocs.io/en/develop/) and for [the latest release](https://uwtools.readthedocs.io/en/main/).

--- a/docs/sections/contributor_guide/developer_setup.rst
+++ b/docs/sections/contributor_guide/developer_setup.rst
@@ -8,18 +8,18 @@ If an existing conda (:miniforge:`Miniforge<>`, :miniconda:`Miniconda<>`, :anaco
 
 .. include:: ../../shared/miniforge3_instructions.rst
 
-2. Install the :anaconda-condev:`condev package<>` into the base environment.
+#. Install the :anaconda-condev:`condev package<>` into the base environment.
 
-  .. code-block:: text
+   .. code-block:: text
 
-    conda install -y -c maddenp condev
+      conda install -y -c maddenp condev
 
-3. In a clone of the :uwtools:`uwtools repository<>`, create the development shell.
+#. In a clone of the :uwtools:`uwtools repository<>`, create the development shell.
 
-  .. code-block:: text
+   .. code-block:: text
 
-    cd /to/your/uwtools/clone
-    make devshell
+      cd /to/your/uwtools/clone
+      make devshell
 
 If the above is successful, you will be in a ``uwtools`` development shell. See below for usage information. You may exit the shell with ``exit`` or ``ctrl-d``.
 
@@ -33,9 +33,9 @@ If your development shell misses any functionality you’re used to in your main
 
 .. code-block:: text
 
-  cat <<EOF >~/.condevrc
-  source ~/.bashrc
-  EOF
+   cat <<EOF >~/.condevrc
+   source ~/.bashrc
+   EOF
 
 Using a ``bash`` Development Shell
 ----------------------------------
@@ -66,10 +66,10 @@ As an alternative to installing :anaconda-condev:`pre-built package<>`, the ``co
 
 .. code-block:: text
 
-  # Activate your conda
-  git clone https://github.com/maddenp/condev.git
-  make -C condev package
-  conda install -y -c local condev
+   # Activate your conda
+   git clone https://github.com/maddenp/condev.git
+   make -C condev package
+   conda install -y -c local condev
 
 Files Derived from ``condev``
 -----------------------------
@@ -78,13 +78,13 @@ The following files in this repo are derived from their counterparts in the :con
 
 .. code-block:: text
 
-  ├── Makefile
-  ├── recipe
-  │   ├── build.sh
-  │   ├── channels
-  │   ├── meta.json
-  │   ├── meta.yaml
-  │   └── run_test.sh
-  ├── src
-  │   ├── pyproject.toml
-  │   ├── setup.py
+   ├── Makefile
+   ├── recipe
+   │   ├── build.sh
+   │   ├── channels
+   │   ├── meta.json
+   │   ├── meta.yaml
+   │   └── run_test.sh
+   ├── src
+   │   ├── pyproject.toml
+   │   ├── setup.py

--- a/docs/sections/contributor_guide/documentation.rst
+++ b/docs/sections/contributor_guide/documentation.rst
@@ -15,7 +15,7 @@ The ``make docs`` command will build the docs under ``docs/build/html``, after w
 
 .. code-block:: text
 
-  file://<filesystem-path-to-your-clone>/docs/build/html/index.index.html
+   file://<filesystem-path-to-your-clone>/docs/build/html/index.index.html
 
 Re-run ``make docs`` and refresh your browser after making and saving changes.
 
@@ -33,15 +33,33 @@ Documentation Guidelines
 
 Please follow these guidelines when contributing to the documentation:
 
+* Keep formatting consistent across pages. Update all pages when better ideas are discovered. Otherwise, follow the conventions established in existing content.
 * Ensure that the ``make docs`` command completes with no errors or warnings.
 * If the link-check portion of ``make docs`` reports that a URL is ``permanently`` redirected, update the link in the docs to use the new URL. Non-permanent redirects can be left as-is.
 * Do not manually wrap lines in the ``.rst`` files. Insert newlines only as needed to achieve correctly formatted HTML, and let HTML wrap long lines and/or provide a scrollbar.
-* Indent ``.. code-block::`` directives 2 spaces per nesting level to achieve the required alignment. For example, indent 0 spaces for code blocks that should align with text on the left margin, and 2 spaces for code blocks that should align with bulleted or numbered list text. Indent actual code 2 **extra** spaces under the ``.. code-block::`` directive.
 * Use one blank line between documentation elements (headers, paragraphs, code blocks, etc.) unless additional lines are necessary to achieve correctly formatted HTML.
 * Remove all trailing whitespace.
 * In general, avoid pronouns like "we" and "you". (Using "we" may be appropriate when synonymous with "The UW Team", "The UFS Community", etc., when the context is clear.) Prefer direct, factual statements about what the code does, requires, etc.
 * The synopsis information printed by ``uw [mode [submode]] --help`` is automatically wrapped and indented based on current terminal size. For visual consistency, please set your terminal width to 100 columns when running such commands to produce output to copy into the docs.
 * Follow the :rst:`RST Sections<basics.html#sections>` guidelines, underlining section headings with = characters, subsections with - characters, and subsubsections with ^ characters. If a further level of refinement is needed, use " to underline paragraph headers.
-* Keep formatting consistent across pages.
 * In [[sub]sub]section titles, capitalize all "principal" words. In practice this usually means all words but articles (a, an, the), logicals (and, etc.), and prepositions (for, of, etc.). Always fully capitalize acronyms (e.g., YAML).
 * Never capitalize proper names when their owners do not (e.g. write `"pandas" <https://pandas.pydata.org/>`_, not "Pandas", even at the start of a sentence) or when referring to a software artifact (e.g. write ``numpy`` when referring to the library, and "NumPy" when referring to the project).
+* When using the ``.. code-block::`` directive, align the actual code with the word ``code``. Also, when ``.. code-block::`` directives appear in bulleted or numberd lists, align them with the text following the space to the righ of the bullet/number. For example:
+
+  .. code-block:: text
+
+     * Lorem ipsum
+
+       .. code-block:: python
+
+          n = 88
+
+  or
+
+  .. code-block:: text
+
+     #. Lorem ipsum
+
+        .. code-block:: python
+
+           n = 88

--- a/docs/sections/user_guide/cli/mode_config.rst
+++ b/docs/sections/user_guide/cli/mode_config.rst
@@ -115,25 +115,25 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
      [2024-01-08T16:57:28]     INFO + values2.nml
      [2024-01-08T16:57:28]     INFO ---------------------------------------------------------------------
      [2024-01-08T16:57:28]     INFO values:       recipient:  - None + World
- 
+
   Note that ``uw`` logs to ``stderr``, so the stream can be redirected:
 
   .. code-block:: text
 
      $ uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose 2>compare.log
- 
+
   The content of ``compare.log``:
- 
+
    .. code-block:: text
- 
+
       [2024-01-08T16:59:20]    DEBUG Command: uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose
       [2024-01-08T16:59:20]     INFO - values1.nml
       [2024-01-08T16:59:20]     INFO + values2.nml
       [2024-01-08T16:59:20]     INFO ---------------------------------------------------------------------
       [2024-01-08T16:59:20]     INFO values:       recipient:  - None + World
-  
+
 .. _realize_configs_cli_examples:
- 
+
 ``realize``
 -----------
 

--- a/docs/sections/user_guide/cli/mode_config.rst
+++ b/docs/sections/user_guide/cli/mode_config.rst
@@ -5,25 +5,25 @@ The ``uw`` mode for handling configs.
 
 .. code-block:: text
 
-  $ uw config --help
-  usage: uw config [-h] MODE ...
+   $ uw config --help
+   usage: uw config [-h] MODE ...
 
-  Handle configs
+   Handle configs
 
-  Optional arguments:
-    -h, --help
-          Show help and exit
+   Optional arguments:
+     -h, --help
+           Show help and exit
 
-  Positional arguments:
-    MODE
-      compare
-          Compare configs
-      realize
-          Realize config
-      translate
-          Translate configs
-      validate
-          Validate config
+   Positional arguments:
+     MODE
+       compare
+           Compare configs
+       realize
+           Realize config
+       translate
+           Translate configs
+       validate
+           Validate config
 
 .. _compare_configs_cli_examples:
 
@@ -32,30 +32,30 @@ The ``uw`` mode for handling configs.
 
 .. code-block:: text
 
-  $ uw config compare --help
-  usage: uw config compare --file-1-path PATH --file-2-path PATH [-h]
-                           [--file-1-format {ini,nml,sh,yaml}] [--file-2-format {ini,nml,sh,yaml}]
-                           [--quiet] [--verbose]
+   $ uw config compare --help
+   usage: uw config compare --file-1-path PATH --file-2-path PATH [-h]
+                            [--file-1-format {ini,nml,sh,yaml}] [--file-2-format {ini,nml,sh,yaml}]
+                            [--quiet] [--verbose]
 
-  Compare configs
+   Compare configs
 
-  Required arguments:
-    --file-1-path PATH
-          Path to file 1
-    --file-2-path PATH
-          Path to file 2
+   Required arguments:
+     --file-1-path PATH
+           Path to file 1
+     --file-2-path PATH
+           Path to file 2
 
-  Optional arguments:
-    -h, --help
-          Show help and exit
-    --file-1-format {ini,nml,sh,yaml}
-          Format of file 1
-    --file-2-format {ini,nml,sh,yaml}
-          Format of file 2
-    --quiet, -q
-          Print no logging messages
-    --verbose, -v
-          Print all logging messages
+   Optional arguments:
+     -h, --help
+           Show help and exit
+     --file-1-format {ini,nml,sh,yaml}
+           Format of file 1
+     --file-2-format {ini,nml,sh,yaml}
+           Format of file 2
+     --quiet, -q
+           Print no logging messages
+     --verbose, -v
+           Print all logging messages
 
 Examples
 ^^^^^^^^
@@ -64,76 +64,76 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
 
 .. code-block:: fortran
 
-  &values
-    greeting = "Hello"
-    recipient = "World"
-  /
+   &values
+     greeting = "Hello"
+     recipient = "World"
+   /
 
 * Compare two config files with the same contents:
 
   .. code-block:: text
 
-    $ uw config compare --file-1-path values1.nml --file-2-path values2.nml
-    [2024-01-08T16:53:04]     INFO - values1.nml
-    [2024-01-08T16:53:04]     INFO + values2.nml
-    [2024-01-08T16:53:04]     INFO ---------------------------------------------------------------------
+     $ uw config compare --file-1-path values1.nml --file-2-path values2.nml
+     [2024-01-08T16:53:04]     INFO - values1.nml
+     [2024-01-08T16:53:04]     INFO + values2.nml
+     [2024-01-08T16:53:04]     INFO ---------------------------------------------------------------------
 
 * If there are differences between the config files, they will be shown below the dashed line. For example, with ``recipient: World`` removed from ``values1.nml``:
 
   .. code-block:: text
 
-    $ uw config compare --file-1-path values1.nml --file-2-path values2.nml
-    [2024-01-08T16:54:03]     INFO - values1.nml
-    [2024-01-08T16:54:03]     INFO + values2.nml
-    [2024-01-08T16:54:03]     INFO ---------------------------------------------------------------------
-    [2024-01-08T16:54:03]     INFO values:       recipient:  - None + World
+     $ uw config compare --file-1-path values1.nml --file-2-path values2.nml
+     [2024-01-08T16:54:03]     INFO - values1.nml
+     [2024-01-08T16:54:03]     INFO + values2.nml
+     [2024-01-08T16:54:03]     INFO ---------------------------------------------------------------------
+     [2024-01-08T16:54:03]     INFO values:       recipient:  - None + World
 
 * If a config file has an unrecognized (or no) extension, ``uw`` will not know how to parse its content:
 
   .. code-block:: text
 
-    $ uw config compare --file-1-path values.txt --file-2-path values1.nml
-    Cannot deduce format of 'values.txt' from unknown extension 'txt'
+     $ uw config compare --file-1-path values.txt --file-2-path values1.nml
+     Cannot deduce format of 'values.txt' from unknown extension 'txt'
 
   In this case, the format can be explicitly specified (``values.txt`` is a copy of ``values1.nml``):
 
   .. code-block:: text
 
-    $ uw config compare --file-1-path values.txt --file-1-format nml --file-2-path values2.nml
-    [2024-01-08T16:56:54]     INFO - values.txt
-    [2024-01-08T16:56:54]     INFO + values2.nml
-    [2024-01-08T16:56:54]     INFO ---------------------------------------------------------------------
-    [2024-01-08T16:56:54]     INFO values:       recipient:  - None + World
+     $ uw config compare --file-1-path values.txt --file-1-format nml --file-2-path values2.nml
+     [2024-01-08T16:56:54]     INFO - values.txt
+     [2024-01-08T16:56:54]     INFO + values2.nml
+     [2024-01-08T16:56:54]     INFO ---------------------------------------------------------------------
+     [2024-01-08T16:56:54]     INFO values:       recipient:  - None + World
 
 * Request verbose log output:
 
   .. code-block:: text
 
-    $ uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose
-    [2024-01-08T16:57:28]    DEBUG Command: uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose
-    [2024-01-08T16:57:28]     INFO - values1.nml
-    [2024-01-08T16:57:28]     INFO + values2.nml
-    [2024-01-08T16:57:28]     INFO ---------------------------------------------------------------------
-    [2024-01-08T16:57:28]     INFO values:       recipient:  - None + World
-
+     $ uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose
+     [2024-01-08T16:57:28]    DEBUG Command: uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose
+     [2024-01-08T16:57:28]     INFO - values1.nml
+     [2024-01-08T16:57:28]     INFO + values2.nml
+     [2024-01-08T16:57:28]     INFO ---------------------------------------------------------------------
+     [2024-01-08T16:57:28]     INFO values:       recipient:  - None + World
+ 
   Note that ``uw`` logs to ``stderr``, so the stream can be redirected:
 
   .. code-block:: text
 
-    $ uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose 2>compare.log
-
+     $ uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose 2>compare.log
+ 
   The content of ``compare.log``:
-
-  .. code-block:: text
-
-    [2024-01-08T16:59:20]    DEBUG Command: uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose
-    [2024-01-08T16:59:20]     INFO - values1.nml
-    [2024-01-08T16:59:20]     INFO + values2.nml
-    [2024-01-08T16:59:20]     INFO ---------------------------------------------------------------------
-    [2024-01-08T16:59:20]     INFO values:       recipient:  - None + World
-
+ 
+   .. code-block:: text
+ 
+      [2024-01-08T16:59:20]    DEBUG Command: uw config compare --file-1-path values1.nml --file-2-path values2.nml --verbose
+      [2024-01-08T16:59:20]     INFO - values1.nml
+      [2024-01-08T16:59:20]     INFO + values2.nml
+      [2024-01-08T16:59:20]     INFO ---------------------------------------------------------------------
+      [2024-01-08T16:59:20]     INFO values:       recipient:  - None + World
+  
 .. _realize_configs_cli_examples:
-
+ 
 ``realize``
 -----------
 
@@ -180,62 +180,62 @@ The examples that follow use YAML file ``config.yaml`` with content
 
 .. code-block:: yaml
 
-  values:
-    date: '{{ yyyymmdd }}'
-    empty:
-    greeting: Hello
-    message: '{{ (greeting + " " + recipient + " ") * repeat }}'
-    recipient: World
-    repeat: 1
+   values:
+     date: '{{ yyyymmdd }}'
+     empty:
+     greeting: Hello
+     message: '{{ (greeting + " " + recipient + " ") * repeat }}'
+     recipient: World
+     repeat: 1
 
 supplemental YAML file ``values1.yaml`` with content
 
 .. code-block:: yaml
 
-  values:
-    date: 20240105
-    greeting: Good Night
-    recipient: Moon
-    repeat: 2
+   values:
+     date: 20240105
+     greeting: Good Night
+     recipient: Moon
+     repeat: 2
 
 and additional supplemental YAML file ``values2.yaml`` with content
 
 .. code-block:: yaml
 
-  values:
-    empty: false
-    repeat: 3
+   values:
+     empty: false
+     repeat: 3
 
 * Show the values in the input config file that have unrendered Jinja2 variables/expressions or empty keys:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.yaml --output-format yaml --values-needed
-    [2024-01-10T21:29:20]     INFO Keys that are complete:
-    [2024-01-10T21:29:20]     INFO     values
-    [2024-01-10T21:29:20]     INFO     values.greeting
-    [2024-01-10T21:29:20]     INFO     values.message
-    [2024-01-10T21:29:20]     INFO     values.recipient
-    [2024-01-10T21:29:20]     INFO     values.repeat
-    [2024-01-10T21:29:20]     INFO 
-    [2024-01-10T21:29:20]     INFO Keys with unrendered Jinja2 variables/expressions:
-    [2024-01-10T21:29:20]     INFO     values.date: {{ yyyymmdd }}
-    [2024-01-10T21:29:20]     INFO 
-    [2024-01-10T21:29:20]     INFO Keys that are set to empty:
-    [2024-01-10T21:29:20]     INFO     values.empty
+     $ uw config realize --input-file config.yaml --output-format yaml --values-needed
+     [2024-01-10T21:29:20]     INFO Keys that are complete:
+     [2024-01-10T21:29:20]     INFO     values
+     [2024-01-10T21:29:20]     INFO     values.greeting
+     [2024-01-10T21:29:20]     INFO     values.message
+     [2024-01-10T21:29:20]     INFO     values.recipient
+     [2024-01-10T21:29:20]     INFO     values.repeat
+     [2024-01-10T21:29:20]     INFO
+     [2024-01-10T21:29:20]     INFO Keys with unrendered Jinja2 variables/expressions:
+     [2024-01-10T21:29:20]     INFO     values.date: {{ yyyymmdd }}
+     [2024-01-10T21:29:20]     INFO
+     [2024-01-10T21:29:20]     INFO Keys that are set to empty:
+     [2024-01-10T21:29:20]     INFO     values.empty
 
 * To realize the config to ``stdout``, a target output format must be explicitly specified:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.yaml --output-format yaml
-    values:
-      date: '{{ yyyymmdd }}'
-      empty: null
-      greeting: Hello
-      message: Hello World
-      recipient: World
-      repeat: 1
+     $ uw config realize --input-file config.yaml --output-format yaml
+     values:
+       date: '{{ yyyymmdd }}'
+       empty: null
+       greeting: Hello
+       message: Hello World
+       recipient: World
+       repeat: 1
 
   Shell redirection via ``|``, ``>``, et al may also be used to stream output to a file, another process, etc.
 
@@ -243,165 +243,165 @@ and additional supplemental YAML file ``values2.yaml`` with content
 
   .. code-block:: text
 
-    $ recipient=Sun uw config realize --input-file config.yaml --output-format yaml values1.yaml values2.yaml
-    values:
-      date: 20240105
-      empty: false
-      greeting: Good Night
-      message: Good Night Sun Good Night Sun Good Night Sun
-      recipient: Moon
-      repeat: 3
+     $ recipient=Sun uw config realize --input-file config.yaml --output-format yaml values1.yaml values2.yaml
+     values:
+       date: 20240105
+       empty: false
+       greeting: Good Night
+       message: Good Night Sun Good Night Sun Good Night Sun
+       recipient: Moon
+       repeat: 3
 
 * Realize the config to a file via command-line argument:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.yaml --output-file realized.yaml values1.yaml
+     $ uw config realize --input-file config.yaml --output-file realized.yaml values1.yaml
 
   The content of ``realized.yaml``:
 
   .. code-block:: yaml
 
-    values:
-      date: 20240105
-      empty: null
-      greeting: Good Night
-      message: Good Night Moon Good Night Moon
-      recipient: Moon
-      repeat: 2
+     values:
+       date: 20240105
+       empty: null
+       greeting: Good Night
+       message: Good Night Moon Good Night Moon
+       recipient: Moon
+       repeat: 2
 
 * With the ``--dry-run`` flag specified, nothing is written to ``stdout`` (or to a file if ``--output-file`` is specified), but a report of what would have been written is logged to ``stderr``:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.yaml --output-file realized.yaml --dry-run values1.yaml
-    [2024-01-10T21:38:32]     INFO values:
-    [2024-01-10T21:38:32]     INFO   date: 20240105
-    [2024-01-10T21:38:32]     INFO   empty: null
-    [2024-01-10T21:38:32]     INFO   greeting: Good Night
-    [2024-01-10T21:38:32]     INFO   message: Good Night Moon Good Night Moon
-    [2024-01-10T21:38:32]     INFO   recipient: Moon
-    [2024-01-10T21:38:32]     INFO   repeat: 2
+     $ uw config realize --input-file config.yaml --output-file realized.yaml --dry-run values1.yaml
+     [2024-01-10T21:38:32]     INFO values:
+     [2024-01-10T21:38:32]     INFO   date: 20240105
+     [2024-01-10T21:38:32]     INFO   empty: null
+     [2024-01-10T21:38:32]     INFO   greeting: Good Night
+     [2024-01-10T21:38:32]     INFO   message: Good Night Moon Good Night Moon
+     [2024-01-10T21:38:32]     INFO   recipient: Moon
+     [2024-01-10T21:38:32]     INFO   repeat: 2
 
 * If an input file is read alone from ``stdin``, ``uw`` will not know how to parse its content:
 
   .. code-block:: text
 
-    $ cat config.yaml | uw config realize --output-file realized.yaml values1.yaml
-    Specify --input-format when --input-file is not specified
+     $ cat config.yaml | uw config realize --output-file realized.yaml values1.yaml
+     Specify --input-format when --input-file is not specified
 
 * Read the config from ``stdin`` and realize to ``stdout``:
 
   .. code-block:: text
 
-    $ cat config.yaml | uw config realize --input-format yaml --output-format yaml values1.yaml 
-    values:
-      date: 20240105
-      empty: null
-      greeting: Good Night
-      message: Good Night Moon Good Night Moon
-      recipient: Moon
-      repeat: 2
+     $ cat config.yaml | uw config realize --input-format yaml --output-format yaml values1.yaml
+     values:
+       date: 20240105
+       empty: null
+       greeting: Good Night
+       message: Good Night Moon Good Night Moon
+       recipient: Moon
+       repeat: 2
 
 * If the config file has an unrecognized (or no) extension, ``uw`` will not know how to parse its content:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.txt --output-format yaml values1.yaml
-    Cannot deduce format of 'config.txt' from unknown extension 'txt'
+     $ uw config realize --input-file config.txt --output-format yaml values1.yaml
+     Cannot deduce format of 'config.txt' from unknown extension 'txt'
 
   In this case, the format can be explicitly specified  (``config.txt`` is a copy of ``config.yaml``):
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.txt --input-format yaml --output-format yaml values1.yaml
-    values:
-      date: 20240105
-      empty: null
-      greeting: Good Night
-      message: Good Night Moon Good Night Moon
-      recipient: Moon
-      repeat: 2
+     $ uw config realize --input-file config.txt --input-format yaml --output-format yaml values1.yaml
+     values:
+       date: 20240105
+       empty: null
+       greeting: Good Night
+       message: Good Night Moon Good Night Moon
+       recipient: Moon
+       repeat: 2
 
 * Request verbose log output:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml
-    [2024-01-10T21:42:17]    DEBUG Command: uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml
-    [2024-01-10T21:42:17]    DEBUG Before update, config has depth 2
-    [2024-01-10T21:42:17]    DEBUG Supplemental config has depth 2
-    [2024-01-10T21:42:17]    DEBUG After update, config has depth 2
-    [2024-01-10T21:42:17]    DEBUG Dereferencing, initial value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}}
-    [2024-01-10T21:42:17]    DEBUG Rendering: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}}
-    [2024-01-10T21:42:17]    DEBUG Rendering: {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}
-    [2024-01-10T21:42:17]    DEBUG Rendering: 20240105
-    [2024-01-10T21:42:17]    DEBUG Rendered: 20240105
-    [2024-01-10T21:42:17]    DEBUG Rendering: None
-    [2024-01-10T21:42:17]    DEBUG Rendered: None
-    [2024-01-10T21:42:17]    DEBUG Rendering: Good Night
-    [2024-01-10T21:42:17]    DEBUG Rendering: {{ (greeting + " " + recipient + " ") * repeat }}
-    [2024-01-10T21:42:17]    DEBUG Rendering: Moon
-    [2024-01-10T21:42:17]    DEBUG Rendering: 2
-    [2024-01-10T21:42:17]    DEBUG Rendered: 2
-    [2024-01-10T21:42:17]    DEBUG Dereferencing, current value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}}
-    [2024-01-10T21:42:17]    DEBUG Rendering: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}}
-    [2024-01-10T21:42:17]    DEBUG Rendering: {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}
-    [2024-01-10T21:42:17]    DEBUG Rendering: 20240105
-    [2024-01-10T21:42:17]    DEBUG Rendered: 20240105
-    [2024-01-10T21:42:17]    DEBUG Rendering: None
-    [2024-01-10T21:42:17]    DEBUG Rendered: None
-    [2024-01-10T21:42:17]    DEBUG Rendering: Good Night
-    [2024-01-10T21:42:17]    DEBUG Rendering: Good Night Moon Good Night Moon
-    [2024-01-10T21:42:17]    DEBUG Rendering: Moon
-    [2024-01-10T21:42:17]    DEBUG Rendering: 2
-    [2024-01-10T21:42:17]    DEBUG Rendered: 2
-    [2024-01-10T21:42:17]    DEBUG Dereferencing, final value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}}
-    values:
-      date: 20240105
-      empty: null
-      greeting: Good Night
-      message: Good Night Moon Good Night Moon
-      recipient: Moon
-      repeat: 2
+     $ uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml
+     [2024-01-10T21:42:17]    DEBUG Command: uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml
+     [2024-01-10T21:42:17]    DEBUG Before update, config has depth 2
+     [2024-01-10T21:42:17]    DEBUG Supplemental config has depth 2
+     [2024-01-10T21:42:17]    DEBUG After update, config has depth 2
+     [2024-01-10T21:42:17]    DEBUG Dereferencing, initial value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}}
+     [2024-01-10T21:42:17]    DEBUG Rendering: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}}
+     [2024-01-10T21:42:17]    DEBUG Rendering: {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}
+     [2024-01-10T21:42:17]    DEBUG Rendering: 20240105
+     [2024-01-10T21:42:17]    DEBUG Rendered: 20240105
+     [2024-01-10T21:42:17]    DEBUG Rendering: None
+     [2024-01-10T21:42:17]    DEBUG Rendered: None
+     [2024-01-10T21:42:17]    DEBUG Rendering: Good Night
+     [2024-01-10T21:42:17]    DEBUG Rendering: {{ (greeting + " " + recipient + " ") * repeat }}
+     [2024-01-10T21:42:17]    DEBUG Rendering: Moon
+     [2024-01-10T21:42:17]    DEBUG Rendering: 2
+     [2024-01-10T21:42:17]    DEBUG Rendered: 2
+     [2024-01-10T21:42:17]    DEBUG Dereferencing, current value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': '{{ (greeting + " " + recipient + " ") * repeat }}', 'recipient': 'Moon', 'repeat': 2}}
+     [2024-01-10T21:42:17]    DEBUG Rendering: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}}
+     [2024-01-10T21:42:17]    DEBUG Rendering: {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}
+     [2024-01-10T21:42:17]    DEBUG Rendering: 20240105
+     [2024-01-10T21:42:17]    DEBUG Rendered: 20240105
+     [2024-01-10T21:42:17]    DEBUG Rendering: None
+     [2024-01-10T21:42:17]    DEBUG Rendered: None
+     [2024-01-10T21:42:17]    DEBUG Rendering: Good Night
+     [2024-01-10T21:42:17]    DEBUG Rendering: Good Night Moon Good Night Moon
+     [2024-01-10T21:42:17]    DEBUG Rendering: Moon
+     [2024-01-10T21:42:17]    DEBUG Rendering: 2
+     [2024-01-10T21:42:17]    DEBUG Rendered: 2
+     [2024-01-10T21:42:17]    DEBUG Dereferencing, final value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}}
+     values:
+       date: 20240105
+       empty: null
+       greeting: Good Night
+       message: Good Night Moon Good Night Moon
+       recipient: Moon
+       repeat: 2
 
   Note that ``uw`` logs to ``stderr`` and writes non-log output to ``stdout``, so the streams can be redirected separately:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml >realized.yaml 2>realized.log
+     $ uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml >realized.yaml 2>realized.log
 
   The content of ``realized.yaml``:
 
   .. code-block:: yaml
 
-    values:
-      date: 20240105
-      empty: null
-      greeting: Good Night
-      message: Good Night Moon Good Night Moon
-      recipient: Moon
-      repeat: 2
+     values:
+       date: 20240105
+       empty: null
+       greeting: Good Night
+       message: Good Night Moon Good Night Moon
+       recipient: Moon
+       repeat: 2
 
   The content of ``realized.log``:
 
   .. code-block:: text
 
-    [2024-01-10T21:43:58]    DEBUG Command: uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml
-    [2024-01-10T21:43:58]    DEBUG Before update, config has depth 2
-    [2024-01-10T21:43:58]    DEBUG Supplemental config has depth 2
-    ...
-    [2024-01-10T21:43:58]    DEBUG Rendering: 2
-    [2024-01-10T21:43:58]    DEBUG Rendered: 2
-    [2024-01-10T21:43:58]    DEBUG Dereferencing, final value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}}
+     [2024-01-10T21:43:58]    DEBUG Command: uw config realize --input-file config.yaml --output-format yaml --verbose values1.yaml
+     [2024-01-10T21:43:58]    DEBUG Before update, config has depth 2
+     [2024-01-10T21:43:58]    DEBUG Supplemental config has depth 2
+     ...
+     [2024-01-10T21:43:58]    DEBUG Rendering: 2
+     [2024-01-10T21:43:58]    DEBUG Rendered: 2
+     [2024-01-10T21:43:58]    DEBUG Dereferencing, final value: {'values': {'date': 20240105, 'empty': None, 'greeting': 'Good Night', 'message': 'Good Night Moon Good Night Moon', 'recipient': 'Moon', 'repeat': 2}}
 
 * Note that ``uw`` does not allow invalid conversions. For example, when attempting to generate an ``sh`` config from a depth-2 ``yaml``:
 
   .. code-block:: text
 
-    $ uw config realize --input-file config.yaml --output-format sh
-    [2024-01-10T21:46:00]    ERROR Cannot realize depth-2 config to type-'sh' config
-    Cannot realize depth-2 config to type-'sh' config
+     $ uw config realize --input-file config.yaml --output-format sh
+     [2024-01-10T21:46:00]    ERROR Cannot realize depth-2 config to type-'sh' config
+     Cannot realize depth-2 config to type-'sh' config
 
   Note that ``ini`` and ``nml`` configs are, by definition, depth-2 configs, while ``sh`` configs are depth-1 and ``yaml`` configs have arbitrary depth.
 
@@ -412,30 +412,30 @@ and additional supplemental YAML file ``values2.yaml`` with content
 
 .. code-block:: text
 
-  $ uw config translate --help
-  usage: uw config translate [-h] [--input-file PATH] [--input-format {atparse}]
-                             [--output-file PATH] [--output-format {jinja2}] [--dry-run] [--quiet]
-                             [--verbose]
+   $ uw config translate --help
+   usage: uw config translate [-h] [--input-file PATH] [--input-format {atparse}]
+                              [--output-file PATH] [--output-format {jinja2}] [--dry-run] [--quiet]
+                              [--verbose]
 
-  Translate configs
+   Translate configs
 
-  Optional arguments:
-    -h, --help
-        Show help and exit
-    --input-file PATH, -i PATH
-        Path to input file (defaults to stdin)
-    --input-format {atparse}
-        Input format
-    --output-file PATH, -o PATH
-        Path to output file (defaults to stdout)
-    --output-format {jinja2}
-        Output format
-    --dry-run
-        Only log info, making no changes
-    --quiet, -q
-        Print no logging messages
-    --verbose, -v
-        Print all logging messages
+   Optional arguments:
+     -h, --help
+         Show help and exit
+     --input-file PATH, -i PATH
+         Path to input file (defaults to stdin)
+     --input-format {atparse}
+         Input format
+     --output-file PATH, -o PATH
+         Path to output file (defaults to stdout)
+     --output-format {jinja2}
+         Output format
+     --dry-run
+         Only log info, making no changes
+     --quiet, -q
+         Print no logging messages
+     --verbose, -v
+         Print all logging messages
 
 Examples
 ^^^^^^^^
@@ -444,14 +444,14 @@ The examples that follow use atparse-formatted template file ``atparse.txt`` wit
 
 .. code-block:: text
 
-  @[greeting], @[recipient]!
+   @[greeting], @[recipient]!
 
 * Convert an atparse-formatted template file to Jinja2 format:
 
   .. code-block:: text
 
-    $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2
-    {{greeting}}, {{recipient}}!
+     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2
+     {{greeting}}, {{recipient}}!
 
   Shell redirection via ``|``, ``>``, et al may also be used to stream output to a file, another process, etc.
 
@@ -459,28 +459,28 @@ The examples that follow use atparse-formatted template file ``atparse.txt`` wit
 
   .. code-block:: text
 
-    $ uw config translate --input-file atparse.txt --input-format atparse --output-file jinja2.txt --output-format jinja2
+     $ uw config translate --input-file atparse.txt --input-format atparse --output-file jinja2.txt --output-format jinja2
 
   The content of ``jinja2.txt``:
 
   .. code-block:: jinja
 
-    {{greeting}}, {{recipient}}!
+     {{greeting}}, {{recipient}}!
 
 * With the ``--dry-run`` flag specified, nothing is written to ``stdout`` (or to a file if ``--output-file`` is specified), but a report of what would have been written is logged to ``stderr``:
 
   .. code-block:: text
 
-    $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2 --dry-run
-    [2024-01-03T16:41:13]     INFO {{greeting}}, {{recipient}}!
+     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2 --dry-run
+     [2024-01-03T16:41:13]     INFO {{greeting}}, {{recipient}}!
 
 
 * If an input is read alone from ``stdin``, ``uw`` will not know how to parse its content as we must always specify the formats:
 
   .. code-block:: text
 
-    $ cat atparse.txt | uw config translate --input-format atparse --output-format jinja2
-    {{greeting}}, {{recipient}}!
+     $ cat atparse.txt | uw config translate --input-format atparse --output-format jinja2
+     {{greeting}}, {{recipient}}!
 
 .. _validate_configs_cli_examples:
 
@@ -489,68 +489,68 @@ The examples that follow use atparse-formatted template file ``atparse.txt`` wit
 
 .. code-block:: text
 
-  $ uw config validate --help
-  usage: uw config validate --schema-file PATH [-h] [--input-file PATH] [--quiet] [--verbose]
+   $ uw config validate --help
+   usage: uw config validate --schema-file PATH [-h] [--input-file PATH] [--quiet] [--verbose]
 
-  Validate config
+   Validate config
 
-  Required arguments:
-    --schema-file PATH
-        Path to schema file to use for validation
+   Required arguments:
+     --schema-file PATH
+         Path to schema file to use for validation
 
-  Optional arguments:
-    -h, --help
-        Show help and exit
-    --input-file PATH, -i PATH
-        Path to input file (defaults to stdin)
-    --quiet, -q
-        Print no logging messages
-    --verbose, -v
-        Print all logging messages
+   Optional arguments:
+     -h, --help
+         Show help and exit
+     --input-file PATH, -i PATH
+         Path to input file (defaults to stdin)
+     --quiet, -q
+         Print no logging messages
+     --verbose, -v
+         Print all logging messages
 
 Examples
 ^^^^^^^^
 
 The examples that follow use :json-schema:`JSON Schema<understanding-json-schema/reference>` file ``schema.jsonschema`` with content
 
-.. code:: json
+.. code-block:: json
 
-  {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-      "values": {
-        "type": "object",
-        "properties": {
-          "greeting": {
-            "type": "string"
-          },
-          "recipient": {
-            "type": "string"
-          }
-        },
-        "required": ["greeting", "recipient"],
-        "additionalProperties": false
-      }
-    },
-    "required": ["values"],
-    "additionalProperties": false
-  }
+   {
+     "$schema": "http://json-schema.org/draft-07/schema#",
+     "type": "object",
+     "properties": {
+       "values": {
+         "type": "object",
+         "properties": {
+           "greeting": {
+             "type": "string"
+           },
+           "recipient": {
+             "type": "string"
+           }
+         },
+         "required": ["greeting", "recipient"],
+         "additionalProperties": false
+       }
+     },
+     "required": ["values"],
+     "additionalProperties": false
+   }
 
 and YAML file ``values.yaml`` with content
 
 .. code-block:: yaml
 
-  values:
-    greeting: Hello
-    recipient: World
+   values:
+     greeting: Hello
+     recipient: World
 
 * Validate a YAML config against a given JSON schema:
 
   .. code-block:: text
 
-    $ uw config validate --schema-file schema.jsonschema --input-file values.yaml
-    [2024-01-03T17:23:07]     INFO 0 UW schema-validation errors found
+     $ uw config validate --schema-file schema.jsonschema --input-file values.yaml
+     [2024-01-03T17:23:07]     INFO 0 UW schema-validation errors found
 
   Shell redirection via ``|``, ``>``, et al may also be used to stream output to a file, another process, etc.
 
@@ -558,63 +558,63 @@ and YAML file ``values.yaml`` with content
 
   .. code-block:: text
 
-    $ cat values.yaml | uw config validate --schema-file schema.jsonschema
-    [2024-01-03T17:26:29]     INFO 0 UW schema-validation errors found
+     $ cat values.yaml | uw config validate --schema-file schema.jsonschema
+     [2024-01-03T17:26:29]     INFO 0 UW schema-validation errors found
 
 * However, reading the schema from ``stdin`` is **not** supported:
 
   .. code-block:: text
 
-    $ cat schema.jsonschema | uw config validate --input-file values.yaml
-    uw config validate: error: the following arguments are required: --schema-file
+     $ cat schema.jsonschema | uw config validate --input-file values.yaml
+     uw config validate: error: the following arguments are required: --schema-file
 
 * If a config fails validation, differences from the schema will be displayed. For example, with ``recipient: World`` removed from ``values.yaml``:
 
   .. code-block:: text
 
-    $ uw config validate --schema-file schema.jsonschema --input-file values.yaml
-    [2024-01-03T17:31:19]    ERROR 1 UW schema-validation error found
-    [2024-01-03T17:31:19]    ERROR 'recipient' is a required property
-    [2024-01-03T17:31:19]    ERROR
-    [2024-01-03T17:31:19]    ERROR Failed validating 'required' in schema['properties']['values']:
-    [2024-01-03T17:31:19]    ERROR     {'additionalProperties': False,
-    [2024-01-03T17:31:19]    ERROR      'properties': {'greeting': {'type': 'string'},
-    [2024-01-03T17:31:19]    ERROR                     'recipient': {'type': 'string'}},
-    [2024-01-03T17:31:19]    ERROR      'required': ['greeting', 'recipient'],
-    [2024-01-03T17:31:19]    ERROR      'type': 'object'}
-    [2024-01-03T17:31:19]    ERROR
-    [2024-01-03T17:31:19]    ERROR On instance['values']:
-    [2024-01-03T17:31:19]    ERROR     {'greeting': 'Hello'}
+     $ uw config validate --schema-file schema.jsonschema --input-file values.yaml
+     [2024-01-03T17:31:19]    ERROR 1 UW schema-validation error found
+     [2024-01-03T17:31:19]    ERROR 'recipient' is a required property
+     [2024-01-03T17:31:19]    ERROR
+     [2024-01-03T17:31:19]    ERROR Failed validating 'required' in schema['properties']['values']:
+     [2024-01-03T17:31:19]    ERROR     {'additionalProperties': False,
+     [2024-01-03T17:31:19]    ERROR      'properties': {'greeting': {'type': 'string'},
+     [2024-01-03T17:31:19]    ERROR                     'recipient': {'type': 'string'}},
+     [2024-01-03T17:31:19]    ERROR      'required': ['greeting', 'recipient'],
+     [2024-01-03T17:31:19]    ERROR      'type': 'object'}
+     [2024-01-03T17:31:19]    ERROR
+     [2024-01-03T17:31:19]    ERROR On instance['values']:
+     [2024-01-03T17:31:19]    ERROR     {'greeting': 'Hello'}
 
 * Request verbose log output:
 
   .. code-block:: text
 
-    $ uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
-    [2024-01-03T17:29:46]    DEBUG Command: uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
-    [2024-01-03T17:29:46]    DEBUG Dereferencing, initial value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
-    [2024-01-03T17:29:46]    DEBUG Rendering: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
-    [2024-01-03T17:29:46]    DEBUG Rendering: {'greeting': 'Hello', 'recipient': 'World'}
-    [2024-01-03T17:29:46]    DEBUG Rendering: Hello
-    [2024-01-03T17:29:46]    DEBUG Rendering: World
-    [2024-01-03T17:29:46]    DEBUG Dereferencing, final value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
-    [2024-01-03T17:29:46]     INFO 0 UW schema-validation errors found
+     $ uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
+     [2024-01-03T17:29:46]    DEBUG Command: uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
+     [2024-01-03T17:29:46]    DEBUG Dereferencing, initial value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
+     [2024-01-03T17:29:46]    DEBUG Rendering: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
+     [2024-01-03T17:29:46]    DEBUG Rendering: {'greeting': 'Hello', 'recipient': 'World'}
+     [2024-01-03T17:29:46]    DEBUG Rendering: Hello
+     [2024-01-03T17:29:46]    DEBUG Rendering: World
+     [2024-01-03T17:29:46]    DEBUG Dereferencing, final value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
+     [2024-01-03T17:29:46]     INFO 0 UW schema-validation errors found
 
   Note that ``uw`` logs to ``stderr``, so the stream can be redirected:
 
   .. code-block:: text
 
-    $ uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose 2>validate.log
+     $ uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose 2>validate.log
 
   The content of ``validate.log``:
 
   .. code-block:: text
 
-    [2024-01-03T17:30:49]    DEBUG Command: uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
-    [2024-01-03T17:30:49]    DEBUG Dereferencing, initial value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
-    [2024-01-03T17:30:49]    DEBUG Rendering: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
-    [2024-01-03T17:30:49]    DEBUG Rendering: {'greeting': 'Hello', 'recipient': 'World'}
-    [2024-01-03T17:30:49]    DEBUG Rendering: Hello
-    [2024-01-03T17:30:49]    DEBUG Rendering: World
-    [2024-01-03T17:30:49]    DEBUG Dereferencing, final value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
-    [2024-01-03T17:30:49]     INFO 0 UW schema-validation errors found
+     [2024-01-03T17:30:49]    DEBUG Command: uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
+     [2024-01-03T17:30:49]    DEBUG Dereferencing, initial value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
+     [2024-01-03T17:30:49]    DEBUG Rendering: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
+     [2024-01-03T17:30:49]    DEBUG Rendering: {'greeting': 'Hello', 'recipient': 'World'}
+     [2024-01-03T17:30:49]    DEBUG Rendering: Hello
+     [2024-01-03T17:30:49]    DEBUG Rendering: World
+     [2024-01-03T17:30:49]    DEBUG Dereferencing, final value: {'values': {'greeting': 'Hello', 'recipient': 'World'}}
+     [2024-01-03T17:30:49]     INFO 0 UW schema-validation errors found

--- a/docs/sections/user_guide/cli/mode_forecast.rst
+++ b/docs/sections/user_guide/cli/mode_forecast.rst
@@ -5,51 +5,51 @@ The ``uw`` mode for configuring and running forecasts.
 
 .. code-block:: text
 
-  $ uw forecast --help
-  usage: uw forecast [-h] MODE ...
-
-  Configure and run forecasts
-
-  Optional arguments:
-    -h, --help
-          Show help and exit
-
-  Positional arguments:
-    MODE
-      run
-          Run a forecast
+   $ uw forecast --help
+   usage: uw forecast [-h] MODE ...
+ 
+   Configure and run forecasts
+ 
+   Optional arguments:
+     -h, --help
+           Show help and exit
+ 
+   Positional arguments:
+     MODE
+       run
+           Run a forecast
 
 ``run``
 -------
 
 .. code-block:: text
 
-  $ uw forecast run --help
-  usage: uw forecast run --config-file PATH --cycle CYCLE --model {FV3} [-h] [--batch-script PATH]
-                         [--dry-run] [--quiet] [--verbose]
-
-  Run a forecast
-
-  Required arguments:
-    --config-file PATH, -c PATH
-        Path to config file
-    --cycle CYCLE
-        The cycle in ISO8601 format
-    --model {FV3}
-        Model name
-
-  Optional arguments:
-    -h, --help
-        Show help and exit
-    --batch-script PATH
-        Path to output batch file (defaults to stdout)
-    --dry-run
-        Only log info, making no changes
-    --quiet, -q
-        Print no logging messages
-    --verbose, -v
-        Print all logging messages
-
+   $ uw forecast run --help
+   usage: uw forecast run --config-file PATH --cycle CYCLE --model {FV3} [-h] [--batch-script PATH]
+                          [--dry-run] [--quiet] [--verbose]
+ 
+   Run a forecast
+ 
+   Required arguments:
+     --config-file PATH, -c PATH
+         Path to config file
+     --cycle CYCLE
+         The cycle in ISO8601 format
+     --model {FV3}
+         Model name
+ 
+   Optional arguments:
+     -h, --help
+         Show help and exit
+     --batch-script PATH
+         Path to output batch file (defaults to stdout)
+     --dry-run
+         Only log info, making no changes
+     --quiet, -q
+         Print no logging messages
+     --verbose, -v
+         Print all logging messages
+ 
 Examples
 ^^^^^^^^
 

--- a/docs/sections/user_guide/cli/mode_forecast.rst
+++ b/docs/sections/user_guide/cli/mode_forecast.rst
@@ -7,13 +7,13 @@ The ``uw`` mode for configuring and running forecasts.
 
    $ uw forecast --help
    usage: uw forecast [-h] MODE ...
- 
+
    Configure and run forecasts
- 
+
    Optional arguments:
      -h, --help
            Show help and exit
- 
+
    Positional arguments:
      MODE
        run
@@ -27,9 +27,9 @@ The ``uw`` mode for configuring and running forecasts.
    $ uw forecast run --help
    usage: uw forecast run --config-file PATH --cycle CYCLE --model {FV3} [-h] [--batch-script PATH]
                           [--dry-run] [--quiet] [--verbose]
- 
+
    Run a forecast
- 
+
    Required arguments:
      --config-file PATH, -c PATH
          Path to config file
@@ -37,7 +37,7 @@ The ``uw`` mode for configuring and running forecasts.
          The cycle in ISO8601 format
      --model {FV3}
          Model name
- 
+
    Optional arguments:
      -h, --help
          Show help and exit
@@ -49,7 +49,7 @@ The ``uw`` mode for configuring and running forecasts.
          Print no logging messages
      --verbose, -v
          Print all logging messages
- 
+
 Examples
 ^^^^^^^^
 

--- a/docs/sections/user_guide/cli/mode_rocoto.rst
+++ b/docs/sections/user_guide/cli/mode_rocoto.rst
@@ -5,21 +5,21 @@ The ``uw`` mode for realizing and validating Rocoto XML documents.
 
 .. code-block:: text
 
-  $ uw rocoto --help
-  usage: uw rocoto [-h] MODE ...
-
-  Realize and validate Rocoto XML Documents
-
-  Optional arguments:
-    -h, --help
-          Show help and exit
-
-  Positional arguments:
-    MODE
-      realize
-          Realize a Rocoto XML workflow document
-      validate
-          Validate Rocoto XML
+   $ uw rocoto --help
+   usage: uw rocoto [-h] MODE ...
+ 
+   Realize and validate Rocoto XML Documents
+ 
+   Optional arguments:
+     -h, --help
+           Show help and exit
+ 
+   Positional arguments:
+     MODE
+       realize
+           Realize a Rocoto XML workflow document
+       validate
+           Validate Rocoto XML
 
 .. _realize_rocoto_cli_examples:
 
@@ -32,29 +32,29 @@ More information about the structured UW YAML file for Rocoto can be found :any:
 
 .. code-block:: text
 
-  $ uw rocoto realize --help
-  usage: uw rocoto realize [-h] [--input-file PATH] [--output-file PATH] [--quiet] [--verbose]
-
-  Realize a Rocoto XML workflow document
-
-  Optional arguments:
-    -h, --help
-        Show help and exit
-    --input-file PATH, -i PATH
-        Path to input file (defaults to stdin)
-    --output-file PATH, -o PATH
-        Path to output file (defaults to stdout)
-    --quiet, -q
-        Print no logging messages
-    --verbose, -v
-        Print all logging messages
+   $ uw rocoto realize --help
+   usage: uw rocoto realize [-h] [--input-file PATH] [--output-file PATH] [--quiet] [--verbose]
+ 
+   Realize a Rocoto XML workflow document
+ 
+   Optional arguments:
+     -h, --help
+         Show help and exit
+     --input-file PATH, -i PATH
+         Path to input file (defaults to stdin)
+     --output-file PATH, -o PATH
+         Path to output file (defaults to stdout)
+     --quiet, -q
+         Print no logging messages
+     --verbose, -v
+         Print all logging messages
 
 Examples
 ^^^^^^^^
 
 The examples that follow use a UW YAML file ``rocoto.yaml`` with content
 
-.. code:: python
+.. code-block:: python
 
    workflow:
      attrs:
@@ -82,99 +82,99 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
 
 * Realize a UW YAML input file to ``stdout`` in Rocoto XML format:
 
-  .. code:: XML
+  .. code-block:: XML
 
-    $ uw rocoto realize --input-file rocoto.yaml
-    [2024-01-02T13:41:25]     INFO 0 UW schema-validation errors found
-    [2024-01-02T13:41:25]     INFO 0 Rocoto validation errors found
-    <?xml version='1.0' encoding='utf-8'?>
-    <!DOCTYPE workflow [
-      <!ENTITY ACCOUNT "myaccount">
-      <!ENTITY FOO "test.log">
-    ]>
-    <workflow realtime="False" scheduler="slurm">
-      <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
-      <log>/some/path/to/&FOO;</log>
-      <task name="hello" cycledefs="howdy">
-        <account>&ACCOUNT;</account>
-        <nodes>1:ppn=1</nodes>
-        <walltime>00:01:00</walltime>
-        <command>echo hello $person</command>
-        <jobname>hello</jobname>
-        <envar>
-          <name>person</name>
-          <value>siri</value>
-        </envar>
-      </task>
-    </workflow>
+     $ uw rocoto realize --input-file rocoto.yaml
+     [2024-01-02T13:41:25]     INFO 0 UW schema-validation errors found
+     [2024-01-02T13:41:25]     INFO 0 Rocoto validation errors found
+     <?xml version='1.0' encoding='utf-8'?>
+     <!DOCTYPE workflow [
+       <!ENTITY ACCOUNT "myaccount">
+       <!ENTITY FOO "test.log">
+     ]>
+     <workflow realtime="False" scheduler="slurm">
+       <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+       <log>/some/path/to/&FOO;</log>
+       <task name="hello" cycledefs="howdy">
+         <account>&ACCOUNT;</account>
+         <nodes>1:ppn=1</nodes>
+         <walltime>00:01:00</walltime>
+         <command>echo hello $person</command>
+         <jobname>hello</jobname>
+         <envar>
+           <name>person</name>
+           <value>siri</value>
+         </envar>
+       </task>
+     </workflow>
 
 * Realize a UW YAML input file to a file named ``rocoto.xml``:
 
-  .. code:: sh
+  .. code-block:: text
 
-    $ uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml
-    [2024-01-02T13:45:46]     INFO 0 UW schema-validation errors found
-    [2024-01-02T13:45:46]     INFO 0 Rocoto validation errors found
+     $ uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml
+     [2024-01-02T13:45:46]     INFO 0 UW schema-validation errors found
+     [2024-01-02T13:45:46]     INFO 0 Rocoto validation errors found
 
   The content of ``rocoto.xml``:
 
-  .. code:: XML
+  .. code-block:: xml
 
-    <?xml version='1.0' encoding='utf-8'?>
-    <!DOCTYPE workflow [
-      <!ENTITY ACCOUNT "myaccount">
-      <!ENTITY FOO "test.log">
-    ]>
-    <workflow realtime="False" scheduler="slurm">
-      <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
-      <log>/some/path/to/&FOO;</log>
-      <task name="hello" cycledefs="howdy">
-        <account>&ACCOUNT;</account>
-        <nodes>1:ppn=1</nodes>
-        <walltime>00:01:00</walltime>
-        <command>echo hello $person</command>
-        <jobname>hello</jobname>
-        <envar>
-          <name>person</name>
-          <value>siri</value>
-        </envar>
-      </task>
-    </workflow>
+     <?xml version='1.0' encoding='utf-8'?>
+     <!DOCTYPE workflow [
+       <!ENTITY ACCOUNT "myaccount">
+       <!ENTITY FOO "test.log">
+     ]>
+     <workflow realtime="False" scheduler="slurm">
+       <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+       <log>/some/path/to/&FOO;</log>
+       <task name="hello" cycledefs="howdy">
+         <account>&ACCOUNT;</account>
+         <nodes>1:ppn=1</nodes>
+         <walltime>00:01:00</walltime>
+         <command>echo hello $person</command>
+         <jobname>hello</jobname>
+         <envar>
+           <name>person</name>
+           <value>siri</value>
+         </envar>
+       </task>
+     </workflow>
 
 * Read the UW YAML from ``stdin`` and write the XML to ``stdout``:
 
-  .. code:: XML
+  .. code-block:: xml
 
-    $ cat rocoto.yaml | uw rocoto realize
-    [2024-01-02T14:09:08]     INFO 0 UW schema-validation errors found
-    [2024-01-02T14:09:08]     INFO 0 Rocoto validation errors found
-    <?xml version='1.0' encoding='utf-8'?>
-    <!DOCTYPE workflow [
-      <!ENTITY ACCOUNT "myaccount">
-      <!ENTITY FOO "test.log">
-    ]>
-    <workflow realtime="False" scheduler="slurm">
-      <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
-      <log>/some/path/to/&FOO;</log>
-      <task name="hello" cycledefs="howdy">
-        <account>&ACCOUNT;</account>
-        <nodes>1:ppn=1</nodes>
-        <walltime>00:01:00</walltime>
-        <command>echo hello $person</command>
-        <jobname>hello</jobname>
-        <envar>
-          <name>person</name>
-          <value>siri</value>
-        </envar>
-      </task>
-    </workflow>
+     $ cat rocoto.yaml | uw rocoto realize
+     [2024-01-02T14:09:08]     INFO 0 UW schema-validation errors found
+     [2024-01-02T14:09:08]     INFO 0 Rocoto validation errors found
+     <?xml version='1.0' encoding='utf-8'?>
+     <!DOCTYPE workflow [
+       <!ENTITY ACCOUNT "myaccount">
+       <!ENTITY FOO "test.log">
+     ]>
+     <workflow realtime="False" scheduler="slurm">
+       <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+       <log>/some/path/to/&FOO;</log>
+       <task name="hello" cycledefs="howdy">
+         <account>&ACCOUNT;</account>
+         <nodes>1:ppn=1</nodes>
+         <walltime>00:01:00</walltime>
+         <command>echo hello $person</command>
+         <jobname>hello</jobname>
+         <envar>
+           <name>person</name>
+           <value>siri</value>
+         </envar>
+       </task>
+     </workflow>
 
 * Realize a UW YAML input file to a file named ``rocoto.xml`` in quiet mode:
 
-  .. code:: sh
+  .. code-block:: text
 
-    $ uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml -q
-    $
+     $ uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml -q
+     $
 
   The contents of ``rocoto.xml`` are unchanged from the previous example.
 
@@ -182,22 +182,22 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
 
   .. note:: This output has been shortened for demonstration purposes.
 
-  .. code:: sh
+  .. code-block:: text
 
-    $ uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml -v
-    [2024-01-02T14:00:01]    DEBUG Command: uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml -v
-    [2024-01-02T14:00:01]    DEBUG Dereferencing, initial value: {'workflow': {'attrs': {'realtime': ...
-    [2024-01-02T14:00:01]    DEBUG Rendering: {'workflow': {'attrs': {'realtime': ...
-    [2024-01-02T14:00:01]    DEBUG Rendering: {'attrs': {'realtime': False, 'scheduler': ...
-    [2024-01-02T14:00:01]    DEBUG Rendering: {'realtime': False, 'scheduler': 'slurm'}
-    [2024-01-02T14:00:01]    DEBUG Rendering: False
-    [2024-01-02T14:00:01]    DEBUG Rendered: False
-    [2024-01-02T14:00:01]    DEBUG Rendering: slurm
-    ...
-    [2024-01-02T14:00:01]    DEBUG Rendering: {'person': 'siri'}
-    [2024-01-02T14:00:01]    DEBUG Rendering: siri
-    [2024-01-02T14:00:01]     INFO 0 UW schema-validation errors found
-    [2024-01-02T14:00:01]     INFO 0 Rocoto validation errors found
+     $ uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml -v
+     [2024-01-02T14:00:01]    DEBUG Command: uw rocoto realize --input-file rocoto.yaml --output-file rocoto.xml -v
+     [2024-01-02T14:00:01]    DEBUG Dereferencing, initial value: {'workflow': {'attrs': {'realtime': ...
+     [2024-01-02T14:00:01]    DEBUG Rendering: {'workflow': {'attrs': {'realtime': ...
+     [2024-01-02T14:00:01]    DEBUG Rendering: {'attrs': {'realtime': False, 'scheduler': ...
+     [2024-01-02T14:00:01]    DEBUG Rendering: {'realtime': False, 'scheduler': 'slurm'}
+     [2024-01-02T14:00:01]    DEBUG Rendering: False
+     [2024-01-02T14:00:01]    DEBUG Rendered: False
+     [2024-01-02T14:00:01]    DEBUG Rendering: slurm
+     ...
+     [2024-01-02T14:00:01]    DEBUG Rendering: {'person': 'siri'}
+     [2024-01-02T14:00:01]    DEBUG Rendering: siri
+     [2024-01-02T14:00:01]     INFO 0 UW schema-validation errors found
+     [2024-01-02T14:00:01]     INFO 0 Rocoto validation errors found
 
 .. _validate_rocoto_cli_examples:
 
@@ -206,20 +206,20 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
 
 .. code-block:: text
 
-  $ uw rocoto validate --help
-  usage: uw rocoto validate [-h] [--input-file PATH] [--quiet] [--verbose]
-
-  Validate Rocoto XML
-
-  Optional arguments:
-    -h, --help
-        Show help and exit
-    --input-file PATH, -i PATH
-        Path to input file (defaults to stdin)
-    --quiet, -q
-        Print no logging messages
-    --verbose, -v
-        Print all logging messages
+   $ uw rocoto validate --help
+   usage: uw rocoto validate [-h] [--input-file PATH] [--quiet] [--verbose]
+ 
+   Validate Rocoto XML
+ 
+   Optional arguments:
+     -h, --help
+         Show help and exit
+     --input-file PATH, -i PATH
+         Path to input file (defaults to stdin)
+     --quiet, -q
+         Print no logging messages
+     --verbose, -v
+         Print all logging messages
 
 Examples
 ^^^^^^^^
@@ -227,74 +227,74 @@ Examples
 The examples that follow use a Rocoto XML file ``rocoto.xml`` with the following content:
 
 .. code-block:: xml
-  :linenos:
+   :linenos:
 
-  <?xml version='1.0' encoding='utf-8'?>
-  <!DOCTYPE workflow [
-    <!ENTITY ACCOUNT "myaccount">
-    <!ENTITY FOO "test.log">
-  ]>
-  <workflow realtime="False" scheduler="slurm">
-    <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
-    <log>/some/path/to/&FOO;</log>
-    <task name="hello" cycledefs="howdy">
-      <account>&ACCOUNT;</account>
-      <nodes>1:ppn=1</nodes>
-      <walltime>00:01:00</walltime>
-      <command>echo hello $person</command>
-      <jobname>hello</jobname>
-      <envar>
-        <name>person</name>
-        <value>siri</value>
-      </envar>
-    </task>
-  </workflow>
-
+   <?xml version='1.0' encoding='utf-8'?>
+   <!DOCTYPE workflow [
+     <!ENTITY ACCOUNT "myaccount">
+     <!ENTITY FOO "test.log">
+   ]>
+   <workflow realtime="False" scheduler="slurm">
+     <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+     <log>/some/path/to/&FOO;</log>
+     <task name="hello" cycledefs="howdy">
+       <account>&ACCOUNT;</account>
+       <nodes>1:ppn=1</nodes>
+       <walltime>00:01:00</walltime>
+       <command>echo hello $person</command>
+       <jobname>hello</jobname>
+       <envar>
+         <name>person</name>
+         <value>siri</value>
+       </envar>
+     </task>
+   </workflow>
+ 
 * To validate an XML from ``stdin``:
 
-  .. code:: sh
+  .. code-block:: text
 
-    $ cat rocoto.xml | uw rocoto validate
-    [2024-01-02T14:18:46]     INFO 0 Rocoto validation errors found
+     $ cat rocoto.xml | uw rocoto validate
+     [2024-01-02T14:18:46]     INFO 0 Rocoto validation errors found
 
 * To validate an XML from file ``rocoto.xml``:
 
-  .. code:: sh
+  .. code-block:: text
 
-    $ uw rocoto validate --input-file rocoto.xml
-    [2024-01-02T14:18:46]     INFO 0 Rocoto validation errors found
+     $ uw rocoto validate --input-file rocoto.xml
+     [2024-01-02T14:18:46]     INFO 0 Rocoto validation errors found
 
 * When the XML is invalid:
 
   In this example, the ``<command>`` line was removed from the XML.
 
-  .. code:: sh
+  .. code-block:: text
 
-    $ uw rocoto validate --input-file rocoto.xml
-    [2024-01-10T21:54:51]    ERROR 3 Rocoto validation errors found
-    [2024-01-10T21:54:51]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_NOELEM: Expecting an element command, got nothing
-    [2024-01-10T21:54:51]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_INTERSEQ: Invalid sequence in interleave
-    [2024-01-10T21:54:51]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_CONTENTVALID: Element task failed to validate content
-    [2024-01-10T21:54:51]    ERROR Invalid Rocoto XML:
-    [2024-01-10T21:54:51]    ERROR  1 <?xml version='1.0' encoding='utf-8'?>
-    [2024-01-10T21:54:51]    ERROR  2 <!DOCTYPE workflow [
-    [2024-01-10T21:54:51]    ERROR  3   <!ENTITY ACCOUNT "myaccount">
-    [2024-01-10T21:54:51]    ERROR  4   <!ENTITY FOO "test.log">
-    [2024-01-10T21:54:51]    ERROR  5 ]>
-    [2024-01-10T21:54:51]    ERROR  6 <workflow realtime="False" scheduler="slurm">
-    [2024-01-10T21:54:51]    ERROR  7   <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
-    [2024-01-10T21:54:51]    ERROR  8   <log>/some/path/to/&FOO;</log>
-    [2024-01-10T21:54:51]    ERROR  9   <task name="hello" cycledefs="howdy">
-    [2024-01-10T21:54:51]    ERROR 10     <account>&ACCOUNT;</account>
-    [2024-01-10T21:54:51]    ERROR 11     <nodes>1:ppn=1</nodes>
-    [2024-01-10T21:54:51]    ERROR 12     <walltime>00:01:00</walltime>
-    [2024-01-10T21:54:51]    ERROR 13     <jobname>hello</jobname>
-    [2024-01-10T21:54:51]    ERROR 14     <envar>
-    [2024-01-10T21:54:51]    ERROR 15       <name>person</name>
-    [2024-01-10T21:54:51]    ERROR 16       <value>siri</value>
-    [2024-01-10T21:54:51]    ERROR 17     </envar>
-    [2024-01-10T21:54:51]    ERROR 18   </task>
-    [2024-01-10T21:54:51]    ERROR 19 </workflow>
+     $ uw rocoto validate --input-file rocoto.xml
+     [2024-01-10T21:54:51]    ERROR 3 Rocoto validation errors found
+     [2024-01-10T21:54:51]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_NOELEM: Expecting an element command, got nothing
+     [2024-01-10T21:54:51]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_INTERSEQ: Invalid sequence in interleave
+     [2024-01-10T21:54:51]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_CONTENTVALID: Element task failed to validate content
+     [2024-01-10T21:54:51]    ERROR Invalid Rocoto XML:
+     [2024-01-10T21:54:51]    ERROR  1 <?xml version='1.0' encoding='utf-8'?>
+     [2024-01-10T21:54:51]    ERROR  2 <!DOCTYPE workflow [
+     [2024-01-10T21:54:51]    ERROR  3   <!ENTITY ACCOUNT "myaccount">
+     [2024-01-10T21:54:51]    ERROR  4   <!ENTITY FOO "test.log">
+     [2024-01-10T21:54:51]    ERROR  5 ]>
+     [2024-01-10T21:54:51]    ERROR  6 <workflow realtime="False" scheduler="slurm">
+     [2024-01-10T21:54:51]    ERROR  7   <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+     [2024-01-10T21:54:51]    ERROR  8   <log>/some/path/to/&FOO;</log>
+     [2024-01-10T21:54:51]    ERROR  9   <task name="hello" cycledefs="howdy">
+     [2024-01-10T21:54:51]    ERROR 10     <account>&ACCOUNT;</account>
+     [2024-01-10T21:54:51]    ERROR 11     <nodes>1:ppn=1</nodes>
+     [2024-01-10T21:54:51]    ERROR 12     <walltime>00:01:00</walltime>
+     [2024-01-10T21:54:51]    ERROR 13     <jobname>hello</jobname>
+     [2024-01-10T21:54:51]    ERROR 14     <envar>
+     [2024-01-10T21:54:51]    ERROR 15       <name>person</name>
+     [2024-01-10T21:54:51]    ERROR 16       <value>siri</value>
+     [2024-01-10T21:54:51]    ERROR 17     </envar>
+     [2024-01-10T21:54:51]    ERROR 18   </task>
+     [2024-01-10T21:54:51]    ERROR 19 </workflow>
 
   To decode this type of output, it is easiest to interpret it from the bottom up. It says:
 
@@ -305,60 +305,60 @@ The examples that follow use a Rocoto XML file ``rocoto.xml`` with the following
   In the following example, an empty ``<dependency>`` element was added at the end of the task:
 
   .. code-block:: xml
-    :linenos:
+     :linenos:
 
-    <?xml version='1.0' encoding='utf-8'?>
-    <!DOCTYPE workflow [
-      <!ENTITY ACCOUNT "myaccount">
-      <!ENTITY FOO "test.log">
-    ]>
-    <workflow realtime="False" scheduler="slurm">
-      <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
-      <log>/some/path/to/&FOO;</log>
-      <task name="hello" cycledefs="howdy">
-        <account>&ACCOUNT;</account>
-        <nodes>1:ppn=1</nodes>
-        <walltime>00:01:00</walltime>
-        <command>echo hello $person</command>
-        <jobname>hello</jobname>
-        <envar>
-          <name>person</name>
-          <value>siri</value>
-        </envar>
-        <dependency>
-        </dependency>
-      </task>
-    </workflow>
+     <?xml version='1.0' encoding='utf-8'?>
+     <!DOCTYPE workflow [
+       <!ENTITY ACCOUNT "myaccount">
+       <!ENTITY FOO "test.log">
+     ]>
+     <workflow realtime="False" scheduler="slurm">
+       <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+       <log>/some/path/to/&FOO;</log>
+       <task name="hello" cycledefs="howdy">
+         <account>&ACCOUNT;</account>
+         <nodes>1:ppn=1</nodes>
+         <walltime>00:01:00</walltime>
+         <command>echo hello $person</command>
+         <jobname>hello</jobname>
+         <envar>
+           <name>person</name>
+           <value>siri</value>
+         </envar>
+         <dependency>
+         </dependency>
+       </task>
+     </workflow>
 
-  .. code:: text
+  .. code-block:: text
 
-    $ uw rocoto validate --input-file rocoto.xml
-    [2024-01-10T21:56:14]    ERROR 2 Rocoto validation errors found
-    [2024-01-10T21:56:14]    ERROR <string>:0:0:ERROR:RELAXNGV:RELAXNG_ERR_INTEREXTRA: Extra element dependency in interleave
-    [2024-01-10T21:56:14]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_CONTENTVALID: Element task failed to validate content
-    [2024-01-10T21:56:14]    ERROR Invalid Rocoto XML:
-    [2024-01-10T21:56:14]    ERROR  1 <?xml version='1.0' encoding='utf-8'?>
-    [2024-01-10T21:56:14]    ERROR  2 <!DOCTYPE workflow [
-    [2024-01-10T21:56:14]    ERROR  3   <!ENTITY ACCOUNT "myaccount">
-    [2024-01-10T21:56:14]    ERROR  4   <!ENTITY FOO "test.log">
-    [2024-01-10T21:56:14]    ERROR  5 ]>
-    [2024-01-10T21:56:14]    ERROR  6 <workflow realtime="False" scheduler="slurm">
-    [2024-01-10T21:56:14]    ERROR  7   <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
-    [2024-01-10T21:56:14]    ERROR  8   <log>/some/path/to/&FOO;</log>
-    [2024-01-10T21:56:14]    ERROR  9   <task name="hello" cycledefs="howdy">
-    [2024-01-10T21:56:14]    ERROR 10     <account>&ACCOUNT;</account>
-    [2024-01-10T21:56:14]    ERROR 11     <nodes>1:ppn=1</nodes>
-    [2024-01-10T21:56:14]    ERROR 12     <walltime>00:01:00</walltime>
-    [2024-01-10T21:56:14]    ERROR 13     <command>echo hello $person</command>
-    [2024-01-10T21:56:14]    ERROR 14     <jobname>hello</jobname>
-    [2024-01-10T21:56:14]    ERROR 15     <envar>
-    [2024-01-10T21:56:14]    ERROR 16       <name>person</name>
-    [2024-01-10T21:56:14]    ERROR 17       <value>siri</value>
-    [2024-01-10T21:56:14]    ERROR 18     </envar>
-    [2024-01-10T21:56:14]    ERROR 19     <dependency>
-    [2024-01-10T21:56:14]    ERROR 20     </dependency>
-    [2024-01-10T21:56:14]    ERROR 21   </task>
-    [2024-01-10T21:56:14]    ERROR 22 </workflow>
+     $ uw rocoto validate --input-file rocoto.xml
+     [2024-01-10T21:56:14]    ERROR 2 Rocoto validation errors found
+     [2024-01-10T21:56:14]    ERROR <string>:0:0:ERROR:RELAXNGV:RELAXNG_ERR_INTEREXTRA: Extra element dependency in interleave
+     [2024-01-10T21:56:14]    ERROR <string>:9:0:ERROR:RELAXNGV:RELAXNG_ERR_CONTENTVALID: Element task failed to validate content
+     [2024-01-10T21:56:14]    ERROR Invalid Rocoto XML:
+     [2024-01-10T21:56:14]    ERROR  1 <?xml version='1.0' encoding='utf-8'?>
+     [2024-01-10T21:56:14]    ERROR  2 <!DOCTYPE workflow [
+     [2024-01-10T21:56:14]    ERROR  3   <!ENTITY ACCOUNT "myaccount">
+     [2024-01-10T21:56:14]    ERROR  4   <!ENTITY FOO "test.log">
+     [2024-01-10T21:56:14]    ERROR  5 ]>
+     [2024-01-10T21:56:14]    ERROR  6 <workflow realtime="False" scheduler="slurm">
+     [2024-01-10T21:56:14]    ERROR  7   <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+     [2024-01-10T21:56:14]    ERROR  8   <log>/some/path/to/&FOO;</log>
+     [2024-01-10T21:56:14]    ERROR  9   <task name="hello" cycledefs="howdy">
+     [2024-01-10T21:56:14]    ERROR 10     <account>&ACCOUNT;</account>
+     [2024-01-10T21:56:14]    ERROR 11     <nodes>1:ppn=1</nodes>
+     [2024-01-10T21:56:14]    ERROR 12     <walltime>00:01:00</walltime>
+     [2024-01-10T21:56:14]    ERROR 13     <command>echo hello $person</command>
+     [2024-01-10T21:56:14]    ERROR 14     <jobname>hello</jobname>
+     [2024-01-10T21:56:14]    ERROR 15     <envar>
+     [2024-01-10T21:56:14]    ERROR 16       <name>person</name>
+     [2024-01-10T21:56:14]    ERROR 17       <value>siri</value>
+     [2024-01-10T21:56:14]    ERROR 18     </envar>
+     [2024-01-10T21:56:14]    ERROR 19     <dependency>
+     [2024-01-10T21:56:14]    ERROR 20     </dependency>
+     [2024-01-10T21:56:14]    ERROR 21   </task>
+     [2024-01-10T21:56:14]    ERROR 22 </workflow>
 
   Once again, interpreting from the bottom:
 

--- a/docs/sections/user_guide/cli/mode_rocoto.rst
+++ b/docs/sections/user_guide/cli/mode_rocoto.rst
@@ -7,13 +7,13 @@ The ``uw`` mode for realizing and validating Rocoto XML documents.
 
    $ uw rocoto --help
    usage: uw rocoto [-h] MODE ...
- 
+
    Realize and validate Rocoto XML Documents
- 
+
    Optional arguments:
      -h, --help
            Show help and exit
- 
+
    Positional arguments:
      MODE
        realize
@@ -34,9 +34,9 @@ More information about the structured UW YAML file for Rocoto can be found :any:
 
    $ uw rocoto realize --help
    usage: uw rocoto realize [-h] [--input-file PATH] [--output-file PATH] [--quiet] [--verbose]
- 
+
    Realize a Rocoto XML workflow document
- 
+
    Optional arguments:
      -h, --help
          Show help and exit
@@ -208,9 +208,9 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
 
    $ uw rocoto validate --help
    usage: uw rocoto validate [-h] [--input-file PATH] [--quiet] [--verbose]
- 
+
    Validate Rocoto XML
- 
+
    Optional arguments:
      -h, --help
          Show help and exit
@@ -249,7 +249,7 @@ The examples that follow use a Rocoto XML file ``rocoto.xml`` with the following
        </envar>
      </task>
    </workflow>
- 
+
 * To validate an XML from ``stdin``:
 
   .. code-block:: text

--- a/docs/sections/user_guide/cli/mode_rocoto.rst
+++ b/docs/sections/user_guide/cli/mode_rocoto.rst
@@ -82,7 +82,7 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
 
 * Realize a UW YAML input file to ``stdout`` in Rocoto XML format:
 
-  .. code-block:: XML
+  .. code-block:: xml
 
      $ uw rocoto realize --input-file rocoto.yaml
      [2024-01-02T13:41:25]     INFO 0 UW schema-validation errors found

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -7,13 +7,13 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
    $ uw template --help
    usage: uw template [-h] MODE ...
- 
+
    Handle templates
- 
+
    Optional arguments:
     -h, --help
           Show help and exit
- 
+
    Positional arguments:
     MODE
       render
@@ -31,9 +31,9 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
                              [--values-format {ini,nml,sh,yaml}] [--values-needed] [--dry-run]
                              [--quiet] [--verbose]
                              [KEY=VALUE ...]
- 
+
    Render a template
- 
+
    Optional arguments:
      -h, --help
          Show help and exit

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -5,19 +5,19 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
 .. code-block:: text
 
-  $ uw template --help
-  usage: uw template [-h] MODE ...
-
-  Handle templates
-
-  Optional arguments:
-   -h, --help
-         Show help and exit
-
-  Positional arguments:
-   MODE
-     render
-         Render a template
+   $ uw template --help
+   usage: uw template [-h] MODE ...
+ 
+   Handle templates
+ 
+   Optional arguments:
+    -h, --help
+          Show help and exit
+ 
+   Positional arguments:
+    MODE
+      render
+          Render a template
 
 .. _template_cli_examples:
 
@@ -26,35 +26,35 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
 .. code-block:: text
 
-  $ uw template render --help
-  usage: uw template render [-h] [--input-file PATH] [--output-file PATH] [--values-file PATH]
-                            [--values-format {ini,nml,sh,yaml}] [--values-needed] [--dry-run]
-                            [--quiet] [--verbose]
-                            [KEY=VALUE ...]
-
-  Render a template
-
-  Optional arguments:
-    -h, --help
-        Show help and exit
-    --input-file PATH, -i PATH
-        Path to input file (defaults to stdin)
-    --output-file PATH, -o PATH
-        Path to output file (defaults to stdout)
-    --values-file PATH
-        Path to file providing override or interpolation values
-    --values-format {ini,nml,sh,yaml}
-        Values format
-    --values-needed
-        Print report of values needed to render template
-    --dry-run
-        Only log info, making no changes
-    --quiet, -q
-        Print no logging messages
-    --verbose, -v
-        Print all logging messages
-    KEY=VALUE
-        A key=value pair to override/supplement config
+   $ uw template render --help
+   usage: uw template render [-h] [--input-file PATH] [--output-file PATH] [--values-file PATH]
+                             [--values-format {ini,nml,sh,yaml}] [--values-needed] [--dry-run]
+                             [--quiet] [--verbose]
+                             [KEY=VALUE ...]
+ 
+   Render a template
+ 
+   Optional arguments:
+     -h, --help
+         Show help and exit
+     --input-file PATH, -i PATH
+         Path to input file (defaults to stdin)
+     --output-file PATH, -o PATH
+         Path to output file (defaults to stdout)
+     --values-file PATH
+         Path to file providing override or interpolation values
+     --values-format {ini,nml,sh,yaml}
+         Values format
+     --values-needed
+         Print report of values needed to render template
+     --dry-run
+         Only log info, making no changes
+     --quiet, -q
+         Print no logging messages
+     --verbose, -v
+         Print all logging messages
+     KEY=VALUE
+         A key=value pair to override/supplement config
 
 Examples
 ^^^^^^^^
@@ -63,30 +63,30 @@ The examples that follow use template file ``template`` with content
 
 .. code-block:: jinja
 
-  {{ greeting }}, {{ recipient }}!
+   {{ greeting }}, {{ recipient }}!
 
 and YAML file ``values.yaml`` with content
 
 .. code-block:: yaml
 
-  greeting: Hello
-  recipient: World
+   greeting: Hello
+   recipient: World
 
 * Show the values needed to render the template:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-needed
-    [2023-12-18T19:16:08]     INFO Value(s) needed to render this template are:
-    [2023-12-18T19:16:08]     INFO greeting
-    [2023-12-18T19:16:08]     INFO recipient
+     $ uw template render --input-file template --values-needed
+     [2023-12-18T19:16:08]     INFO Value(s) needed to render this template are:
+     [2023-12-18T19:16:08]     INFO greeting
+     [2023-12-18T19:16:08]     INFO recipient
 
 * Render the template to ``stdout``:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml
-    Hello, World!
+     $ uw template render --input-file template --values-file values.yaml
+     Hello, World!
 
   Shell redirection via ``|``, ``>``, et al may also be used to stream output to a file, another process, etc.
 
@@ -94,132 +94,132 @@ and YAML file ``values.yaml`` with content
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml --output-file rendered
+     $ uw template render --input-file template --values-file values.yaml --output-file rendered
 
   The content of ``rendered``:
 
   .. code-block:: text
 
-    Hello, World!
+     Hello, World!
 
 * With the ``--dry-run`` flag specified, nothing is written to ``stdout`` (or to a file if ``--output-file`` is specified), but a report of what would have been written is logged to ``stderr``:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml --dry-run
-    [2023-12-18T19:38:15]     INFO Hello, World!
+     $ uw template render --input-file template --values-file values.yaml --dry-run
+     [2023-12-18T19:38:15]     INFO Hello, World!
 
 * Read the template from ``stdin`` and render to ``stdout``:
 
   .. code-block:: text
 
-    $ cat template | uw template render --values-file values.yaml
-    Hello, World!
+     $ cat template | uw template render --values-file values.yaml
+     Hello, World!
 
 * If the values file has an unrecognized (or no) extension, ``uw`` will not know how to parse its content:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.txt
-    Cannot deduce format of 'values.txt' from unknown extension 'txt'
+     $ uw template render --input-file template --values-file values.txt
+     Cannot deduce format of 'values.txt' from unknown extension 'txt'
 
   In this case, the format can be explicitly specified:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.txt --values-format yaml
-    Hello, World!
+     $ uw template render --input-file template --values-file values.txt --values-format yaml
+     Hello, World!
 
 * It is an error to render a template without providing all needed values. For example, with ``recipient: World`` removed from ``values.yaml``:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml
-    [2023-12-18T19:30:05]    ERROR Required value(s) not provided:
-    [2023-12-18T19:30:05]    ERROR recipient
+     $ uw template render --input-file template --values-file values.yaml
+     [2023-12-18T19:30:05]    ERROR Required value(s) not provided:
+     [2023-12-18T19:30:05]    ERROR recipient
 
   But values may be supplemented by ``key=value`` command-line arguments, e.g.
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml recipient=Reader
-    Hello, Reader!
+     $ uw template render --input-file template --values-file values.yaml recipient=Reader
+     Hello, Reader!
 
   Such ``key=value`` arguments may also be used to *override* file-based values
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml recipient=Reader greeting="Good day"
-    Good day, Reader!
+     $ uw template render --input-file template --values-file values.yaml recipient=Reader greeting="Good day"
+     Good day, Reader!
 
 * Request verbose log output:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml --verbose
-    [2023-12-18T23:25:01]    DEBUG Command: uw template render --input-file template --values-file values.yaml --verbose
-    [2023-12-18T23:25:01]    DEBUG Internal arguments:
-    [2023-12-18T23:25:01]    DEBUG ---------------------------------------------------------------------
-    [2023-12-18T23:25:01]    DEBUG           values: values.yaml
-    [2023-12-18T23:25:01]    DEBUG    values_format: yaml
-    [2023-12-18T23:25:01]    DEBUG       input_file: template
-    [2023-12-18T23:25:01]    DEBUG      output_file: None
-    [2023-12-18T23:25:01]    DEBUG        overrides: {}
-    [2023-12-18T23:25:01]    DEBUG    values_needed: False
-    [2023-12-18T23:25:01]    DEBUG          dry_run: False
-    [2023-12-18T23:25:01]    DEBUG ---------------------------------------------------------------------
-    [2023-12-18T23:25:01]    DEBUG Read initial values from values.yaml
-    Hello, World!
+     $ uw template render --input-file template --values-file values.yaml --verbose
+     [2023-12-18T23:25:01]    DEBUG Command: uw template render --input-file template --values-file values.yaml --verbose
+     [2023-12-18T23:25:01]    DEBUG Internal arguments:
+     [2023-12-18T23:25:01]    DEBUG ---------------------------------------------------------------------
+     [2023-12-18T23:25:01]    DEBUG           values: values.yaml
+     [2023-12-18T23:25:01]    DEBUG    values_format: yaml
+     [2023-12-18T23:25:01]    DEBUG       input_file: template
+     [2023-12-18T23:25:01]    DEBUG      output_file: None
+     [2023-12-18T23:25:01]    DEBUG        overrides: {}
+     [2023-12-18T23:25:01]    DEBUG    values_needed: False
+     [2023-12-18T23:25:01]    DEBUG          dry_run: False
+     [2023-12-18T23:25:01]    DEBUG ---------------------------------------------------------------------
+     [2023-12-18T23:25:01]    DEBUG Read initial values from values.yaml
+     Hello, World!
 
   Note that ``uw`` logs to ``stderr`` and writes non-log output to ``stdout``, so the streams can be redirected separately:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.yaml --verbose >rendered 2>rendered.log
+     $ uw template render --input-file template --values-file values.yaml --verbose >rendered 2>rendered.log
 
   The content of ``rendered``:
 
   .. code-block:: text
 
-    Hello, World!
+     Hello, World!
 
   The content of ``rendered.log``:
 
   .. code-block:: text
 
-    [2023-12-18T23:27:04]    DEBUG Command: uw template render --input-file template --values-file values.yaml --verbose
-    [2023-12-18T23:27:04]    DEBUG Internal arguments:
-    [2023-12-18T23:27:04]    DEBUG ---------------------------------------------------------------------
-    [2023-12-18T23:27:04]    DEBUG           values: values.yaml
-    [2023-12-18T23:27:04]    DEBUG    values_format: yaml
-    [2023-12-18T23:27:04]    DEBUG       input_file: template
-    [2023-12-18T23:27:04]    DEBUG      output_file: None
-    [2023-12-18T23:27:04]    DEBUG        overrides: {}
-    [2023-12-18T23:27:04]    DEBUG    values_needed: False
-    [2023-12-18T23:27:04]    DEBUG          dry_run: False
-    [2023-12-18T23:27:04]    DEBUG ---------------------------------------------------------------------
-    [2023-12-18T23:27:04]    DEBUG Read initial values from values.yaml
+     [2023-12-18T23:27:04]    DEBUG Command: uw template render --input-file template --values-file values.yaml --verbose
+     [2023-12-18T23:27:04]    DEBUG Internal arguments:
+     [2023-12-18T23:27:04]    DEBUG ---------------------------------------------------------------------
+     [2023-12-18T23:27:04]    DEBUG           values: values.yaml
+     [2023-12-18T23:27:04]    DEBUG    values_format: yaml
+     [2023-12-18T23:27:04]    DEBUG       input_file: template
+     [2023-12-18T23:27:04]    DEBUG      output_file: None
+     [2023-12-18T23:27:04]    DEBUG        overrides: {}
+     [2023-12-18T23:27:04]    DEBUG    values_needed: False
+     [2023-12-18T23:27:04]    DEBUG          dry_run: False
+     [2023-12-18T23:27:04]    DEBUG ---------------------------------------------------------------------
+     [2023-12-18T23:27:04]    DEBUG Read initial values from values.yaml
 
 * Non-YAML-formatted files may also be used as values sources. For example, ``template``
 
   .. code-block:: jinja
 
-    {{ values.greeting }}, {{ values.recipient }}!
+     {{ values.greeting }}, {{ values.recipient }}!
 
   can be rendered with ``values.nml``
 
   .. code-block:: fortran
 
-    &values
-      greeting = "Hello"
-      recipient = "World"
-    /
+     &values
+       greeting = "Hello"
+       recipient = "World"
+     /
 
   like so:
 
   .. code-block:: text
 
-    $ uw template render --input-file template --values-file values.nml
-    Hello, World!
+     $ uw template render --input-file template --values-file values.nml
+     Hello, World!
 
   Note that ``ini`` and ``nml`` configs are, by definition, depth-2 configs, while ``sh`` configs are depth-1 and ``yaml`` configs have arbitrary depth.

--- a/docs/sections/user_guide/installation.rst
+++ b/docs/sections/user_guide/installation.rst
@@ -11,15 +11,15 @@ Use an Existing conda Installation
 Install Into an Existing Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To install ``uwtools`` into an exiting environment in an existing conda (e.g. :miniforge:`Miniforge<>`, :miniconda:`Miniconda<>`, :anaconda:`Anaconda<>`) installation:
+To install ``uwtools`` into an existing environment in an existing conda (e.g. :miniforge:`Miniforge<>`, :miniconda:`Miniconda<>`, :anaconda:`Anaconda<>`) installation:
 
 #. Activate that environment.
 #. Identify the ``uwtools`` version number to install from the available versions shown by ``conda search -c ufs-community --override-channels uwtools``.
 #. Install ``uwtools`` into the active environment:
 
-  .. code-block:: text
+   .. code-block:: text
 
-    conda install -c ufs-community uwtools=<version>
+      conda install -c ufs-community uwtools=<version>
 
 Create a Standalone ``uwtools`` Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,9 +29,9 @@ To create a standalone conda environment providing ``uwtools``:
 #. Identify the ``uwtools`` version number to install from the available versions shown by ``conda search -c ufs-community --override-channels uwtools``.
 #. Create the environment (here named ``uwtools`` via the ``-n`` flag, but any name may be used):
 
-  .. code-block:: text
+   .. code-block:: text
 
-    conda create -n uwtools -c ufs-community uwtools=<version>
+      conda create -n uwtools -c ufs-community uwtools=<version>
 
 Use a Fresh Miniforge Installation
 ----------------------------------
@@ -40,32 +40,32 @@ If no existing conda installation is available, install :miniforge:`Miniforge<>`
 
 .. include:: ../../shared/miniforge3_instructions.rst
 
-2. Continue with the `Use an Existing conda Installation`_ instructions.
+#. Continue with the `Use an Existing conda Installation`_ instructions.
 
 Build the ``uwtools`` Package Locally
 -------------------------------------
 
-1. Install the necessary build packages into the conda installation's base environment (see the `Use a Fresh Miniforge Installation`_ instructions if an installation is unavailable or not writable):
+#. Install the necessary build packages into the conda installation's base environment (see the `Use a Fresh Miniforge Installation`_ instructions if an installation is unavailable or not writable):
 
-  .. code-block:: text
+   .. code-block:: text
 
-    conda install conda-build conda-verify
+      conda install conda-build conda-verify
 
-2. In a clone of the :uwtools:`uwtools repository<>`, build the ``uwtools`` package:
+#. In a clone of the :uwtools:`uwtools repository<>`, build the ``uwtools`` package:
 
-  .. code-block:: text
+   .. code-block:: text
 
-    cd /to/your/uwtools/clone
-    conda build recipe
+      cd /to/your/uwtools/clone
+      conda build recipe
 
-3. Verify local availability of the newly built package:
+#. Verify local availability of the newly built package:
 
-  .. code-block:: text
+   .. code-block:: text
 
-    conda search -c local --override-channels uwtools # do not add -c conda-forge to this command
+      conda search -c local --override-channels uwtools # do not add -c conda-forge to this command
 
-4. Optionally, create an environment from the newly built package:
+#. Optionally, create an environment from the newly built package:
 
-  .. code-block:: text
+   .. code-block:: text
 
-    conda create -n uwtools -c local uwtools[=<version>] # specify version if multiple choices are available
+      conda create -n uwtools -c local uwtools[=<version>] # specify version if multiple choices are available

--- a/docs/shared/miniforge3_instructions.rst
+++ b/docs/shared/miniforge3_instructions.rst
@@ -1,17 +1,17 @@
 This recipe uses the ``aarch64`` (64-bit ARM) Miniforge for Linux, and installs into ``$HOME/conda``. Adjust as necessary for the target system.
 
-1. Download, install, and activate the latest :miniforge3:`Miniforge<>` for the target system.
+#. Download, install, and activate the latest :miniforge3:`Miniforge<>` for the target system.
 
-  .. code-block:: text
+   .. code-block:: text
 
-    wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
-    bash Miniforge3-Linux-aarch64.sh -bfp ~/conda
-    rm Miniforge3-Linux-aarch64.sh
-    source ~/conda/etc/profile.d/conda.sh
-    conda activate
+      wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
+      bash Miniforge3-Linux-aarch64.sh -bfp ~/conda
+      rm Miniforge3-Linux-aarch64.sh
+      source ~/conda/etc/profile.d/conda.sh
+      conda activate
 
-  After initial installation, this conda may be activated with the command
+   After initial installation, this conda may be activated with the command
 
-  .. code-block:: text
+   .. code-block:: text
 
-    source ~/conda/etc/profile.d/conda.sh && conda activate
+      source ~/conda/etc/profile.d/conda.sh && conda activate


### PR DESCRIPTION
**Synopsis**

- Fix typo `exiting` -> `existing`.
- Use Sphinx `#.` auto-numbering by correcting indentation.
- Update guidelines for code-block indentation.
- Fix some `code-block::` directives.

There are a lot of whitespace diffs in this PR, so you might like to hide those under the _Files changed_ tab when you review.

Preview docs are [here](https://uwtools--383.org.readthedocs.build/en/383/).

**Type**

- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
