### PR TITLE
UW-474

### DIFF
--- a/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
+++ b/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
@@ -85,7 +85,7 @@ In the example, the resulting log would appear in the XML file as:
    <log>
      <cyclestr>/some/path/to/&FOO;</cyclestr>
    </log>
- 
+
 The ``attrs:`` block is optional within the ``cyclestr:`` block, and can be used to specify the cycle offset.
 
 Tasks Section
@@ -234,15 +234,15 @@ This translates to Rocoto XML (whitespace added for readability):
 .. code-block:: xml
 
    <metatask name=greetings/>
- 
+
      <var name="greeting">hello hola bonjour</var>
      <var name="person">Jane John Jenn</var>
- 
+
      <task name='#greeting#'>
- 
+
        <command>echo #greeting# #person#<command>
        ...
- 
+
      </task>
    </metatask>
 
@@ -323,7 +323,7 @@ Any number of entities may optionally be specified.
        <!ENTITY FOO "12">
        <!ENTITY BAR "baz">
    ]>
- 
+
 Defining the Workflow Log
 -------------------------
 
@@ -602,10 +602,10 @@ The XML will look like this
 
    <metatask name="member">
      <var name="member">001 002 003</var>
- 
+
      <metatask name="graphics_#member#_field">
        <var name="field">001 002 003</var>
- 
+
        <task name="graphics_mem#member#_#field#">
          <command>"echo $member $field"</command>
          <envar>
@@ -618,6 +618,6 @@ The XML will look like this
          </envar>
          ...
        </task>
- 
+
      </metatask>
    </metatask>

--- a/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
+++ b/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
@@ -555,7 +555,7 @@ Dependency Keys
      </dependency>
 
   * The ``command:`` key accepts a ``cyclestr:`` block.
-  * The ``sh:`` key may be suffixed with ``_<name>`` to provide a unique name for the dependency, e.g. ``sh_foo:`` would translate to XML tag ``<sh name="foo">``.
+  * The ``sh:`` key may be suffixed with an underscore and a name to provide a unique name for the dependency, e.g. ``sh_count_grib:`` would translate to XML tag ``<sh name="count_grib">``.
   * The optional attributes ``runopt`` and ``shell`` are accepted under an ``attrs:`` key. See the :rocoto:`Rocoto documentation<>` for details.
 
 The ``metatask:`` Key

--- a/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
+++ b/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
@@ -474,9 +474,7 @@ The ``streq:`` and ``strneq:`` keys compare the values in their ``left:`` and ``
 Dependency Keys
 ^^^^^^^^^^^^^^^
 
-These keys define dependencies on other tasks, metatasks, data, or wall time.
-
-* The ``taskdep:`` key
+* The ``taskdep:`` key defines a dependency on another task:
 
   .. code-block:: yaml
 
@@ -492,7 +490,7 @@ These keys define dependencies on other tasks, metatasks, data, or wall time.
        <taskdep task="hello" state="succeeded" cycle_offset="-06:00:00"/>
      </dependency>
 
-* The ``metataskdep:`` key
+* The ``metataskdep:`` key defines a dependency on a metatask:
 
   .. code-block:: yaml
 
@@ -509,9 +507,7 @@ These keys define dependencies on other tasks, metatasks, data, or wall time.
        <metataskdep metatask="greetings" state="succeeded" cycle_offset="-06:00:00" threshold="1"/>
      </dependency>
 
-* The ``datadep:`` key
-
-  The ``value:`` key for ``datadep:`` accepts a ``cyclestr:`` block.
+* The ``datadep:`` key defines a dependency on on-disk data:
 
   .. code-block:: yaml
 
@@ -527,9 +523,9 @@ These keys define dependencies on other tasks, metatasks, data, or wall time.
        <datadep age="120" minsize="1024b">/path/to/a/file.txt</datadep>
      </dependency>
 
-* The ``timedep:`` key
+   * The ``value:`` key accepts a ``cyclestr:`` block.
 
-  The ``timedep:`` key will almost certainly want a ``cyclestr:`` block.
+* The ``timedep:`` key defines a dependency on a real-world time:
 
   .. code-block:: text
 
@@ -542,6 +538,25 @@ These keys define dependencies on other tasks, metatasks, data, or wall time.
      <dependency>
        <timedep><cyclestr>@Y@m@d@H@M@S</cyclestr></timedep>
      </dependency>
+
+  * The ``timedep:`` key will almost certainly want a ``cyclestr:`` block.
+
+* The ``sh:`` key defines a dependency on the successful execution of a shell command:
+
+  .. code-block:: yaml
+
+     sh:
+       command: test $(find /some/dir -type f -name "*.grib2" | wc -l) -eq 24
+
+  .. code-block:: xml
+
+     <dependency>
+       <sh>test $(find /some/dir -type f -name "*.grib2" | wc -l) -eq 24</sh>
+     </dependency>
+
+  * The ``command:`` key accepts a ``cyclestr:`` block.
+  * The ``sh:`` key may be suffixed with ``_<name>`` to provide a unique name for the dependency, e.g. ``sh_foo:`` would translate to XML tag ``<sh name="foo">``.
+  * The optional attributes ``runopt`` and ``shell`` are accepted under an ``attrs:`` key. See the :rocoto:`Rocoto documentation<>` for details.
 
 The ``metatask:`` Key
 ---------------------

--- a/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
+++ b/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
@@ -14,21 +14,21 @@ Starting at the top level of the UW YAML config for Rocoto, there are several re
 
 .. code-block:: yaml
 
