### PR TITLE
UW-472

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CHANNELS    = $(addprefix -c ,$(shell tr '\n' ' ' <$(RECIPE_DIR)/channels)) -c local
 METAJSON    = $(RECIPE_DIR)/meta.json
 RECIPEFILES = $(addprefix $(RECIPE_DIR)/,meta.yaml)
-TARGETS     = clean-devenv devshell env format lint meta package test typecheck unittest
+TARGETS     = clean-devenv devshell docs env format lint meta package test typecheck unittest
 
 
 export RECIPE_DIR := $(shell cd ./recipe && pwd)
@@ -20,6 +20,9 @@ clean-devenv:
 
 devshell:
 	condev-shell || true
+
+docs:
+	$(MAKE) -C docs docs
 
 env: package
 	conda create -y -n $(call spec,buildnum,-) $(CHANNELS) $(call spec,build,=)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,28 +35,21 @@ Compare Mode
 
 When the Linux diff tool just doesn't work for comparing unordered namelists with mixed-case keys, this is your go-to! It also works on the other configuration formats, but the Fortran namelists are the *real* catalyst behind this gem!
 
-| :any:`CLI documentation with examples<compare_configs_cli_examples>`
+| :any:`CLI documentation with examples<cli_config_compare_examples>`
 
 Realize Mode
 """"""""""""
 
 This mode renders values created by :jinja2:`Jinja2 templates<templates>`, and lets you override values in one file or object with those from others, not necessarily with the same configuration format. With ``uwtools``, you can even reference the content of other files to build up a configuration from its pieces.
 
-| :any:`CLI documentation with examples<realize_configs_cli_examples>`
-
-Translate Mode
-""""""""""""""
-
-This tool helps transform legacy configuration files templated with the atparse tool (common at NOAA) into :jinja2:`Jinja2 templates<templates>` for use with the ``uw config realize`` and ``uw template render`` tools, or their API equivalents.
-
-| :any:`CLI documentation with examples<translate_configs_cli_examples>`
+| :any:`CLI documentation with examples<cli_config_realize_examples>`
 
 Validate Mode
 """""""""""""
 
 In this mode, you can provide a :json-schema:`JSON Schema<>` file alongside your configuration to validate that it meets the requirements set by the schema. We've enabled robust logging to make it easier to repair your configs when problems arise.
 
-| :any:`CLI documentation with examples<validate_configs_cli_examples>`
+| :any:`CLI documentation with examples<cli_config_validate_examples>`
 
 Templating
 ^^^^^^^^^^
@@ -64,9 +57,19 @@ Templating
 | **CLI**: ``uw template -h``
 | **API**: ``import uwtools.api.template``
 
