### PR TITLE
UW-476

### DIFF
--- a/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
+++ b/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
@@ -490,7 +490,7 @@ Dependency Keys
        <taskdep task="hello" state="succeeded" cycle_offset="-06:00:00"/>
      </dependency>
 
-* The ``taskvalid`` key defines a dependency on another task being defined in the same cycle. In this example, the task defined with the ``validtask:`` dependency would be runnable only if a task ``bar`` was defined in the same cycle:
+* The ``taskvalid`` key defines a dependency on another task being defined in the same cycle. In this example, the task defined with the ``taskvalid:`` dependency would be runnable only if a task ``bar`` was defined in the same cycle:
 
   .. code-block:: yaml
 

--- a/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
+++ b/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
@@ -474,7 +474,7 @@ The ``streq:`` and ``strneq:`` keys compare the values in their ``left:`` and ``
 Dependency Keys
 ^^^^^^^^^^^^^^^
 
-* The ``taskdep:`` key defines a dependency on another task:
+* The ``taskdep:`` key defines a dependency on another task's successful completion:
 
   .. code-block:: yaml
 
@@ -488,6 +488,20 @@ Dependency Keys
 
      <dependency>
        <taskdep task="hello" state="succeeded" cycle_offset="-06:00:00"/>
+     </dependency>
+
+* The ``taskvalid`` key defines a dependency on another task being defined in the same cycle. In this example, the task defined with the ``validtask:`` dependency would be runnable only if a task ``bar`` was defined in the same cycle:
+
+  .. code-block:: yaml
+
+     validtask:
+       attrs:
+         task: bar
+
+  .. code-block:: xml
+
+     <dependency>
+       <taskvalid task="bar"/>
      </dependency>
 
 * The ``metataskdep:`` key defines a dependency on a metatask:

--- a/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
+++ b/docs/sections/user_guide/uw_yaml/rocoto_yaml.rst
@@ -490,7 +490,7 @@ Dependency Keys
        <taskdep task="hello" state="succeeded" cycle_offset="-06:00:00"/>
      </dependency>
 
-* The ``taskvalid`` key defines a dependency on another task being defined in the same cycle. In this example, the task defined with the ``taskvalid:`` dependency would be runnable only if a task ``bar`` was defined in the same cycle:
+* The ``taskvalid`` key defines a dependency on another task being defined in the same cycle. In this example, the task defined with the ``taskvalid:`` dependency would be runnable only if a task ``bar`` were defined in the same cycle:
 
   .. code-block:: yaml
 

--- a/src/uwtools/resources/rocoto.jsonschema
+++ b/src/uwtools/resources/rocoto.jsonschema
@@ -205,9 +205,22 @@
         "^taskvalid(_.*)?$": {
           "additionalProperties": false,
           "properties": {
-            "task": {
-              "type": "string"
-            }
+            "attrs": {
+              "additionalProperties": false,
+              "properties": {
+                "task": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task"
+              ],
+              "type": "object"
+            },
+            "required": [
+              "attrs"
+            ],
+            "type": "object"
           },
           "type": "object"
         },

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -217,6 +217,8 @@ class _RocotoXML:
             self._add_task_dependency_datadep(e, config)
         elif tag == STR.taskdep:
             self._add_task_dependency_taskdep(e, config)
+        elif tag == STR.taskvalid:
+            self._add_task_dependency_taskvalid(e, config)
         elif tag == STR.timedep:
             self._add_task_dependency_timedep(e, config)
         else:
@@ -260,6 +262,15 @@ class _RocotoXML:
         :param config: Configuration data for this element.
         """
         self._set_attrs(SubElement(e, STR.taskdep), config)
+
+    def _add_task_dependency_taskvalid(self, e: Element, config: dict) -> None:
+        """
+        Add a <taskvalid> element to the <dependency>.
+
+        :param e: The parent element to add the new element to.
+        :param config: Configuration data for this element.
+        """
+        self._set_attrs(SubElement(e, STR.taskvalid), config)
 
     def _add_task_dependency_timedep(self, e: Element, config: dict) -> None:
         """
@@ -441,6 +452,7 @@ class STR:
     task: str = "task"
     taskdep: str = "taskdep"
     tasks: str = "tasks"
+    taskvalid: str = "taskvalid"
     timedep: str = "timedep"
     value: str = "value"
     var: str = "var"

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -296,6 +296,15 @@ class Test__RocotoXML:
         assert child.tag == "taskdep"
         assert child.get("task") == "foo"
 
+    def test__add_task_dependency_taskvalid(self, instance, root):
+        config = {"taskvalid": {"attrs": {"task": "foo"}}}
+        instance._add_task_dependency(e=root, config=config)
+        dependency = root[0]
+        assert dependency.tag == "dependency"
+        taskvalid = dependency[0]
+        assert taskvalid.tag == "taskvalid"
+        assert taskvalid.get("task") == "foo"
+
     @pytest.mark.parametrize(
         "value",
         [


### PR DESCRIPTION
**Synopsis**

Address [UW-476](https://jira.epic.oarcloud.noaa.gov/browse/UW-476), updating the JSON Schema to correctly support `taskdep:`, and adding library implementation, test support, and documentation for this dependency type.

Preview docs are [here](https://uwtools--387.org.readthedocs.build/en/387/sections/user_guide/uw_yaml/rocoto_yaml.html).

**Type**

- [x] Documentation
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