-  workflow:
-    attrs:
-      realtime: false
-      scheduler: slurm
-    cycledef:
-      - attrs:
-          activation_offset: -06:00
-          group: howdy
-        spec: 202209290000 202209300000 06:00:00
-    entities:
-      ACCOUNT: myaccount
-      FOO: test.log
-    log: /some/path/to/&FOO;
-    tasks:
-      ...
+   workflow:
+     attrs:
+       realtime: false
+       scheduler: slurm
+     cycledef:
+       - attrs:
+           activation_offset: -06:00
+           group: howdy
+         spec: 202209290000 202209300000 06:00:00
+     entities:
+       ACCOUNT: myaccount
+       FOO: test.log
+     log: /some/path/to/&FOO;
+     tasks:
+       ...
 
 UW YAML Keys
 ^^^^^^^^^^^^
@@ -37,32 +37,31 @@ UW YAML Keys
 
 .. code-block:: xml
 
-  <workflow realtime="false" scheduler="slurm">
-  ...
-  </workflow>
+   <workflow realtime="false" scheduler="slurm">
+   ...
+   </workflow>
 
 ``cycledef:``: This section is a list of grouped cycle definitions for a workflow. Any number of ``cycledef:`` keys is supported. Similar to ``attrs:`` for the ``workflow:`` level, this section has an ``attrs:`` key that follows the exact requirements of those in the Rocoto XML language. The ``spec:`` key is required and supports either the "start, stop, step" syntax, or the "crontab-like" method supported by Rocoto. The example above translates to a single ``<cycledef>`` tag:
 
 .. code-block:: xml
 
-  <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
+   <cycledef group="howdy">202209290000 202209300000 06:00:00</cycledef>
 
 ``entities:``: This section defines key/value pairs -- each rendered as ``<!ENTITY key "value">`` -- to translate to named entities (variables) in XML. The example above would yield:
 
 .. code-block:: xml
 
-  <?xml version='1.0' encoding='utf-8'?>
-  <!DOCTYPE workflow [
-    <!ENTITY ACCOUNT "myaccount">
-    <!ENTITY FOO "test.log">
-  ]>
+   <?xml version='1.0' encoding='utf-8'?>
+   <!DOCTYPE workflow [
+     <!ENTITY ACCOUNT "myaccount">
+     <!ENTITY FOO "test.log">
+   ]>
 
 ``log:``: This is a path-like string that defines where to put the Rocoto logs. It corresponds to the ``<log>`` tag. For example:
 
 .. code-block:: xml
 
-  <log>/some/path/to/&FOO;</log>
-
+   <log>/some/path/to/&FOO;</log>
 
 ``tasks:``: This section is explained in the ``Tasks Section``.
 
@@ -73,20 +72,20 @@ The ``<cyclestr>`` tag in Rocoto transforms specific flags to represent componen
 
 .. code-block:: yaml
 
-  entities:
-    FOO: test@Y-@m-@dT@X.log
-  log:
-    cyclestr:
-      value: /some/path/to/&FOO;
+   entities:
+     FOO: test@Y-@m-@dT@X.log
+   log:
+     cyclestr:
+       value: /some/path/to/&FOO;
 
 In the example, the resulting log would appear in the XML file as:
 
 .. code-block:: xml
 
-  <log>
-    <cyclestr>/some/path/to/&FOO;</cyclestr>
-  </log>
-
+   <log>
+     <cyclestr>/some/path/to/&FOO;</cyclestr>
+   </log>
+ 
 The ``attrs:`` block is optional within the ``cyclestr:`` block, and can be used to specify the cycle offset.
 
 Tasks Section
@@ -101,25 +100,25 @@ Let's dissect the following task example:
 
 .. code-block:: yaml
 
-  task_hello:
-    attrs:
-      cycledefs: howdy
-    account: "&ACCOUNT;"
-    command: "echo hello $person"
-    nodes: 1:ppn=1
-    walltime: 00:01:00
-    envars:
-      person: siri
-    dependencies:
+   task_hello:
+     attrs:
+       cycledefs: howdy
+     account: "&ACCOUNT;"
+     command: "echo hello $person"
+     nodes: 1:ppn=1
+     walltime: 00:01:00
+     envars:
+       person: siri
+     dependencies:
 
 Each task is named by its UW YAML key. Blocks under ``tasks:`` prefixed with ``task_`` will be named with what follows the prefix. In the example above the task will be named ``hello`` and will appear in the XML like this:
 
 .. code-block:: xml
 
-  <task name="hello" cycledefs="howdy">
-    <jobname>hello</jobname>
-    ...
-  </task>
+   <task name="hello" cycledefs="howdy">
+     <jobname>hello</jobname>
+     ...
+   </task>
 
 where the ``attrs:`` section may set any of the Rocoto-allowed XML attributes. The ``<jobname>`` tag will, by default, use the same name, but may be overridden with an explicit ``jobname:`` key under the task.
 