-This one is pretty straightforward. It has a single ``render`` mode that gives you the full power of rendering a :jinja2:`Jinja2 template<templates>` in the same easy-to-use interface as your other workflow tools.
+Render Mode
+"""""""""""
 
-| :any:`CLI documentation with examples<template_cli_examples>`
+The ``render`` mode that gives you the full power of rendering a :jinja2:`Jinja2 template<templates>` in the same easy-to-use interface as your other workflow tools.
+
+| :any:`CLI documentation with examples<cli_template_render_examples>`
+
+Translate Mode
+""""""""""""""
+
+This tool helps transform legacy configuration files templated with the atparse tool (common at NOAA) into :jinja2:`Jinja2 templates<templates>` for use with the ``uw config realize`` and ``uw template render`` tools, or their API equivalents.
+
+| :any:`CLI documentation with examples<cli_template_translate_examples>`
 
 Rocoto Configurability
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -81,14 +84,14 @@ Realize Mode
 
 This is where you put in your structured YAML that defines your workflow of choice and it pops out a verified Rocoto XML.
 
-| :any:`CLI documentation with examples<realize_rocoto_cli_examples>`
+| :any:`CLI documentation with examples<cli_rocoto_realize_examples>`
 
 Validate Mode
 """""""""""""
 
 Do you already have a Rocoto XML, but don't want to run Rocoto to make sure it works? Use the validate mode to check to see if Rocoto will be happy.
 
-| :any:`CLI documentation with examples<validate_rocoto_cli_examples>`
+| :any:`CLI documentation with examples<cli_rocoto_validate_examples>`
 
 The Drivers
 -----------

--- a/docs/sections/user_guide/cli/mode_config.rst
+++ b/docs/sections/user_guide/cli/mode_config.rst
@@ -20,12 +20,10 @@ The ``uw`` mode for handling configs.
            Compare configs
        realize
            Realize config
-       translate
-           Translate configs
        validate
            Validate config
 
-.. _compare_configs_cli_examples:
+.. _cli_config_compare_examples:
 
 ``compare``
 -----------
@@ -132,7 +130,7 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
       [2024-01-08T16:59:20]     INFO ---------------------------------------------------------------------
       [2024-01-08T16:59:20]     INFO values:       recipient:  - None + World
 
-.. _realize_configs_cli_examples:
+.. _cli_config_realize_examples:
 
 ``realize``
 -----------
@@ -405,84 +403,7 @@ and additional supplemental YAML file ``values2.yaml`` with content
 
   Note that ``ini`` and ``nml`` configs are, by definition, depth-2 configs, while ``sh`` configs are depth-1 and ``yaml`` configs have arbitrary depth.
 
-.. _translate_configs_cli_examples:
-
-``translate``
--------------
-
-.. code-block:: text
-
-   $ uw config translate --help
-   usage: uw config translate [-h] [--input-file PATH] [--input-format {atparse}]
-                              [--output-file PATH] [--output-format {jinja2}] [--dry-run] [--quiet]
-                              [--verbose]
-
-   Translate configs
-
-   Optional arguments:
-     -h, --help
-         Show help and exit
-     --input-file PATH, -i PATH
-         Path to input file (defaults to stdin)
-     --input-format {atparse}
-         Input format
-     --output-file PATH, -o PATH
-         Path to output file (defaults to stdout)
-     --output-format {jinja2}
-         Output format
-     --dry-run
-         Only log info, making no changes
-     --quiet, -q
-         Print no logging messages
-     --verbose, -v
-         Print all logging messages
-
-Examples
-^^^^^^^^
-
-The examples that follow use atparse-formatted template file ``atparse.txt`` with content
-
-.. code-block:: text
-
-   @[greeting], @[recipient]!
-
-* Convert an atparse-formatted template file to Jinja2 format:
-
-  .. code-block:: text
-
-     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2
-     {{greeting}}, {{recipient}}!
-
-  Shell redirection via ``|``, ``>``, et al may also be used to stream output to a file, another process, etc.
-
-* Convert the template to a file via command-line argument:
-
-  .. code-block:: text
-
-     $ uw config translate --input-file atparse.txt --input-format atparse --output-file jinja2.txt --output-format jinja2
-
-  The content of ``jinja2.txt``:
-
-  .. code-block:: jinja
-
-     {{greeting}}, {{recipient}}!
-
-* With the ``--dry-run`` flag specified, nothing is written to ``stdout`` (or to a file if ``--output-file`` is specified), but a report of what would have been written is logged to ``stderr``:
-
-  .. code-block:: text
-
-     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2 --dry-run
-     [2024-01-03T16:41:13]     INFO {{greeting}}, {{recipient}}!
-
-
-* If an input is read alone from ``stdin``, ``uw`` will not know how to parse its content as we must always specify the formats:
-
-  .. code-block:: text
-
-     $ cat atparse.txt | uw config translate --input-format atparse --output-format jinja2
-     {{greeting}}, {{recipient}}!
-
-.. _validate_configs_cli_examples:
+.. _cli_config_validate_examples:
 
 ``validate``
 ------------

--- a/docs/sections/user_guide/cli/mode_forecast.rst
+++ b/docs/sections/user_guide/cli/mode_forecast.rst
@@ -50,6 +50,8 @@ The ``uw`` mode for configuring and running forecasts.
      --verbose, -v
          Print all logging messages
 
+.. _cli_forecast_run_examples:
+
 Examples
 ^^^^^^^^
 

--- a/docs/sections/user_guide/cli/mode_forecast.rst
+++ b/docs/sections/user_guide/cli/mode_forecast.rst
@@ -52,8 +52,6 @@ The ``uw`` mode for configuring and running forecasts.
 
 .. _cli_forecast_run_examples:
 
-.. _cli_forecast_run_examples:
-
 Examples
 ^^^^^^^^
 

--- a/docs/sections/user_guide/cli/mode_rocoto.rst
+++ b/docs/sections/user_guide/cli/mode_rocoto.rst
@@ -21,7 +21,7 @@ The ``uw`` mode for realizing and validating Rocoto XML documents.
        validate
            Validate Rocoto XML
 
-.. _realize_rocoto_cli_examples:
+.. _cli_rocoto_realize_examples:
 
 ``realize``
 -----------
@@ -199,7 +199,7 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
      [2024-01-02T14:00:01]     INFO 0 UW schema-validation errors found
      [2024-01-02T14:00:01]     INFO 0 Rocoto validation errors found
 
-.. _validate_rocoto_cli_examples:
+.. _cli_rocoto_validate_examples:
 
 ``validate``
 ------------

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -19,7 +19,7 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
       render
           Render a template
 
-.. _template_cli_examples:
+.. _cli_template_render_examples:
 
 ``render``
 ----------
@@ -223,3 +223,80 @@ and YAML file ``values.yaml`` with content
      Hello, World!
 
   Note that ``ini`` and ``nml`` configs are, by definition, depth-2 configs, while ``sh`` configs are depth-1 and ``yaml`` configs have arbitrary depth.
+
+.. _cli_template_translate_examples:
+
+``translate``
+-------------
+
+.. code-block:: text
+
+   $ uw config translate --help
+   usage: uw config translate [-h] [--input-file PATH] [--input-format {atparse}]
+                              [--output-file PATH] [--output-format {jinja2}] [--dry-run] [--quiet]
+                              [--verbose]
+ 
+   Translate configs
+ 
+   Optional arguments:
+     -h, --help
+         Show help and exit
+     --input-file PATH, -i PATH
+         Path to input file (defaults to stdin)
+     --input-format {atparse}
+         Input format
+     --output-file PATH, -o PATH
+         Path to output file (defaults to stdout)
+     --output-format {jinja2}
+         Output format
+     --dry-run
+         Only log info, making no changes
+     --quiet, -q
+         Print no logging messages
+     --verbose, -v
+         Print all logging messages
+
+Examples
+^^^^^^^^
+
+The examples that follow use atparse-formatted template file ``atparse.txt`` with content
+
+.. code-block:: text
+
+   @[greeting], @[recipient]!
+
+* Convert an atparse-formatted template file to Jinja2 format:
+
+  .. code-block:: text
+
+     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2
+     {{greeting}}, {{recipient}}!
+
+  Shell redirection via ``|``, ``>``, et al may also be used to stream output to a file, another process, etc.
+
+* Convert the template to a file via command-line argument:
+
+  .. code-block:: text
+
+     $ uw config translate --input-file atparse.txt --input-format atparse --output-file jinja2.txt --output-format jinja2
+
+  The content of ``jinja2.txt``:
+
+  .. code-block:: jinja
+
+     {{greeting}}, {{recipient}}!
+
+* With the ``--dry-run`` flag specified, nothing is written to ``stdout`` (or to a file if ``--output-file`` is specified), but a report of what would have been written is logged to ``stderr``:
+
+  .. code-block:: text
+
+     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2 --dry-run
+     [2024-01-03T16:41:13]     INFO {{greeting}}, {{recipient}}!
+
+
+* If an input is read alone from ``stdin``, ``uw`` will not know how to parse its content as we must always specify the formats:
+
+  .. code-block:: text
+
+     $ cat atparse.txt | uw config translate --input-format atparse --output-format jinja2
+     {{greeting}}, {{recipient}}!

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -7,17 +7,19 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
    $ uw template --help
    usage: uw template [-h] MODE ...
-
+ 
    Handle templates
-
+ 
    Optional arguments:
-    -h, --help
-          Show help and exit
-
+     -h, --help
+         Show help and exit
+ 
    Positional arguments:
-    MODE
-      render
-          Render a template
+     MODE
+       render
+         Render a template
+       translate
+         Translate atparse to Jinja2
 
 .. _cli_template_render_examples:
 
@@ -231,24 +233,19 @@ and YAML file ``values.yaml`` with content
 
 .. code-block:: text
 
-   $ uw config translate --help
-   usage: uw config translate [-h] [--input-file PATH] [--input-format {atparse}]
-                              [--output-file PATH] [--output-format {jinja2}] [--dry-run] [--quiet]
-                              [--verbose]
- 
-   Translate configs
- 
+   $ uw template translate --help
+   usage: uw template translate [-h] [--input-file PATH] [--output-file PATH] [--dry-run] [--quiet]
+                                [--verbose]
+   
+   Translate atparse to Jinja2
+   
    Optional arguments:
      -h, --help
          Show help and exit
      --input-file PATH, -i PATH
          Path to input file (defaults to stdin)
-     --input-format {atparse}
-         Input format
      --output-file PATH, -o PATH
          Path to output file (defaults to stdout)
-     --output-format {jinja2}
-         Output format
      --dry-run
          Only log info, making no changes
      --quiet, -q
@@ -269,7 +266,7 @@ The examples that follow use atparse-formatted template file ``atparse.txt`` wit
 
   .. code-block:: text
 
-     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2
+     $ uw template translate --input-file atparse.txt
      {{greeting}}, {{recipient}}!
 
   Shell redirection via ``|``, ``>``, et al may also be used to stream output to a file, another process, etc.
@@ -278,7 +275,7 @@ The examples that follow use atparse-formatted template file ``atparse.txt`` wit
 
   .. code-block:: text
 
-     $ uw config translate --input-file atparse.txt --input-format atparse --output-file jinja2.txt --output-format jinja2
+     $ uw template translate --input-file atparse.txt --output-file jinja2.txt
 
   The content of ``jinja2.txt``:
 
@@ -290,13 +287,12 @@ The examples that follow use atparse-formatted template file ``atparse.txt`` wit
 
   .. code-block:: text
 
-     $ uw config translate --input-file atparse.txt --input-format atparse --output-format jinja2 --dry-run
+     $ uw template translate --input-file atparse.txt --dry-run
      [2024-01-03T16:41:13]     INFO {{greeting}}, {{recipient}}!
-
 
 * If an input is read alone from ``stdin``, ``uw`` will not know how to parse its content as we must always specify the formats:
 
   .. code-block:: text
 
-     $ cat atparse.txt | uw config translate --input-format atparse --output-format jinja2
+     $ cat atparse.txt | uw template translate
      {{greeting}}, {{recipient}}!

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -289,10 +289,3 @@ The examples that follow use atparse-formatted template file ``atparse.txt`` wit
 
      $ uw template translate --input-file atparse.txt --dry-run
      [2024-01-03T16:41:13]     INFO {{greeting}}, {{recipient}}!
-
-* If an input is read alone from ``stdin``, ``uw`` will not know how to parse its content as we must always specify the formats:
-
-  .. code-block:: text
-
-     $ cat atparse.txt | uw template translate
-     {{greeting}}, {{recipient}}!

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -7,13 +7,13 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
    $ uw template --help
    usage: uw template [-h] MODE ...
- 
+
    Handle templates
- 
+
    Optional arguments:
      -h, --help
          Show help and exit
- 
+
    Positional arguments:
      MODE
        render
@@ -236,9 +236,9 @@ and YAML file ``values.yaml`` with content
    $ uw template translate --help
    usage: uw template translate [-h] [--input-file PATH] [--output-file PATH] [--dry-run] [--quiet]
                                 [--verbose]
-   
+
    Translate atparse to Jinja2
-   
+
    Optional arguments:
      -h, --help
          Show help and exit

--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -1,7 +1,6 @@
 import os
 from typing import List, Optional, Union
 
-from uwtools.config.atparse_to_jinja2 import convert as _convert_atparse_to_jinja2
 from uwtools.config.formats.fieldtable import FieldTableConfig as _FieldTableConfig
 from uwtools.config.formats.ini import INIConfig as _INIConfig
 from uwtools.config.formats.nml import NMLConfig as _NMLConfig
@@ -172,32 +171,6 @@ def realize_to_dict(
         values_needed=values_needed,
         dry_run=dry_run,
     )
-
-
-def translate(
-    input_format: str,
-    output_format: str,
-    input_file: OptionalPath = None,
-    output_file: OptionalPath = None,
-    dry_run: bool = False,
-) -> bool:
-    """
-    Translate a config to a different format.
-
-    Currently supports atparse -> Jinja2 translation, in which ``@[]`` tokens are replaced with
-    Jinja2 ``{{}}`` equivalents. Specify ``input_format=atparse`` and ``output_format=jinja2``. If
-    no input file is specified, ``stdin`` is read. If no output file is specified, ``stdout`` is
-    written to. In ``dry_run`` mode, output is written to ``stderr``.
-
-    :param input_file: Path to the template containing atparse syntax
-    :param output_file: Path to the file to write the converted template to
-    :param dry_run: Run in dry-run mode?
-    :return: ``True`` if translation was successful, ``False`` otherwise
-    """
-    if input_format == _FORMAT.atparse and output_format == _FORMAT.jinja2:
-        _convert_atparse_to_jinja2(input_file=input_file, output_file=output_file, dry_run=dry_run)
-        return True
-    return False
 
 
 def validate(

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional, Union
 
+from uwtools.config.atparse_to_jinja2 import convert as _convert_atparse_to_jinja2
 from uwtools.config.jinja2 import render as _render
 from uwtools.types import DefinitePath, OptionalPath
 
@@ -42,3 +43,24 @@ def render(
         values_needed=values_needed,
         dry_run=dry_run,
     )
+
+
+def translate(
+    input_file: OptionalPath = None,
+    output_file: OptionalPath = None,
+    dry_run: bool = False,
+) -> bool:
+    """
+    Translate an atparse template to a Jinja2 template.
+
+    ``@[]`` tokens are replaced with Jinja2 ``{{}}`` equivalents. If no input file is specified,
+    ``stdin`` is read. If no output file is specified, ``stdout`` is written to. In ``dry_run``
+    mode, output is written to ``stderr``.
+
+    :param input_file: Path to the template containing atparse syntax
+    :param output_file: Path to the file to write the converted template to
+    :param dry_run: Run in dry-run mode?
+    :return: ``True``
+    """
+    _convert_atparse_to_jinja2(input_file=input_file, output_file=output_file, dry_run=dry_run)
+    return True

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -74,7 +74,6 @@ def _add_subparser_config(subparsers: Subparsers) -> ModeChecks:
     return {
         STR.compare: _add_subparser_config_compare(subparsers),
         STR.realize: _add_subparser_config_realize(subparsers),
-        STR.translate: _add_subparser_config_translate(subparsers),
         STR.validate: _add_subparser_config_validate(subparsers),
     }
 
@@ -131,26 +130,6 @@ def _add_subparser_config_realize(subparsers: Subparsers) -> SubmodeChecks:
     ]
 
 
-def _add_subparser_config_translate(subparsers: Subparsers) -> SubmodeChecks:
-    """
-    Subparser for mode: config translate
-
-    :param subparsers: Parent parser's subparsers, to add this subparser to.
-    """
-    parser = _add_subparser(subparsers, STR.translate, "Translate configs")
-    optional = _basic_setup(parser)
-    _add_arg_input_file(optional)
-    _add_arg_input_format(optional, choices=[FORMAT.atparse])
-    _add_arg_output_file(optional)
-    _add_arg_output_format(optional, choices=[FORMAT.jinja2])
-    _add_arg_dry_run(optional)
-    checks = _add_args_quiet_and_verbose(optional)
-    return checks + [
-        partial(_check_file_vs_format, STR.infile, STR.infmt),
-        partial(_check_file_vs_format, STR.outfile, STR.outfmt),
-    ]
-
-
 def _add_subparser_config_validate(subparsers: Subparsers) -> SubmodeChecks:
     """
     Subparser for mode: config validate
@@ -174,7 +153,6 @@ def _dispatch_config(args: Args) -> bool:
     return {
         STR.compare: _dispatch_config_compare,
         STR.realize: _dispatch_config_realize,
-        STR.translate: _dispatch_config_translate,
         STR.validate: _dispatch_config_validate,
     }[args[STR.submode]](args)
 
@@ -206,21 +184,6 @@ def _dispatch_config_realize(args: Args) -> bool:
         output_format=args[STR.outfmt],
         supplemental_configs=args[STR.suppfiles],
         values_needed=args[STR.valsneeded],
-        dry_run=args[STR.dryrun],
-    )
-
-
-def _dispatch_config_translate(args: Args) -> bool:
-    """
-    Dispatch logic for config translate submode.
-
-    :param args: Parsed command-line args.
-    """
-    return uwtools.api.config.translate(
-        input_file=args[STR.infile],
-        input_format=args[STR.infmt],
-        output_file=args[STR.outfile],
-        output_format=args[STR.outfmt],
         dry_run=args[STR.dryrun],
     )
 
@@ -384,7 +347,24 @@ def _add_subparser_template(subparsers: Subparsers) -> ModeChecks:
     subparsers = _add_subparsers(parser, STR.submode)
     return {
         STR.render: _add_subparser_template_render(subparsers),
+        STR.translate: _add_subparser_template_translate(subparsers),
     }