@@ -131,10 +130,10 @@ The name of the task can be any string accepted by Rocoto as a task name (includ
 
 .. code-block:: xml
 
-  <envar>
-    <name>person</name>
-    <value>siri</value>
-  </envar>
+   <envar>
+     <name>person</name>
+     <value>siri</value>
+   </envar>
 
 ``dependencies:``: [Optional] Any number of dependencies accepted by Rocoto. This section is described in more detail below.
 
@@ -154,29 +153,29 @@ Each of the dependencies that require attributes (the ``key="value"`` parts insi
 
 .. code-block:: yaml
 
-  task_hello:
-    command: "hello world"
-    ...
-  task_goodbye:
-    command: "goodbye"
-    dependencies:
-       taskdep:
-         attrs:
-           task: hello
+   task_hello:
+     command: "hello world"
+     ...
+   task_goodbye:
+     command: "goodbye"
+     dependencies:
+        taskdep:
+          attrs:
+            task: hello
 
 Here, the ``taskdep:`` dependency says that the ``goodbye`` task cannot run until the ``hello`` task is complete. The resulting Rocoto XML looks like this:
 
 .. code-block:: xml
 
-  <task name="hello">
-    ...
-  </task>
-  <task name="goodbye"/>
-    ...
-    <dependency>
-      <taskdep task="hello"/>
-    </dependency>
-  </task>
+   <task name="hello">
+     ...
+   </task>
+   <task name="goodbye"/>
+     ...
+     <dependency>
+       <taskdep task="hello"/>
+     </dependency>
+   </task>
 
 Repeated Dependencies and Boolean Operators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,30 +184,29 @@ Because UW YAML represents a hash table (a dictionary in Python), each key at th
 
 .. code-block:: yaml
 
-  task_hello:
-    command: "hello world"
-    ...
-    dependencies:
-      and:
-        datadep_foo:
-          value: "foo.txt"
-        datadep_bar:
-          value: "bar.txt"
-
+   task_hello:
+     command: "hello world"
+     ...
+     dependencies:
+       and:
+         datadep_foo:
+           value: "foo.txt"
+         datadep_bar:
+           value: "bar.txt"
 
 This would result in Rocoto XML in this form:
 
 .. code-block:: xml
 
-  <task name="hello"/>
-    ...
-    <dependency>
-      <and>
-        <datadep>"foo.txt"</datadep>
-        <datadep>"bar.txt"</datadep>
-      </and>
-    </dependency>
-  </task>
+   <task name="hello"/>
+     ...
+     <dependency>
+       <and>
+         <datadep>"foo.txt"</datadep>
+         <datadep>"bar.txt"</datadep>
+       </and>
+     </dependency>
+   </task>
 
 The ``datadep_foo:`` and ``datadep_bar:`` UW YAML keys were named arbitrarily after the first ``_``, but could have been even more descriptive such as ``datadep_foo_file:`` or ``datadep_foo_text:``. The important part is that the YAML key prefix matches the Rocoto XML tag name.
 
@@ -223,30 +221,30 @@ A Rocoto ``metatask`` expands into one or more tasks via substitution of values,
 
 .. code-block:: text
 
-  metatask_greetings:
-    var:
-      greeting: hello hola bonjour
-      person: Jane John Jenn
-    task_#greeting#:
-      command: "echo #greeting# #world#"
-      ...
+   metatask_greetings:
+     var:
+       greeting: hello hola bonjour
+       person: Jane John Jenn
+     task_#greeting#:
+       command: "echo #greeting# #world#"
+       ...
 
 This translates to Rocoto XML (whitespace added for readability):
 
 .. code-block:: xml
 
-  <metatask name=greetings/>
-
-    <var name="greeting">hello hola bonjour</var>
-    <var name="person">Jane John Jenn</var>
-
-    <task name='#greeting#'>
-
-      <command>echo #greeting# #person#<command>
-      ...
-
-    </task>
-  </metatask>
+   <metatask name=greetings/>
+ 
+     <var name="greeting">hello hola bonjour</var>
+     <var name="person">Jane John Jenn</var>
+ 
+     <task name='#greeting#'>
+ 
+       <command>echo #greeting# #person#<command>
+       ...
+ 
+     </task>
+   </metatask>
 
 UW YAML Definitions
 -------------------
@@ -258,32 +256,32 @@ The ``cyclestr:`` Key
 
 .. code-block:: yaml
 
-  cyclestr:
-    value: "/some/path/to/workflow_@Y@m@d@H.log" # required
-    attrs:
-      offset: "1:00:00"
+   cyclestr:
+     value: "/some/path/to/workflow_@Y@m@d@H.log" # required
+     attrs:
+       offset: "1:00:00"
 
 .. code-block:: xml
 
-  <cyclestr offset="1:00:00">"/some/path/to/workflow_@Y@m@d@H.log"</cyclestr>
+   <cyclestr offset="1:00:00">"/some/path/to/workflow_@Y@m@d@H.log"</cyclestr>
 
 The ``workflow:`` Key
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
 
-  workflow:
-    attrs:
-      cyclethrottle: 2
-      realtime: true # required
-      scheduler: slurm # required
-      taskthrottle: 20
+   workflow:
+     attrs:
+       cyclethrottle: 2
+       realtime: true # required
+       scheduler: slurm # required
+       taskthrottle: 20
 
 .. code-block:: xml
 
-  <workflow cyclethrottle="2" realtime="true" scheduler="slurm" taskthrottle="20">
-    ...
-  </workflow>
+   <workflow cyclethrottle="2" realtime="true" scheduler="slurm" taskthrottle="20">
+     ...
+   </workflow>
 
 Defining Cycles
 ---------------
@@ -292,19 +290,19 @@ At least one ``cycledef:`` is required.
 
 .. code-block:: yaml
 
-  cycledef:
-    - attrs:
-        group: synop
-        activation_offset: "-1:00:00"
-      spec: 202301011200 202301021200 06:00:00 # Also accepts crontab-like string
-    - attrs:
-        group: hourly
-      spec: 202301011200 202301021200 01:00:00 # Also accepts crontab-like string
+   cycledef:
+     - attrs:
+         group: synop
+         activation_offset: "-1:00:00"
+       spec: 202301011200 202301021200 06:00:00 # Also accepts crontab-like string
+     - attrs:
+         group: hourly
+       spec: 202301011200 202301021200 01:00:00 # Also accepts crontab-like string
 
 .. code-block:: xml
 
-  <cycledef group="synop" activation_offset="-1:00:00">202301011200 202301021200 06:00:00</cycledef>
-  <cycledef group="hourly">202301011200 202301021200 01:00:00</cycledef>
+   <cycledef group="synop" activation_offset="-1:00:00">202301011200 202301021200 06:00:00</cycledef>
+   <cycledef group="hourly">202301011200 202301021200 01:00:00</cycledef>
 
 Defining Entities
 -----------------
@@ -313,19 +311,19 @@ Any number of entities may optionally be specified.
 
 .. code-block:: yaml
 
-  entities:
-    FOO: 12
-    BAR: baz
+   entities:
+     FOO: 12
+     BAR: baz
 
 .. code-block:: xml
 
-  <?xml version="1.0"?>
-  <!DOCTYPE workflow
-  [
-      <!ENTITY FOO "12">
-      <!ENTITY BAR "baz">
-  ]>
-
+   <?xml version="1.0"?>
+   <!DOCTYPE workflow
+   [
+       <!ENTITY FOO "12">
+       <!ENTITY BAR "baz">
+   ]>
+ 
 Defining the Workflow Log
 -------------------------
 
@@ -333,23 +331,23 @@ Defining the Workflow Log
 
 .. code-block:: yaml
 
-  log: /some/path/to/workflow.log
+   log: /some/path/to/workflow.log
 
 .. code-block:: xml
 
-  <log>/some/path/to/workflow.log</log>
+   <log>/some/path/to/workflow.log</log>
 
 A cycle string may be specified here, instead.
 
 .. code-block:: yaml
 
-  log:
-    cyclestr:
-      value: /some/path/to/workflow_@Y@m@d.log
+   log:
+     cyclestr:
+       value: /some/path/to/workflow_@Y@m@d.log
 
 .. code-block:: xml
 
-  <log><cyclestr>/some/path/to/workflow_@Y@m@d.log</cyclestr></log>
+   <log><cyclestr>/some/path/to/workflow_@Y@m@d.log</cyclestr></log>
 
 Defining the Set of Tasks
 -------------------------
@@ -358,9 +356,9 @@ At least one task or metatask must be defined in the ``tasks:`` section.
 
 .. code-block:: yaml
 
-  tasks:
-    task_*:
-    metatask_*:
+   tasks:
+     task_*:
+     metatask_*:
 
 The ``task_*:`` Key
 ^^^^^^^^^^^^^^^^^^^
@@ -369,51 +367,51 @@ Multiple ``task_*:`` YAML entries may exist under the ``tasks:`` and/or ``metata
 
 .. code-block:: yaml
 
-  task_foo:
-    attrs:
-      cycledefs: hourly
-      maxtries: 2
-      throttle: 10
-      final: false
-    command: echo hello world
-    walltime: 00:10:00
-    cores: 1
+   task_foo:
+     attrs:
+       cycledefs: hourly
+       maxtries: 2
+       throttle: 10
+       final: false
+     command: echo hello world
+     walltime: 00:10:00
+     cores: 1
 
 .. code-block:: xml
 
-  <task name="foo" cycledefs="hourly" maxtries="2" throttle="10" final="False">
-    ...
-  </task>
+   <task name="foo" cycledefs="hourly" maxtries="2" throttle="10" final="False">
+     ...
+   </task>
 
 The following keys take strings values. Please see the :rocoto:`Rocoto documentation<>` for specifics on how to set them.
 
 .. code-block:: yaml
 
-  account:
-  exclusive:
-  jobname:
-  join:
-  memory:
-  native:
-  nodes:
-  partition:
-  queue:
-  rewind:
-  shared:
-  stderr:
-  stdout:
+   account:
+   exclusive:
+   jobname:
+   join:
+   memory:
+   native:
+   nodes:
+   partition:
+   queue:
+   rewind:
+   shared:
+   stderr:
+   stdout:
 
 The following UW YAML keys take integer, string, or ``cyclestr:`` values.
 
 .. code-block:: yaml
 
-  command:
-  deadline:
-  jobname:
-  join:
-  native:
-  stderr:
-  stdout:
+   command:
+   deadline:
+   jobname:
+   join:
+   native:
+   stderr:
+   stdout:
 
 The ``dependency:`` Key
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -427,31 +425,31 @@ Boolean operator keys operate on **one or more additional dependency entries** f
 
 .. code-block:: yaml
 
-  and:
-  or:
-  not:
-  nand:
-  nor:
-  xor:
-  some:
+   and:
+   or:
+   not:
+   nand:
+   nor:
+   xor:
+   some:
 
 .. code-block:: yaml
 
-  or:
-    datadep:
-      value: /some/path/to/foo.txt
-    taskdep:
-      attrs:
-        task: foo
+   or:
+     datadep:
+       value: /some/path/to/foo.txt
+     taskdep:
+       attrs:
+         task: foo
 
 .. code-block:: xml
 
-  <dependency>
-    <or>
-      <datadep>/some/path/to/foo.txt</datadep>
-      <taskdep task="foo"/>
-    </or>
-  </dependency>
+   <dependency>
+     <or>
+       <datadep>/some/path/to/foo.txt</datadep>
+       <taskdep task="foo"/>
+     </or>
+   </dependency>
 
 Comparison Depenedencies
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -460,18 +458,18 @@ The ``streq:`` and ``strneq:`` keys compare the values in their ``left:`` and ``
 
 .. code-block:: yaml
 
-  streq:
-    left: &FOO;
-    right: bar
+   streq:
+     left: &FOO;
+     right: bar
 
 .. code-block:: xml
 
-  <dependency>
-    <streq>
-      <left>&FOO;</left>
-      <right>bar</right>
-    </streq>
-  </dependency>
+   <dependency>
+     <streq>
+       <left>&FOO;</left>
+       <right>bar</right>
+     </streq>
+   </dependency>
 
 Dependency Keys
 ^^^^^^^^^^^^^^^
@@ -482,34 +480,34 @@ These keys define dependencies on other tasks, metatasks, data, or wall time.
 
   .. code-block:: yaml
 
-    taskdep:
-      attrs:
-        cycle_offset: "-06:00:00"
-        state: succeeded
-        task: hello # required
+     taskdep:
+       attrs:
+         cycle_offset: "-06:00:00"
+         state: succeeded
+         task: hello # required
 
   .. code-block:: xml
 
-    <dependency>
-      <taskdep task="hello" state="succeeded" cycle_offset="-06:00:00"/>
-    </dependency>
+     <dependency>
+       <taskdep task="hello" state="succeeded" cycle_offset="-06:00:00"/>
+     </dependency>
 
 * The ``metataskdep:`` key
 
   .. code-block:: yaml
 
-    metataskdep:
-      attrs:
-        cycle_offset: "-06:00:00"
-        state: succeeded
-        metatask: greetings # required
-        threshold: 1
+     metataskdep:
+       attrs:
+         cycle_offset: "-06:00:00"
+         state: succeeded
+         metatask: greetings # required
+         threshold: 1
 
   .. code-block:: xml
 
-    <dependency>
-      <metataskdep metatask="greetings" state="succeeded" cycle_offset="-06:00:00" threshold="1"/>
-    </dependency>
+     <dependency>
+       <metataskdep metatask="greetings" state="succeeded" cycle_offset="-06:00:00" threshold="1"/>
+     </dependency>
 
 * The ``datadep:`` key
 
@@ -517,17 +515,17 @@ These keys define dependencies on other tasks, metatasks, data, or wall time.
 
   .. code-block:: yaml
 
-    datadep:
-      attrs:
-        age: 120
-        minsize: 1024b
-      value: /path/to/a/file.txt # required
+     datadep:
+       attrs:
+         age: 120
+         minsize: 1024b
+       value: /path/to/a/file.txt # required
 
   .. code-block:: xml
 
-    <dependency>
-      <datadep age="120" minsize="1024b">/path/to/a/file.txt</datadep>
-    </dependency>
+     <dependency>
+       <datadep age="120" minsize="1024b">/path/to/a/file.txt</datadep>
+     </dependency>
 
 * The ``timedep:`` key
 
@@ -535,21 +533,20 @@ These keys define dependencies on other tasks, metatasks, data, or wall time.
 
   .. code-block:: text
 
-    timedep:
-      cyclestr:
-        value: @Y@m@d@H@M@S
+     timedep:
+       cyclestr:
+         value: @Y@m@d@H@M@S
 
   .. code-block:: xml
 
-    <dependency>
-      <timedep><cyclestr>@Y@m@d@H@M@S</cyclestr></timedep>
-    </dependency>
+     <dependency>
+       <timedep><cyclestr>@Y@m@d@H@M@S</cyclestr></timedep>
+     </dependency>
 
 The ``metatask:`` Key
 ---------------------
 
-One or more metatasks may be included under the ``tasks:`` key, or nested under other
-``metatask_*:`` keys.
+One or more metatasks may be included under the ``tasks:`` key, or nested under other ``metatask_*:`` keys.
 
 Here is an example of specifying a nested metatask.
 
@@ -557,55 +554,55 @@ Here is an example of specifying a nested metatask.
 
 .. code-block:: text
 
-  metatask_member:
-    var:
-      member: 001 002 003
-    metatask_graphics_#member#_field:
-      var:
-        field: temp u v
-      task_graphics_mem#member#_#field#:
-        command: "echo $member $field"
-        envars:
-          member: #member#
-          field: #field#
-        ...
+   metatask_member:
+     var:
+       member: 001 002 003
+     metatask_graphics_#member#_field:
+       var:
+         field: temp u v
+       task_graphics_mem#member#_#field#:
+         command: "echo $member $field"
+         envars:
+           member: #member#
+           field: #field#
+         ...
 
 This will run tasks named:
 
 .. code-block:: text
 
-  graphics_mem001_temp
-  graphics_mem002_temp
-  graphics_mem003_temp
-  graphics_mem001_u
-  graphics_mem002_u
-  graphics_mem003_u
-  graphics_mem001_v
-  graphics_mem002_v
-  graphics_mem003_v
+   graphics_mem001_temp
+   graphics_mem002_temp
+   graphics_mem003_temp
+   graphics_mem001_u
+   graphics_mem002_u
+   graphics_mem003_u
+   graphics_mem001_v
+   graphics_mem002_v
+   graphics_mem003_v
 
 The XML will look like this
 
 .. code-block:: xml
 
-  <metatask name="member">
-    <var name="member">001 002 003</var>
-
-    <metatask name="graphics_#member#_field">
-      <var name="field">001 002 003</var>
-
-      <task name="graphics_mem#member#_#field#">
-        <command>"echo $member $field"</command>
-        <envar>
-          <name>member</name>
-          <value>mem#member#</value>
-        </envar>
-        <envar>
-          <name>field</name>
-          <value>#field#</value>
-        </envar>
-        ...
-      </task>
-
-    </metatask>
-  </metatask>
+   <metatask name="member">
+     <var name="member">001 002 003</var>
+ 
+     <metatask name="graphics_#member#_field">
+       <var name="field">001 002 003</var>
+ 
+       <task name="graphics_mem#member#_#field#">
+         <command>"echo $member $field"</command>
+         <envar>
+           <name>member</name>
+           <value>mem#member#</value>
+         </envar>
+         <envar>
+           <name>field</name>
+           <value>#field#</value>
+         </envar>
+         ...
+       </task>
+ 
+     </metatask>
+   </metatask>

--- a/src/uwtools/resources/rocoto.jsonschema
+++ b/src/uwtools/resources/rocoto.jsonschema
@@ -222,7 +222,7 @@
       "maxProperties": 3,
       "minProperties": 2,
       "patternProperties": {
-        "^metatask(_.+)?$": {
+        "^metatask_.+$": {
           "$ref": "#/$defs/metatask"
         },
         "^task_.+$": {
@@ -522,7 +522,7 @@
           "additionalProperties": false,
           "minProperties": 1,
           "patternProperties": {
-            "^metatask(_.+)?$": {
+            "^metatask_.+$": {
               "$ref": "#/$defs/metatask"
             },
             "^task_.+$": {

--- a/src/uwtools/resources/rocoto.jsonschema
+++ b/src/uwtools/resources/rocoto.jsonschema
@@ -130,6 +130,30 @@
           },
           "type": "object"
         },
+        "^sh(_.*)?$": {
+          "additionalProperties": false,
+          "properties": {
+            "attrs": {
+              "additionalProperties": false,
+              "properties": {
+                "runopt": {
+                  "type": "string"
+                },
+                "shell": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "command": {
+              "$ref": "#/$defs/compoundTimeString"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "type": "object"
+        },
         "^some(_.*)?$": {
           "patternProperties": {
             "^threshold(_.*)?$": {

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -241,7 +241,7 @@ class _RocotoXML:
         :param name_attr: XML name attribute for element.
         """
         e = self._add_compound_time_string(e, config[STR.command], STR.sh)
-        config["attrs"]["name"] = name_attr
+        config["attrs"][STR.name] = name_attr
         self._set_attrs(e, config)
 
     def _add_task_dependency_strequality(self, e: Element, config: dict, tag: str) -> None:

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -241,7 +241,7 @@ class _RocotoXML:
         :param name_attr: XML name attribute for element.
         """
         e = self._add_compound_time_string(e, config[STR.command], STR.sh)
-        config["attrs"][STR.name] = name_attr
+        config[STR.attrs][STR.name] = name_attr
         self._set_attrs(e, config)
 
     def _add_task_dependency_strequality(self, e: Element, config: dict, tag: str) -> None:

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -241,8 +241,7 @@ class _RocotoXML:
         :param name_attr: XML name attribute for element.
         """
         e = self._add_compound_time_string(e, config[STR.command], STR.sh)
-        if name_attr:
-            config["attrs"]["name"] = name_attr
+        config["attrs"]["name"] = name_attr
         self._set_attrs(e, config)
 
     def _add_task_dependency_strequality(self, e: Element, config: dict, tag: str) -> None:

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -124,36 +124,36 @@ class _RocotoXML:
             e.text = str(config)
         return e
 
-    def _add_metatask(self, e: Element, config: dict, taskname: str) -> None:
+    def _add_metatask(self, e: Element, config: dict, name_attr: str) -> None:
         """
         Add a <metatask> element to the <workflow>.
 
         :param e: The parent element to add the new element to.
         :param config: Configuration data for this element.
-        :param taskname: The name of the metatask being defined.
+        :param name_attr: XML name attribute for element.
         """
-        e = SubElement(e, STR.metatask, name=taskname)
+        e = SubElement(e, STR.metatask, name=name_attr)
         for key, val in config.items():
-            tag, taskname = self._tag_name(key)
+            tag, name = self._tag_name(key)
             if tag == STR.metatask:
-                self._add_metatask(e, val, taskname)
+                self._add_metatask(e, val, name)
             elif tag == STR.task:
-                self._add_task(e, val, taskname)
+                self._add_task(e, val, name)
             elif tag == STR.var:
                 for name, value in val.items():
                     SubElement(e, STR.var, name=name).text = value
 
-    def _add_task(self, e: Element, config: dict, taskname: str) -> None:
+    def _add_task(self, e: Element, config: dict, name_attr: str) -> None:
         """
         Add a <task> element to the <workflow>.
 
         :param e: The parent element to add the new element to.
         :param config: Configuration data for this element.
-        :param taskname: The name of the task being defined.
+        :param name_attr: XML name attribute for element.
         """
-        e = SubElement(e, STR.task, name=taskname)
+        e = SubElement(e, STR.task, name=name_attr)
         self._set_attrs(e, config)
-        self._set_and_render_jobname(config, taskname)
+        self._set_and_render_jobname(config, name_attr)
         for tag in (
             STR.account,
             STR.cores,
@@ -209,10 +209,10 @@ class _RocotoXML:
             e = SubElement(e, tag)
             for subtag, subconfig in config.items():
                 self._add_task_dependency_child(e, subconfig, subtag)
-        elif tag == STR.sh:
-            self._add_task_dependency_sh(e, config, name)
         elif tag in (STR.streq, STR.strneq):
             self._add_task_dependency_strequality(e, config, tag)
+        elif tag == STR.sh:
+            self._add_task_dependency_sh(e, config, name)
         elif tag == STR.datadep:
             self._add_task_dependency_datadep(e, config)
         elif tag == STR.taskdep:
@@ -232,14 +232,17 @@ class _RocotoXML:
         e = self._add_compound_time_string(e, config[STR.value], STR.datadep)
         self._set_attrs(e, config)
 
-    def _add_task_dependency_sh(self, e: Element, config: dict, name: Optional[str] = None) -> None:
+    def _add_task_dependency_sh(
+        self, e: Element, config: dict, name_attr: Optional[str] = None
+    ) -> None:
         """
         :param e: The parent element to add the new element to.
         :param config: Configuration data for the tag.
+        :param name_attr: XML name attribute for element.
         """
         e = self._add_compound_time_string(e, config[STR.command], STR.sh)
-        if name:
-            config["attrs"]["name"] = name
+        if name_attr:
+            config["attrs"]["name"] = name_attr
         self._set_attrs(e, config)
 
     def _add_task_dependency_strequality(self, e: Element, config: dict, tag: str) -> None:

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -204,13 +204,13 @@ class _RocotoXML:
         :param config: Configuration data for this element.
         :param tag: Name of new element to add.
         """
-        tag, _ = self._tag_name(tag)
+        tag, name = self._tag_name(tag)
         if tag in (STR.and_, STR.nand, STR.nor, STR.not_, STR.or_, STR.xor):
             e = SubElement(e, tag)
             for subtag, subconfig in config.items():
                 self._add_task_dependency_child(e, subconfig, subtag)
         elif tag == STR.sh:
-            self._add_task_dependency_sh(e, config)
+            self._add_task_dependency_sh(e, config, name)
         elif tag in (STR.streq, STR.strneq):
             self._add_task_dependency_strequality(e, config, tag)
         elif tag == STR.datadep:
@@ -232,12 +232,14 @@ class _RocotoXML:
         e = self._add_compound_time_string(e, config[STR.value], STR.datadep)
         self._set_attrs(e, config)
 
-    def _add_task_dependency_sh(self, e: Element, config: dict) -> None:
+    def _add_task_dependency_sh(self, e: Element, config: dict, name: Optional[str] = None) -> None:
         """
         :param e: The parent element to add the new element to.
         :param config: Configuration data for the tag.
         """
         e = self._add_compound_time_string(e, config[STR.command], STR.sh)
+        if name:
+            config["attrs"]["name"] = name
         self._set_attrs(e, config)
 
     def _add_task_dependency_strequality(self, e: Element, config: dict, tag: str) -> None:
@@ -381,9 +383,9 @@ class _RocotoXML:
         """
         Return the tag and metadata extracted from a metadata-bearing key.
 
-        :param key: A string of the form "tag_metadata" (or simply STR.tag).
+        :param key: A string of the form "<tag>_<metadata>" (or simply STR.<tag>).
         """
-        # For example, key "task_foo"bar" will be split into tag "task" and name "foo_bar".
+        # For example, key "task_foo_bar" will be split into tag "task" and name "foo_bar".
         parts = key.split("_")
         tag = parts[0]
         name = "_".join(parts[1:]) if parts[1:] else ""

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -209,6 +209,8 @@ class _RocotoXML:
             e = SubElement(e, tag)
             for subtag, subconfig in config.items():
                 self._add_task_dependency_child(e, subconfig, subtag)
+        elif tag == STR.sh:
+            self._add_task_dependency_sh(e, config)
         elif tag in (STR.streq, STR.strneq):
             self._add_task_dependency_strequality(e, config, tag)
         elif tag == STR.datadep:
@@ -228,6 +230,14 @@ class _RocotoXML:
         :param config: Configuration data for this element.
         """
         e = self._add_compound_time_string(e, config[STR.value], STR.datadep)
+        self._set_attrs(e, config)
+
+    def _add_task_dependency_sh(self, e: Element, config: dict) -> None:
+        """
+        :param e: The parent element to add the new element to.
+        :param config: Configuration data for the tag.
+        """
+        e = self._add_compound_time_string(e, config[STR.command], STR.sh)
         self._set_attrs(e, config)
 
     def _add_task_dependency_strequality(self, e: Element, config: dict, tag: str) -> None:
@@ -417,6 +427,7 @@ class STR:
     partition: str = "partition"
     queue: str = "queue"
     rewind: str = "rewind"
+    sh: str = "sh"
     shared: str = "shared"
     stderr: str = "stderr"
     stdout: str = "stdout"

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -140,8 +140,8 @@ class _RocotoXML:
             elif tag == STR.task:
                 self._add_task(e, val, name)
             elif tag == STR.var:
-                for name, value in val.items():
-                    SubElement(e, STR.var, name=name).text = value
+                for varname, value in val.items():
+                    SubElement(e, STR.var, name=varname).text = value
 
     def _add_task(self, e: Element, config: dict, name_attr: str) -> None:
         """

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -252,12 +252,13 @@ class Test__RocotoXML:
         assert e.text == str(value)
 
     def test__add_task_dependency_sh(self, instance, root):
-        config = {"sh": {"attrs": {"runopt": "-c", "shell": "/bin/bash"}, "command": "ls"}}
+        config = {"sh_foo": {"attrs": {"runopt": "-c", "shell": "/bin/bash"}, "command": "ls"}}
         instance._add_task_dependency(e=root, config=config)
         dependency = root[0]
         assert dependency.tag == "dependency"
         sh = dependency[0]
         assert sh.tag == "sh"
+        assert sh.get("name") == "foo"
         assert sh.get("runopt") == "-c"
         assert sh.get("shell") == "/bin/bash"
         assert sh.text == "ls"
@@ -439,6 +440,7 @@ class Test__RocotoXML:
 
 # PM MOVE THIS
 
+
 def test_schema_dependency_sh():
     errors = validator("$defs", "dependency")
     # Basic spec:
@@ -448,13 +450,19 @@ def test_schema_dependency_sh():
     # A _<name> suffix is allowed:
     assert not errors({"sh_foo": {"command": "foo"}})
     # Optional attributes "runopt" and "shell" are supported:
-    assert not errors({"sh_foo": {"attrs": {"runopt": "-c", "shell": "/bin/bash"}, "command": "foo"}})
+    assert not errors(
+        {"sh_foo": {"attrs": {"runopt": "-c", "shell": "/bin/bash"}, "command": "foo"}}
+    )
     # Other attributes are not allowed:
-    assert "Additional properties are not allowed ('color' was unexpected)" in errors({"sh_foo": {"attrs": {"color": "blue"}, "command": "foo"}})
+    assert "Additional properties are not allowed ('color' was unexpected)" in errors(
+        {"sh_foo": {"attrs": {"color": "blue"}, "command": "foo"}}
+    )
     # The command is a compoundTimeString:
     assert not errors({"sh": {"command": {"cyclestr": {"value": "foo-@Y@m@d@H"}}}})
-    
+
+
 # PM MOVE THIS
+
 
 def test_schema_compoundTimeString():
     errors = validator("$defs", "compoundTimeString")

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -437,6 +437,25 @@ class Test__RocotoXML:
 # Schema tests
 
 
+# PM MOVE THIS
+
+def test_schema_dependency_sh():
+    errors = validator("$defs", "dependency")
+    # Basic spec:
+    assert not errors({"sh": {"command": "foo"}})
+    # The "command" property is mandatory:
+    assert "command' is a required property" in errors({"sh": {}})
+    # A _<name> suffix is allowed:
+    assert not errors({"sh_foo": {"command": "foo"}})
+    # Optional attributes "runopt" and "shell" are supported:
+    assert not errors({"sh_foo": {"attrs": {"runopt": "-c", "shell": "/bin/bash"}, "command": "foo"}})
+    # Other attributes are not allowed:
+    assert "Additional properties are not allowed ('color' was unexpected)" in errors({"sh_foo": {"attrs": {"color": "blue"}, "command": "foo"}})
+    # The command is a compoundTimeString:
+    assert not errors({"sh": {"command": {"cyclestr": {"value": "foo-@Y@m@d@H"}}}})
+    
+# PM MOVE THIS
+
 def test_schema_compoundTimeString():
     errors = validator("$defs", "compoundTimeString")
     # Just a string is ok:

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -438,7 +438,22 @@ class Test__RocotoXML:
 # Schema tests
 
 
-# PM MOVE THIS
+def test_schema_compoundTimeString():
+    errors = validator("$defs", "compoundTimeString")
+    # Just a string is ok:
+    assert not errors("foo")
+    # An int value is ok:
+    assert not errors(20240103120000)
+    # A simple cycle string is ok:
+    assert not errors({"cyclestr": {"value": "@Y@m@d@H"}})
+    # The "value" entry is required:
+    assert "is not valid" in errors({"cyclestr": {}})
+    # Unknown properties are not allowed:
+    assert "is not valid" in errors({"cyclestr": {"foo": "bar"}})
+    # An "offset" attribute may be provided:
+    assert not errors({"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "06:00:00"}}})
+    # The "offset" value must be a valid time string:
+    assert "is not valid" in errors({"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "x"}}})
 
 
 def test_schema_dependency_sh():
@@ -459,27 +474,6 @@ def test_schema_dependency_sh():
     )
     # The command is a compoundTimeString:
     assert not errors({"sh": {"command": {"cyclestr": {"value": "foo-@Y@m@d@H"}}}})
-
-
-# PM MOVE THIS
-
-
-def test_schema_compoundTimeString():
-    errors = validator("$defs", "compoundTimeString")
-    # Just a string is ok:
-    assert not errors("foo")
-    # An int value is ok:
-    assert not errors(20240103120000)
-    # A simple cycle string is ok:
-    assert not errors({"cyclestr": {"value": "@Y@m@d@H"}})
-    # The "value" entry is required:
-    assert "is not valid" in errors({"cyclestr": {}})
-    # Unknown properties are not allowed:
-    assert "is not valid" in errors({"cyclestr": {"foo": "bar"}})
-    # An "offset" attribute may be provided:
-    assert not errors({"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "06:00:00"}}})
-    # The "offset" value must be a valid time string:
-    assert "is not valid" in errors({"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "x"}}})
 
 
 def test_schema_workflow_cycledef():

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -251,6 +251,17 @@ class Test__RocotoXML:
         assert e.tag == "timedep"
         assert e.text == str(value)
 
+    def test__add_task_dependency_sh(self, instance, root):
+        config = {"sh": {"attrs": {"runopt": "-c", "shell": "/bin/bash"}, "command": "ls"}}
+        instance._add_task_dependency(e=root, config=config)
+        dependency = root[0]
+        assert dependency.tag == "dependency"
+        sh = dependency[0]
+        assert sh.tag == "sh"
+        assert sh.get("runopt") == "-c"
+        assert sh.get("shell") == "/bin/bash"
+        assert sh.text == "ls"
+
     def test__add_task_dependency_streq(self, instance, root):
         config = {"streq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}
         instance._add_task_dependency(e=root, config=config)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -150,7 +150,7 @@ class Test__RocotoXML:
         taskname = "test-metatask"
         orig = instance._add_metatask
         with patch.multiple(instance, _add_metatask=D, _add_task=D) as mocks:
-            orig(e=root, config=config, taskname=taskname)
+            orig(e=root, config=config, name_attr=taskname)
         metatask = root[0]
         assert metatask.tag == "metatask"
         assert metatask.get("name") == taskname
@@ -166,7 +166,7 @@ class Test__RocotoXML:
         }
         taskname = "test-task"
         with patch.multiple(instance, _add_task_dependency=D, _add_task_envar=D) as mocks:
-            instance._add_task(e=root, config=config, taskname=taskname)
+            instance._add_task(e=root, config=config, name_attr=taskname)
         task = root[0]
         assert task.tag == "task"
         assert task.get("name") == taskname
@@ -179,7 +179,7 @@ class Test__RocotoXML:
     def test__add_task_cores_int_or_str(self, cores, instance, root):
         # Ensure that either int or str "cores" values are accepted.
         config = {"command": "c", "cores": cores, "walltime": "00:00:01"}
-        instance._add_task(e=root, config=config, taskname="foo")
+        instance._add_task(e=root, config=config, name_attr="foo")
 
     def test__add_task_dependency_and(self, instance, root):
         config = {"and": {"or_get_obs": {"taskdep": {"attrs": {"task": "foo"}}}}}


### PR DESCRIPTION
**Synopsis**

Address [UW-474](https://jira.epic.oarcloud.noaa.gov/browse/UW-474), adding support for the Rocoto `<sh>` dependency.

Doc updates can be previewed [here](https://uwtools--385.org.readthedocs.build/en/385/).

**Type**

- [x] Documentation
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