+
+
+def _add_subparser_template_translate(subparsers: Subparsers) -> SubmodeChecks:
+    """
+    Subparser for mode: template translate
+
+    :param subparsers: Parent parser's subparsers, to add this subparser to.
+    """
+    parser = _add_subparser(
+        subparsers, STR.translate, "Translate atparse template to Jinja2 template"
+    )
+    optional = _basic_setup(parser)
+    _add_arg_input_file(optional)
+    _add_arg_output_file(optional)
+    _add_arg_dry_run(optional)
+    return _add_args_quiet_and_verbose(optional)
 
 
 def _add_subparser_template_render(subparsers: Subparsers) -> SubmodeChecks:
@@ -412,7 +392,12 @@ def _dispatch_template(args: Args) -> bool:
 
     :param args: Parsed command-line args.
     """
-    return {STR.render: _dispatch_template_render}[args[STR.submode]](args)
+    return {
+        STR.render: _dispatch_template_render,
+        STR.translate: _dispatch_template_translate,
+    }[
+        args[STR.submode]
+    ](args)
 
 
 def _dispatch_template_render(args: Args) -> bool:
@@ -428,6 +413,21 @@ def _dispatch_template_render(args: Args) -> bool:
         output_file=args[STR.outfile],
         overrides=_dict_from_key_eq_val_strings(args[STR.keyvalpairs]),
         values_needed=args[STR.valsneeded],
+        dry_run=args[STR.dryrun],
+    )
+
+
+def _dispatch_template_translate(args: Args) -> bool:
+    """
+    Dispatch logic for template translate submode.
+
+    :param args: Parsed command-line args.
+    """
+    return uwtools.api.template.translate(
+        input_file=args[STR.infile],
+        input_format=args[STR.infmt],
+        output_file=args[STR.outfile],
+        output_format=args[STR.outfmt],
         dry_run=args[STR.dryrun],
     )
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -358,7 +358,7 @@ def _add_subparser_template_translate(subparsers: Subparsers) -> SubmodeChecks:
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
     parser = _add_subparser(
-        subparsers, STR.translate, "Translate atparse template to Jinja2 template"
+        subparsers, STR.translate, "Translate atparse to Jinja2"
     )
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -357,9 +357,7 @@ def _add_subparser_template_translate(subparsers: Subparsers) -> SubmodeChecks:
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
-    parser = _add_subparser(
-        subparsers, STR.translate, "Translate atparse to Jinja2"
-    )
+    parser = _add_subparser(subparsers, STR.translate, "Translate atparse to Jinja2")
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
     _add_arg_output_file(optional)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -425,9 +425,7 @@ def _dispatch_template_translate(args: Args) -> bool:
     """
     return uwtools.api.template.translate(
         input_file=args[STR.infile],
-        input_format=args[STR.infmt],
         output_file=args[STR.outfile],
-        output_format=args[STR.outfmt],
         dry_run=args[STR.dryrun],
     )
 

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -1,5 +1,5 @@
 """
-Utilities for rendering Jinja2 templates.
+Convert atparse templates to Jinja2 templates.
 """
 
 import re

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -25,7 +25,7 @@ def convert(
 
     def lines() -> Generator[str, Any, Any]:
         with readable(input_file) as f_in:
-            for line in f_in:
+            for line in f_in.read().strip().split("\n"):
                 yield _replace(line.strip())
 
     def write(f_out: IO) -> None:

--- a/src/uwtools/tests/api/test_config.py
+++ b/src/uwtools/tests/api/test_config.py
@@ -8,7 +8,6 @@ import yaml
 
 from uwtools.api import config
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.utils.file import FORMAT
 
 
 def test_compare():
@@ -68,32 +67,6 @@ def test_realize_to_dict():
     _realize.assert_called_once_with(
         **dict({**kwargs, **{"output_file": os.devnull, "output_format": None}})
     )
-
-
-@pytest.mark.parametrize(
-    "infmt,outfmt,success_expected",
-    [
-        (FORMAT.atparse, FORMAT.jinja2, True),
-        ("invalid", FORMAT.jinja2, False),
-        (FORMAT.atparse, "invalid", False),
-    ],
-)
-def test_translate(infmt, outfmt, success_expected):
-    kwargs: dict = {
-        "input_file": "path1",
-        "input_format": infmt,
-        "output_file": "path2",
-        "output_format": outfmt,
-        "dry_run": True,
-    }
-    with patch.object(config, "_convert_atparse_to_jinja2") as _catj:
-        assert config.translate(**kwargs) is success_expected
-    if success_expected:
-        _catj.assert_called_once_with(
-            input_file=kwargs["input_file"],
-            output_file=kwargs["output_file"],
-            dry_run=kwargs["dry_run"],
-        )
 
 
 @pytest.mark.parametrize("cfg", [{"foo": "bar"}, YAMLConfig(config={})])

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -18,3 +18,18 @@ def test_render():
     with patch.object(template, "_render") as _render:
         template.render(**kwargs)
     _render.assert_called_once_with(**kwargs)
+
+
+def test_translate():
+    kwargs: dict = {
+        "input_file": "path1",
+        "output_file": "path2",
+        "dry_run": True,
+    }
+    with patch.object(template, "_convert_atparse_to_jinja2") as _catj:
+        assert template.translate(**kwargs)
+    _catj.assert_called_once_with(
+        input_file=kwargs["input_file"],
+        output_file=kwargs["output_file"],
+        dry_run=kwargs["dry_run"],
+    )

--- a/src/uwtools/tests/fixtures/FV3_GFS_v16.yaml
+++ b/src/uwtools/tests/fixtures/FV3_GFS_v16.yaml
@@ -1,54 +1,54 @@
 sphum:
   longname: specific humidity
   units: kg/kg
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30
 liq_wat:
   longname: cloud water mixing ratio
   units: kg/kg
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30
 rainwat:
   longname: rain mixing ratio
   units: kg/kg
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30
 ice_wat:
   longname: cloud ice mixing ratio
   units: kg/kg
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30
 snowwat:
   longname: snow mixing ratio
   units: kg/kg
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30
 graupel:
   longname: graupel mixing ratio
   units: kg/kg
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30
 o3mr:
   longname: ozone mixing ratio
   units: kg/kg
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30
 sgs_tke:
   longname: subgrid scale turbulent kinetic energy
   units: m2/s2
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 0.0
 cld_amt:
   longname: cloud amount
   units: 1
-  profile_type: 
+  profile_type:
     name: fixed
     surface_value: 1.e30

--- a/src/uwtools/tests/fixtures/FV3_GFS_v16_update.yaml
+++ b/src/uwtools/tests/fixtures/FV3_GFS_v16_update.yaml
@@ -4,18 +4,18 @@ forecast:
       sphum:
         longname: specific humidity
         units: kg/kg
-        profile_type: 
+        profile_type:
           name: fixed
           surface_value: 2.0
       liq_wat:
         longname: cloud water mixing ratio
         units: kg/kg
-        profile_type: 
+        profile_type:
           name: fixed
           surface_value: 2.0
       rainwat:
         longname: rain mixing ratio
         units: kg/kg
-        profile_type: 
+        profile_type:
           name: fixed
           surface_value: 2.0

--- a/src/uwtools/tests/fixtures/expt_dir.yaml
+++ b/src/uwtools/tests/fixtures/expt_dir.yaml
@@ -1,5 +1,5 @@
 cycle-dependent:
-  INPUT/gfs_data.nc: path/to/gfs_data.tile7.halo0.nc 
+  INPUT/gfs_data.nc: path/to/gfs_data.tile7.halo0.nc
   INPUT/sfc_data.nc: path/to/sfc_data.tile7.halo0.nc
   INPUT/gfs_bndy.tile7.000.nc: path/to/gfs_bndy.tile7.000.nc
   INPUT/gfs_bndy.tile7.006.nc: path/to/gfs_bndy.tile7.006.nc

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -32,12 +32,7 @@ def test__abort(capsys):
 
 def test__add_subparser_config(subparsers):
     cli._add_subparser_config(subparsers)
-    assert submodes(subparsers.choices[STR.config]) == [
-        STR.compare,
-        STR.realize,
-        STR.translate,
-        STR.validate,
-    ]
+    assert submodes(subparsers.choices[STR.config]) == [STR.compare, STR.realize, STR.validate]
 
 
 def test__add_subparser_config_compare(subparsers):
@@ -67,7 +62,7 @@ def test__add_subparser_forecast_run(subparsers):
 
 def test__add_subparser_template(subparsers):
     cli._add_subparser_template(subparsers)
-    assert submodes(subparsers.choices[STR.template]) == [STR.render]
+    assert submodes(subparsers.choices[STR.template]) == [STR.render, STR.translate]
 
 
 def test__add_subparser_template_render(subparsers):
@@ -180,7 +175,6 @@ def test__dict_from_key_eq_val_strings():
     [
         (STR.compare, "_dispatch_config_compare"),
         (STR.realize, "_dispatch_config_realize"),
-        (STR.translate, "_dispatch_config_translate"),
         (STR.validate, "_dispatch_config_validate"),
     ],
 )
@@ -333,7 +327,10 @@ def test__dispatch_rocoto_validate_xml_no_optional():
     validate.assert_called_once_with(xml_file=None)
 
 
-@pytest.mark.parametrize("params", [(STR.render, "_dispatch_template_render")])
+@pytest.mark.parametrize(
+    "params",
+    [(STR.render, "_dispatch_template_render"), (STR.translate, "_dispatch_template_translate")],
+)
 def test__dispatch_template(params):
     submode, funcname = params
     args = {STR.submode: submode}
@@ -395,7 +392,7 @@ def test__dispatch_template_translate():
         STR.dryrun: 3,
     }
     with patch.object(
-        uwtools.api.config, "_convert_atparse_to_jinja2"
+        uwtools.api.template, "_convert_atparse_to_jinja2"
     ) as _convert_atparse_to_jinja2:
         cli._dispatch_template_translate(args)
     _convert_atparse_to_jinja2.assert_called_once_with(input_file=1, output_file=2, dry_run=3)

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -50,11 +50,6 @@ def test__add_subparser_config_realize(subparsers):
     assert subparsers.choices[STR.realize]
 
 
-def test__add_subparser_config_translate(subparsers):
-    cli._add_subparser_config_translate(subparsers)
-    assert subparsers.choices[STR.translate]
-
-
 def test__add_subparser_config_validate(subparsers):
     cli._add_subparser_config_validate(subparsers)
     assert subparsers.choices[STR.validate]
@@ -78,6 +73,11 @@ def test__add_subparser_template(subparsers):
 def test__add_subparser_template_render(subparsers):
     cli._add_subparser_template_render(subparsers)
     assert subparsers.choices[STR.render]
+
+
+def test__add_subparser_template_translate(subparsers):
+    cli._add_subparser_template_translate(subparsers)
+    assert subparsers.choices[STR.translate]
 
 
 @pytest.mark.parametrize(
@@ -250,43 +250,6 @@ def test__dispatch_config_realize_no_optional():
     )
 
 
-def test__dispatch_config_translate_atparse_to_jinja2():
-    args = {
-        STR.infile: 1,
-        STR.infmt: FORMAT.atparse,
-        STR.outfile: 3,
-        STR.outfmt: FORMAT.jinja2,
-        STR.dryrun: 5,
-    }
-    with patch.object(
-        uwtools.api.config, "_convert_atparse_to_jinja2"
-    ) as _convert_atparse_to_jinja2:
-        cli._dispatch_config_translate(args)
-    _convert_atparse_to_jinja2.assert_called_once_with(input_file=1, output_file=3, dry_run=5)
-
-
-def test__dispatch_config_translate_no_optional():
-    args = {
-        STR.dryrun: False,
-        STR.infile: None,
-        STR.infmt: FORMAT.atparse,
-        STR.outfile: None,
-        STR.outfmt: FORMAT.jinja2,
-    }
-    with patch.object(
-        uwtools.api.config, "_convert_atparse_to_jinja2"
-    ) as _convert_atparse_to_jinja2:
-        cli._dispatch_config_translate(args)
-    _convert_atparse_to_jinja2.assert_called_once_with(
-        input_file=None, output_file=None, dry_run=False
-    )
-
-
-def test__dispatch_config_translate_unsupported():
-    args = {STR.infile: 1, STR.infmt: "jpg", STR.outfile: 3, STR.outfmt: "png", STR.dryrun: 5}
-    assert cli._dispatch_config_translate(args) is False
-
-
 def test__dispatch_config_validate_config_obj():
     config = uwtools.api.config._YAMLConfig(config={})
     _dispatch_config_validate_args = {STR.schemafile: 1, STR.infile: config}
@@ -422,6 +385,34 @@ def test__dispatch_template_render_yaml():
         overrides={"foo": "88", "bar": "99"},
         values_needed=6,
         dry_run=7,
+    )
+
+
+def test__dispatch_template_translate():
+    args = {
+        STR.infile: 1,
+        STR.outfile: 2,
+        STR.dryrun: 3,
+    }
+    with patch.object(
+        uwtools.api.config, "_convert_atparse_to_jinja2"
+    ) as _convert_atparse_to_jinja2:
+        cli._dispatch_template_translate(args)
+    _convert_atparse_to_jinja2.assert_called_once_with(input_file=1, output_file=2, dry_run=3)
+
+
+def test__dispatch_template_translate_no_optional():
+    args = {
+        STR.dryrun: False,
+        STR.infile: None,
+        STR.outfile: None,
+    }
+    with patch.object(
+        uwtools.api.template, "_convert_atparse_to_jinja2"
+    ) as _convert_atparse_to_jinja2:
+        cli._dispatch_template_translate(args)
+    _convert_atparse_to_jinja2.assert_called_once_with(
+        input_file=None, output_file=None, dry_run=False
     )
 
 

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -37,6 +37,9 @@ def test_StdinProxy():
         assert sp.read() == msg
         # But the stdin proxy can be read multiple times:
         assert sp.read() == msg
+        # And the proxy can be iterated over:
+        for line in sp:
+            assert line == msg
 
 
 def test__stdinproxy():


### PR DESCRIPTION
**Synopsis**

Address [UW-472](https://jira.epic.oarcloud.noaa.gov/browse/UW-472):

- Rename `uw config translate` -> `uw template translate`.
- Remove format options, making atparse and Jinja2 the de facto input and output formats, respectively.
- Bugfix: Prevent extra newline when reading from `stdin` via `uw template translate`.
- Update unit tests and RST docs.
- Add a convenience `make docs` target to the _top-level_ `Makefile`.
- Get rid of trailing whitespace in a couple files.

Preview docs are [here](https://uwtools--384.org.readthedocs.build/en/384/).

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
