### PR TITLE
tagged-scalars

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -163,15 +163,14 @@ class Config(ABC, UserDict):
         """
         Render as much Jinja2 syntax as possible.
         """
-        log.debug("Dereferencing, initial value: %s", self.data)
         while True:
+            log.debug("Dereferencing, current value: %s", str(self))
             new = dereference(val=self.data, context={**os.environ, **self.data})
+            assert isinstance(new, dict)
             if new == self.data:
                 break
-            log.debug("Dereferencing, current value: %s", self.data)
-            assert isinstance(new, dict)
             self.data = new
-        log.debug("Dereferencing, final value: %s", self.data)
+        log.debug("Dereferencing, final value: %s", str(self))
 
     @abstractmethod
     def dump(self, path: OptionalPath) -> None:

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -163,14 +163,20 @@ class Config(ABC, UserDict):
         """
         Render as much Jinja2 syntax as possible.
         """
+
+        def logstate(state: str) -> None:
+            log.debug("Dereferencing, %s value:", state)
+            for line in str(self).split("\n"):
+                log.debug("  %s", line)
+
         while True:
-            log.debug("Dereferencing, current value: %s", str(self))
+            logstate("current")
             new = dereference(val=self.data, context={**os.environ, **self.data})
             assert isinstance(new, dict)
             if new == self.data:
                 break
             self.data = new
-        log.debug("Dereferencing, final value: %s", str(self))
+        logstate("final")
 
     @abstractmethod
     def dump(self, path: OptionalPath) -> None:

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -190,12 +190,12 @@ class Config(ABC, UserDict):
 
     @staticmethod
     @abstractmethod
-    def dump_dict(path: OptionalPath, cfg: dict) -> None:
+    def dump_dict(cfg: dict, path: OptionalPath = None) -> None:
         """
         Dumps a provided config dictionary to stdout or a file.
 
-        :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
+        :param path: Path to dump config to.
         """
 
     @staticmethod

--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -12,16 +12,16 @@ class FieldTableConfig(YAMLConfig):
 
     # Public methods
 
-    def dump(self, path: OptionalPath) -> None:
+    def dump(self, path: OptionalPath = None) -> None:
         """
         Dumps the config in Field Table format.
 
         :param path: Path to dump config to.
         """
-        self.dump_dict(path, self.data)
+        self.dump_dict(self.data, path)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict) -> None:
+    def dump_dict(cfg: dict, path: OptionalPath = None) -> None:
         """
         Dumps a provided config dictionary in Field Table format.
 
@@ -40,9 +40,8 @@ class FieldTableConfig(YAMLConfig):
             name: fixed
             surface_value: 1.e30
 
-        :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
-        :param opts: Other options required by a subclass.
+        :param path: Path to dump config to.
         """
         lines = []
         for field, settings in cfg.items():

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -40,7 +40,7 @@ class INIConfig(Config):
 
     # Public methods
 
-    def dump(self, path: OptionalPath) -> None:
+    def dump(self, path: OptionalPath = None) -> None:
         """
         Dumps the config in INI format.
 
@@ -48,22 +48,23 @@ class INIConfig(Config):
         """
         config_check_depths_dump(config_obj=self, target_format=FORMAT.ini)
 
-        self.dump_dict(path, self.data)
+        self.dump_dict(self.data, path)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict) -> None:
+    def dump_dict(cfg: dict, path: OptionalPath = None) -> None:
         """
         Dumps a provided config dictionary in INI format.
 
-        :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
+        :param path: Path to dump config to.
         """
+
         # Configparser adds a newline after each section, presumably to create nice-looking output
         # when an INI contains multiple sections. Unfortunately, it also adds a newline after the
         # _final_ section, resulting in an anomalous trailing newline. To avoid this, write first to
         # memory, then strip the trailing newline.
-        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.ini)
 
+        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.ini)
         parser = configparser.ConfigParser()
         s = StringIO()
         parser.read_dict(cfg)

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -54,15 +54,15 @@ class NMLConfig(Config):
         """
         config_check_depths_dump(config_obj=self, target_format=FORMAT.nml)
 
-        self.dump_dict(path, self.data)
+        self.dump_dict(self.data, path)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict) -> None:
+    def dump_dict(cfg: dict, path: OptionalPath = None) -> None:
         """
         Dumps a provided config dictionary in Fortran namelist format.
 
-        :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
+        :param path: Path to dump config to.
         """
 
         # f90nml honors namelist and variable order if it receives an OrderedDict as input, so

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -54,15 +54,15 @@ class SHConfig(Config):
         :param path: Path to dump config to.
         """
         config_check_depths_dump(config_obj=self, target_format=FORMAT.sh)
-        self.dump_dict(path, self.data)
+        self.dump_dict(self.data, path)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict) -> None:
+    def dump_dict(cfg: dict, path: OptionalPath = None) -> None:
         """
         Dumps a provided config dictionary in bash format.
 
-        :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
+        :param path: Path to dump config to.
         """
 
         # Write first to a StringIO object to avoid creating a partial file in case of problems

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -44,7 +44,7 @@ class YAMLConfig(Config):
         The string representation of a YAMLConfig object.
         """
         yaml.add_representer(TaggedScalar, TaggedScalar.represent)
-        return yaml.dump(self.data).strip()
+        return yaml.dump(self.data, default_flow_style=True).strip()
 
     # Private methods
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -43,6 +43,7 @@ class YAMLConfig(Config):
         """
         The string representation of a YAMLConfig object.
         """
+        yaml.add_representer(TaggedScalar, TaggedScalar.represent)
         return yaml.dump(self.data)
 
     # Private methods
@@ -95,22 +96,21 @@ class YAMLConfig(Config):
 
     # Public methods
 
-    def dump(self, path: OptionalPath) -> None:
+    def dump(self, path: OptionalPath = None) -> None:
         """
         Dumps the config in YAML format.
 
         :param path: Path to dump config to.
         """
-        self.dump_dict(path, self.data)
+        self.dump_dict(self.data, path)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict) -> None:
+    def dump_dict(cfg: dict, path: OptionalPath = None) -> None:
         """
         Dumps a provided config dictionary in YAML format.
 
-        :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
-        :param opts: Other options required by a subclass.
+        :param path: Path to dump config to.
         """
         yaml.add_representer(TaggedScalar, TaggedScalar.represent)
         with writable(path) as f:

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace as ns
-from typing import Dict, Optional, Union
+from typing import Optional
 
 import yaml
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import INCLUDE_TAG, log_and_error
+from uwtools.config.support import INCLUDE_TAG, TaggedScalar, log_and_error
 from uwtools.utils.file import FORMAT, OptionalPath, readable, writable
 
 _MSGS = ns(
@@ -128,22 +128,3 @@ class YAMLConfig(Config):
         Returns the config's format name.
         """
         return FORMAT.yaml
-
-
-class TaggedScalar:
-    """
-    PM WRITEME.
-    """
-
-    TAGS = ("!bool", "!float", "!int", "!str")
-
-    def __init__(self, _: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> None:
-        self.tag: str = node.tag
-        self.value: str = node.value
-
-    def reify(self) -> Union[bool, float, int, str]:
-        """
-        PM WRITEME.
-        """
-        converters: Dict[str, type] = dict(zip(self.TAGS, [bool, float, int, str]))
-        return converters[self.tag](self.value)

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -44,7 +44,7 @@ class YAMLConfig(Config):
         The string representation of a YAMLConfig object.
         """
         yaml.add_representer(TaggedScalar, TaggedScalar.represent)
-        return yaml.dump(self.data)
+        return yaml.dump(self.data).strip()
 
     # Private methods
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -4,7 +4,7 @@ from typing import Optional
 import yaml
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import INCLUDE_TAG, TaggedScalar, log_and_error
+from uwtools.config.support import INCLUDE_TAG, TaggedString, log_and_error
 from uwtools.utils.file import FORMAT, OptionalPath, readable, writable
 
 _MSGS = ns(
@@ -43,7 +43,7 @@ class YAMLConfig(Config):
         """
         The string representation of a YAMLConfig object.
         """
-        yaml.add_representer(TaggedScalar, TaggedScalar.represent)
+        yaml.add_representer(TaggedString, TaggedString.represent)
         return yaml.dump(self.data, default_flow_style=True).strip()
 
     # Private methods
@@ -90,8 +90,8 @@ class YAMLConfig(Config):
         """
         loader = yaml.SafeLoader
         loader.add_constructor(INCLUDE_TAG, self._yaml_include)
-        for tag in TaggedScalar.TAGS:
-            loader.add_constructor(tag, TaggedScalar)
+        for tag in TaggedString.TAGS:
+            loader.add_constructor(tag, TaggedString)
         return loader
 
     # Public methods
@@ -112,7 +112,7 @@ class YAMLConfig(Config):
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to.
         """
-        yaml.add_representer(TaggedScalar, TaggedScalar.represent)
+        yaml.add_representer(TaggedString, TaggedString.represent)
         with writable(path) as f:
             yaml.dump(cfg, f, sort_keys=False)
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -112,6 +112,7 @@ class YAMLConfig(Config):
         :param cfg: The in-memory config object to dump.
         :param opts: Other options required by a subclass.
         """
+        yaml.add_representer(TaggedScalar, TaggedScalar.represent)
         with writable(path) as f:
             yaml.dump(cfg, f, sort_keys=False)
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace as ns
-from typing import Optional
+from typing import Dict, Optional, Union
 
 import yaml
 
@@ -89,6 +89,8 @@ class YAMLConfig(Config):
         """
         loader = yaml.SafeLoader
         loader.add_constructor(INCLUDE_TAG, self._yaml_include)
+        for tag in TaggedScalar.TAGS:
+            loader.add_constructor(tag, TaggedScalar)
         return loader
 
     # Public methods
@@ -126,3 +128,22 @@ class YAMLConfig(Config):
         Returns the config's format name.
         """
         return FORMAT.yaml
+
+
+class TaggedScalar:
+    """
+    PM WRITEME.
+    """
+
+    TAGS = ("!bool", "!float", "!int", "!str")
+
+    def __init__(self, _: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> None:
+        self.tag: str = node.tag
+        self.value: str = node.value
+
+    def reify(self) -> Union[bool, float, int, str]:
+        """
+        PM WRITEME.
+        """
+        converters: Dict[str, type] = dict(zip(self.TAGS, [bool, float, int, str]))
+        return converters[self.tag](self.value)

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -44,7 +44,7 @@ class YAMLConfig(Config):
         The string representation of a YAMLConfig object.
         """
         yaml.add_representer(TaggedString, TaggedString.represent)
-        return yaml.dump(self.data, default_flow_style=True).strip()
+        return yaml.dump(self.data, default_flow_style=False).strip()
 
     # Private methods
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -110,23 +110,21 @@ def dereference(val: _ConfigVal, context: dict, local: Optional[dict] = None) ->
     """
     Render Jinja2 syntax, wherever possible.
 
+    Build a replacement value with Jinja2 syntax rendered. Depend on recursion for dict and list
+    values; render strings; convert values tagged with explicit types; and return objects of other
+    types unmodified. Rendering may fail for valid reasons -- notably a replacement value not being
+    available in the given context object. In such cases, return the original value: Any unrendered
+    Jinja2 syntax it contains may may be rendered by later processing with better context.
+
+    When rendering dict values, replacement values will be taken from, in priority order
+      1. The full context dict
+      2. Local sibling values in the dict
+
     :param val: A value possibly containing Jinja2 syntax.
     :param context: Values to use when rendering Jinja2 syntax.
     :param local: Local sibling values to use if a match is not found in context.
     :return: The input value, with Jinja2 syntax rendered.
     """
-
-    # Build a replacement value with Jinja2 syntax rendered. Depend on recursion for dict and list
-    # values; render strings; and return objects of any other type unmodified. Rendering may fail
-    # for valid reasons -- notably a replacement value not being available in the given context
-    # object. In such cases, return the original value: Any unrendered Jinja2 syntax it contains may
-    # may be rendered by later processing with better context.
-
-    # Note that, for rendering performed on dict values, replacement values will be taken from, in
-    # priority order, 1. The full context dict, 2. Local sibling values in the dict.
-
-    # PM FIX UP THIS DOCSTRING!
-
     rendered: _ConfigVal = val  # fall-back value
     if isinstance(val, dict):
         return {k: dereference(v, context, local=val) for k, v in val.items()}

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -215,7 +215,7 @@ def _deref_convert(val: TaggedString) -> _ConfigVal:
     _deref_debug("Converting", val.value)
     try:
         converted = val.convert()
-        _deref_debug("Converted", val.value)
+        _deref_debug("Converted", converted)
     except Exception as e:  # pylint: disable=broad-exception-caught
         _deref_debug("Conversion failed", str(e))
     return converted

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -16,7 +16,7 @@ from jinja2 import (
 )
 from jinja2.exceptions import UndefinedError
 
-from uwtools.config.support import format_to_config
+from uwtools.config.support import TaggedScalar, format_to_config
 from uwtools.logging import MSGWIDTH, log
 from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils.file import get_file_format, readable, writable
@@ -137,16 +137,21 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
         return val
 
     rendered: _YAMLVal
-    log.debug("Rendering: %s", val)
     if isinstance(val, dict):
         return {k: dereference(v, context, local=val) for k, v in val.items()}
     if isinstance(val, list):
         return [dereference(v, context) for v in val]
     if isinstance(val, str):
+        log.debug("Rendering: %s", val)
         rendered = _render(val)
+        log.debug("Rendered: %s", rendered)
+    elif isinstance(val, TaggedScalar):
+        log.debug("Rendering: %s", val.value)
+        val.value = _render(val.value)
+        rendered = val
+        log.debug("Rendered: %s", val.value)
     else:
         rendered = val
-    log.debug("Rendered: %s", rendered)
     return rendered
 
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -5,7 +5,6 @@ Support for rendering Jinja2 templates.
 import os
 from typing import Dict, List, Optional, Set, Union
 
-import yaml
 from jinja2 import (
     BaseLoader,
     Environment,
@@ -133,12 +132,11 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
         return [dereference(v, context) for v in val]
     if isinstance(val, str):
         try:
-            rendered = (
+            return (
                 _register_filters(Environment(undefined=StrictUndefined))
                 .from_string(val)
                 .render({**(local or {}), **context})
             )
-            return _reify_scalar_str(rendered)
         except Exception as e:  # pylint: disable=broad-exception-caught
             log.debug("Rendering ERROR: %s", e)
     log.debug("Rendered: %s", val)
@@ -250,19 +248,6 @@ def _register_filters(env: Environment) -> Environment:
     )
     env.filters.update(filters)
     return env
-
-
-def _reify_scalar_str(s: str) -> Union[bool, float, int, str]:
-    """
-    Reify a string to a Python object, using YAML. Jinja2 templates will be passed as-is.
-
-    :param s: The string to reify.
-    """
-    try:
-        r = yaml.safe_load(s)
-    except yaml.YAMLError:
-        return s
-    return r
 
 
 def _report(args: dict) -> None:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -215,9 +215,9 @@ def _deref_convert(val: TaggedScalar) -> _ConfigVal:
     _deref_debug("Converting", val.value)
     try:
         converted = val.convert()
+        _deref_debug("Converted", val.value)
     except Exception as e:  # pylint: disable=broad-exception-caught
         _deref_debug("Conversion failed", str(e))
-    _deref_debug("Converted", val.value)
     return converted
 
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -125,12 +125,7 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
     # Note that, for rendering performed on dict values, replacement values will be taken from, in
     # priority order, 1. The full context dict, 2. Local sibling values in the dict.
 
-    log.debug("Rendering: %s", val)
-    if isinstance(val, dict):
-        return {k: dereference(v, context, local=val) for k, v in val.items()}
-    if isinstance(val, list):
-        return [dereference(v, context) for v in val]
-    if isinstance(val, str):
+    def _render(val: str) -> str:
         try:
             return (
                 _register_filters(Environment(undefined=StrictUndefined))
@@ -139,8 +134,20 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             log.debug("Rendering ERROR: %s", e)
-    log.debug("Rendered: %s", val)
-    return val
+        return val
+
+    rendered: _YAMLVal
+    log.debug("Rendering: %s", val)
+    if isinstance(val, dict):
+        return {k: dereference(v, context, local=val) for k, v in val.items()}
+    if isinstance(val, list):
+        return [dereference(v, context) for v in val]
+    if isinstance(val, str):
+        rendered = _render(val)
+    else:
+        rendered = val
+    log.debug("Rendered: %s", rendered)
+    return rendered
 
 
 def render(

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -142,62 +142,6 @@ def dereference(val: _ConfigVal, context: dict, local: Optional[dict] = None) ->
     return rendered
 
 
-def _deref_convert(val: TaggedScalar) -> _ConfigVal:
-    """
-    Convert a string tagged with an explicit type.
-
-    If conversion cannot be performed (e.g. the value was tagged as an int but int() is not a value
-    that can be represented as an int, the original value will be returned unchanged.
-
-    :param val: A scalar value tagged with an explicit type.
-    :return: The value translated to the specified type.
-    """
-    converted: _ConfigVal = val  # fall-back value
-    _deref_debug("Converting", val.value)
-    try:
-        converted = val.convert()
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        _deref_debug("Conversion failed", str(e))
-    _deref_debug("Converted", val.value)
-    return converted
-
-
-def _deref_debug(action: str, val: _ConfigVal) -> None:
-    """
-    Log a debug-level message related to dereferencing.
-
-    :param action: The dereferencing activity being performed.
-    :param val: The value being dereferenced.
-    """
-    log.debug("[dereference] %s: %s", action, val)
-
-
-def _deref_render(val: str, context: dict, local: Optional[dict] = None) -> str:
-    """
-    Render a Jinja2 variable/expression as part of dereferencing.
-
-    If this function cannot render the value, either because it contains no Jinja2 syntax or because
-    insufficient context is currently available, a debug message will be logged and the original
-    value will be returned unchanged.
-
-    :param val: The value potentially containing Jinja2 syntax to render.
-    :param context: Values to use when rendering Jinja2 syntax.
-    :param local: Local sibling values to use if a match is not found in context.
-    :return: The rendered value (potentially unchanged).
-    """
-    try:
-        rendered = (
-            _register_filters(Environment(undefined=StrictUndefined))
-            .from_string(val)
-            .render({**(local or {}), **context})
-        )
-        _deref_debug("Rendered", rendered)
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        _deref_debug("Rendering failed", str(e))
-        rendered = val
-    return rendered
-
-
 def render(
     values: Union[dict, DefinitePath],
     values_format: Optional[str] = None,
@@ -255,6 +199,62 @@ def render(
 
 
 # Private functions
+
+
+def _deref_convert(val: TaggedScalar) -> _ConfigVal:
+    """
+    Convert a string tagged with an explicit type.
+
+    If conversion cannot be performed (e.g. the value was tagged as an int but int() is not a value
+    that can be represented as an int, the original value will be returned unchanged.
+
+    :param val: A scalar value tagged with an explicit type.
+    :return: The value translated to the specified type.
+    """
+    converted: _ConfigVal = val  # fall-back value
+    _deref_debug("Converting", val.value)
+    try:
+        converted = val.convert()
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        _deref_debug("Conversion failed", str(e))
+    _deref_debug("Converted", val.value)
+    return converted
+
+
+def _deref_debug(action: str, val: _ConfigVal) -> None:
+    """
+    Log a debug-level message related to dereferencing.
+
+    :param action: The dereferencing activity being performed.
+    :param val: The value being dereferenced.
+    """
+    log.debug("[dereference] %s: %s", action, val)
+
+
+def _deref_render(val: str, context: dict, local: Optional[dict] = None) -> str:
+    """
+    Render a Jinja2 variable/expression as part of dereferencing.
+
+    If this function cannot render the value, either because it contains no Jinja2 syntax or because
+    insufficient context is currently available, a debug message will be logged and the original
+    value will be returned unchanged.
+
+    :param val: The value potentially containing Jinja2 syntax to render.
+    :param context: Values to use when rendering Jinja2 syntax.
+    :param local: Local sibling values to use if a match is not found in context.
+    :return: The rendered value (potentially unchanged).
+    """
+    try:
+        rendered = (
+            _register_filters(Environment(undefined=StrictUndefined))
+            .from_string(val)
+            .render({**(local or {}), **context})
+        )
+        _deref_debug("Rendered", rendered)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        _deref_debug("Rendering failed", str(e))
+        rendered = val
+    return rendered
 
 
 def _dry_run_template(rendered_template: str) -> bool:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -145,11 +145,7 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
 
     rendered: _YAMLVal
     if isinstance(val, dict):
-        new = {}
-        for k, v in val.items():
-            new[k] = dereference(v, context, local=val)
-        return new
-        # return {k: dereference(v, context, local=val) for k, v in val.items()}
+        return {k: dereference(v, context, local=val) for k, v in val.items()}
     if isinstance(val, list):
         return [dereference(v, context) for v in val]
     if isinstance(val, str):

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -125,6 +125,8 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
     # Note that, for rendering performed on dict values, replacement values will be taken from, in
     # priority order, 1. The full context dict, 2. Local sibling values in the dict.
 
+    # PM FIX UP THIS DOCSTRING!
+
     def _render(val: str) -> str:
         try:
             return (

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -133,7 +133,7 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
                 .render({**(local or {}), **context})
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
-            log.debug("Rendering ERROR: %s", e)
+            log.debug("ERROR rendering: %s", e)
         return val
 
     rendered: _YAMLVal
@@ -148,9 +148,16 @@ def dereference(val: _YAMLVal, context: dict, local: Optional[dict] = None) -> _
     elif isinstance(val, TaggedScalar):
         log.debug("Rendering: %s", val.value)
         val.value = _render(val.value)
-        rendered = val
         log.debug("Rendered: %s", val.value)
+        log.debug("Reifying: %s", val.value)
+        try:
+            rendered = val.reify()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            log.debug(" ERROR reifying: %s", e)
+            rendered = val
+        log.debug("Reified: %s", val.value)
     else:
+        log.debug("Ignoring: %s", val)
         rendered = val
     return rendered
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -16,12 +16,12 @@ from jinja2 import (
 )
 from jinja2.exceptions import UndefinedError
 
-from uwtools.config.support import TaggedScalar, format_to_config
+from uwtools.config.support import TaggedString, format_to_config
 from uwtools.logging import MSGWIDTH, log
 from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils.file import get_file_format, readable, writable
 
-_ConfigVal = Union[bool, dict, float, int, list, str, TaggedScalar]
+_ConfigVal = Union[bool, dict, float, int, list, str, TaggedString]
 
 
 class J2Template:
@@ -133,7 +133,7 @@ def dereference(val: _ConfigVal, context: dict, local: Optional[dict] = None) ->
     if isinstance(val, str):
         _deref_debug("Rendering", val)
         rendered = _deref_render(val, context, local)
-    elif isinstance(val, TaggedScalar):
+    elif isinstance(val, TaggedString):
         _deref_debug("Rendering", val.value)
         val.value = _deref_render(val.value, context, local)
         rendered = _deref_convert(val)
@@ -201,7 +201,7 @@ def render(
 # Private functions
 
 
-def _deref_convert(val: TaggedScalar) -> _ConfigVal:
+def _deref_convert(val: TaggedString) -> _ConfigVal:
     """
     Convert a string tagged with an explicit type.
 

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -63,7 +63,7 @@ class TaggedScalar:
         self.tag: str = node.tag
         self.value: str = node.value
 
-    def reify(self) -> Union[bool, float, int, str]:
+    def convert(self) -> Union[bool, float, int, str]:
         """
         PM WRITEME.
         """

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -1,5 +1,7 @@
 from importlib import import_module
-from typing import Type
+from typing import Dict, Type, Union
+
+import yaml
 
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
@@ -46,3 +48,22 @@ def log_and_error(msg: str) -> Exception:
     """
     log.error(msg)
     return UWConfigError(msg)
+
+
+class TaggedScalar:
+    """
+    PM WRITEME.
+    """
+
+    TAGS = ("!bool", "!float", "!int", "!str")
+
+    def __init__(self, _: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> None:
+        self.tag: str = node.tag
+        self.value: str = node.value
+
+    def reify(self) -> Union[bool, float, int, str]:
+        """
+        PM WRITEME.
+        """
+        converters: Dict[str, type] = dict(zip(self.TAGS, [bool, float, int, str]))
+        return converters[self.tag](self.value)

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -54,7 +54,10 @@ def log_and_error(msg: str) -> Exception:
 
 class TaggedScalar:
     """
-    PM WRITEME.
+    A class supporting custom YAML tags specifying type conversions.
+
+    The constructor implements the interface required by a pyyaml Loader object's add_consructor()
+    method. See the pyyaml documentation for details.
     """
 
     TAGS = ("!bool", "!float", "!int", "!str")
@@ -65,7 +68,9 @@ class TaggedScalar:
 
     def convert(self) -> Union[bool, float, int, str]:
         """
-        PM WRITEME.
+        Return the original YAML value converted to the specified type.
+
+        Will raise an exception if the value cannot be represented as the specified type.
         """
         converters: Dict[str, type] = dict(zip(self.TAGS, [bool, float, int, str]))
         return converters[self.tag](self.value)
@@ -73,6 +78,9 @@ class TaggedScalar:
     @staticmethod
     def represent(dumper: yaml.Dumper, data: TaggedScalar) -> yaml.nodes.ScalarNode:
         """
-        PM WRITEME.
+        Serialize a tagged scalar as "!type value".
+
+        Implements the interface required by pyyaml's add_representer() function. See the pyyaml
+        documentation for details.
         """
         return dumper.represent_scalar(data.tag, data.value)

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -60,19 +60,19 @@ class TaggedScalar:
     method. See the pyyaml documentation for details.
     """
 
-    TAGS = ("!float", "!int", "!str")
+    TAGS = ("!float", "!int")
 
     def __init__(self, _: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> None:
         self.tag: str = node.tag
         self.value: str = node.value
 
-    def convert(self) -> Union[float, int, str]:
+    def convert(self) -> Union[float, int]:
         """
         Return the original YAML value converted to the specified type.
 
         Will raise an exception if the value cannot be represented as the specified type.
         """
-        converters: Dict[str, type] = dict(zip(self.TAGS, [float, int, str]))
+        converters: Dict[str, type] = dict(zip(self.TAGS, [float, int]))
         return converters[self.tag](self.value)
 
     @staticmethod

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from importlib import import_module
 from typing import Dict, Type, Union
 
@@ -67,3 +69,10 @@ class TaggedScalar:
         """
         converters: Dict[str, type] = dict(zip(self.TAGS, [bool, float, int, str]))
         return converters[self.tag](self.value)
+
+    @staticmethod
+    def represent(dumper: yaml.Dumper, data: TaggedScalar) -> yaml.nodes.ScalarNode:
+        """
+        PM WRITEME.
+        """
+        return dumper.represent_scalar(data.tag, data.value)

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -60,19 +60,19 @@ class TaggedScalar:
     method. See the pyyaml documentation for details.
     """
 
-    TAGS = ("!bool", "!float", "!int", "!str")
+    TAGS = ("!float", "!int", "!str")
 
     def __init__(self, _: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> None:
         self.tag: str = node.tag
         self.value: str = node.value
 
-    def convert(self) -> Union[bool, float, int, str]:
+    def convert(self) -> Union[float, int, str]:
         """
         Return the original YAML value converted to the specified type.
 
         Will raise an exception if the value cannot be represented as the specified type.
         """
-        converters: Dict[str, type] = dict(zip(self.TAGS, [bool, float, int, str]))
+        converters: Dict[str, type] = dict(zip(self.TAGS, [float, int, str]))
         return converters[self.tag](self.value)
 
     @staticmethod

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -66,6 +66,9 @@ class TaggedString:
         self.tag: str = node.tag
         self.value: str = node.value
 
+    def __repr__(self) -> str:
+        return "%s %s" % (self.tag, self.value)
+
     def convert(self) -> Union[float, int]:
         """
         Return the original YAML value converted to the specified type.

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -52,7 +52,7 @@ def log_and_error(msg: str) -> Exception:
     return UWConfigError(msg)
 
 
-class TaggedScalar:
+class TaggedString:
     """
     A class supporting custom YAML tags specifying type conversions.
 
@@ -76,7 +76,7 @@ class TaggedScalar:
         return converters[self.tag](self.value)
 
     @staticmethod
-    def represent(dumper: yaml.Dumper, data: TaggedScalar) -> yaml.nodes.ScalarNode:
+    def represent(dumper: yaml.Dumper, data: TaggedString) -> yaml.nodes.ScalarNode:
         """
         Serialize a tagged scalar as "!type value".
 

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -116,7 +116,7 @@ def realize_config(
         _realize_config_values_needed(input_obj)
         return {}
     output_obj = format_to_config(output_format)
-    output_obj.dump_dict(path=output_file, cfg=input_obj.data)
+    output_obj.dump_dict(cfg=input_obj.data, path=output_file)
     return input_obj.data
 
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -167,7 +167,7 @@ class Driver(ABC):
             config_obj.dereference()
             config_obj.dump(output_path)
         else:
-            config_class.dump_dict(path=output_path, cfg=user_values)
+            config_class.dump_dict(cfg=user_values, path=output_path)
 
         msg = f"Configure file {output_path} created"
         log.info(msg)

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -125,13 +125,13 @@ def test_dereference(caplog, tmp_path):
     #   - Initially-unrenderable values may be rendered via iteration.
     #   - Finally-unrenderable values do not cause errors and are returned unmodified.
     log.setLevel(logging.DEBUG)
-    path = tmp_path / "config.yaml"
     yaml = """
 a: !int '{{ b.c + 11 }}'
 b:
   c: !int '{{ N | int + 11 }}'
 d: '{{ X }}'
 """.strip()
+    path = tmp_path / "config.yaml"
     with open(path, "w", encoding="utf-8") as f:
         print(yaml, file=f)
     config = YAMLConfig(path)

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -43,11 +43,11 @@ class ConcreteConfig(Config):
         with readable(config_file) as f:
             return yaml.safe_load(f.read())
 
-    def dump(self, path):
+    def dump(self, path=None):
         pass
 
     @staticmethod
-    def dump_dict(path, cfg, opts=None):
+    def dump_dict(cfg, path=None):
         pass
 
     @staticmethod
@@ -148,7 +148,7 @@ def test_invalid_config(caplog, fmt2, tmp_path):
     cfgin = tools.format_to_config(fmt1)(fixture_path("hello_workflow.yaml"))
     depthin = depth(cfgin.data)
     with raises(UWConfigError) as e:
-        tools.format_to_config(fmt2).dump_dict(path=outfile, cfg=cfgin.data)
+        tools.format_to_config(fmt2).dump_dict(cfg=cfgin.data, path=outfile)
     msg = f"Cannot dump depth-{depthin} config to type-'{fmt2}' config"
     assert logged(caplog, msg)
     assert msg in str(e.value)
@@ -187,7 +187,7 @@ def test_transform_config(fmt1, fmt2, tmp_path):
     outfile = tmp_path / f"test_{fmt1}to{fmt2}_dump.{fmt2}"
     reference = fixture_path(f"simple.{fmt2}")
     cfgin = tools.format_to_config(fmt1)(fixture_path(f"simple.{fmt1}"))
-    tools.format_to_config(fmt2).dump_dict(path=outfile, cfg=cfgin.data)
+    tools.format_to_config(fmt2).dump_dict(cfg=cfgin.data, path=outfile)
     with open(reference, "r", encoding="utf-8") as f1:
         reflines = [line.strip().replace("'", "") for line in f1]
     with open(outfile, "r", encoding="utf-8") as f2:

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -17,7 +17,7 @@ from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.support import depth
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
-from uwtools.tests.support import fixture_path, logged, regex_logged
+from uwtools.tests.support import fixture_path, logged
 from uwtools.utils.file import FORMAT, readable
 
 # Fixtures
@@ -118,7 +118,7 @@ def test_depth(config):
     assert config.depth == 1
 
 
-def test_dereference(caplog, tmp_path):
+def test_dereference(tmp_path):
     # Test demonstrates that:
     #   - Config dereferencing uses environment variables.
     #   - Initially-unrenderable values do not cause errors.
@@ -137,13 +137,6 @@ d: '{{ X }}'
     config = YAMLConfig(path)
     with patch.dict(os.environ, {"N": "55"}, clear=True):
         config.dereference()
-    for excerpt in [
-        # pylint: disable-next=line-too-long
-        "current value: {a: !int '{{ b.c + 11 }}', b: {c: !int '{{ N | int + 11 }}'}, d: '{{ X }}'}",
-        "current value: {a: !int '{{ b.c + 11 }}', b: {c: 66}, d: '{{ X }}'}",
-        "final value: {a: 77, b: {c: 66}, d: '{{ X }}'}",
-    ]:
-        assert regex_logged(caplog, excerpt)
     assert config == {"a": 77, "b": {"c": 66}, "d": "{{ X }}"}
 
 

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -117,6 +117,7 @@ def test_depth(config):
     assert config.depth == 1
 
 
+@pytest.mark.skip("PM FIX")
 def test_dereference(caplog, config):
     # Test demonstrates that:
     #   - Config dereferencing uses environment variables.

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -64,10 +64,9 @@ def validate(template):
 # Tests
 
 
-@pytest.mark.skip("PM FIX")
 def test_dereference_dict():
     val = {"n": "{{ int }}"}
-    assert jinja2.dereference(val=val, context={"int": 88}) == {"n": 88}
+    assert jinja2.dereference(val=val, context={"int": 88}) == {"n": "88"}
 
 
 @pytest.mark.skip("PM FIX")

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -15,7 +15,7 @@ from pytest import fixture, raises
 
 from uwtools.config import jinja2
 from uwtools.config.jinja2 import J2Template
-from uwtools.config.support import TaggedScalar
+from uwtools.config.support import TaggedString
 from uwtools.logging import log
 from uwtools.tests.support import logged, regex_logged
 
@@ -235,7 +235,7 @@ def test_render_values_needed(caplog, template, values_file):
 def test__deref_convert_no(caplog, tag):
     log.setLevel(logging.DEBUG)
     loader = yaml.SafeLoader(os.devnull)
-    val = TaggedScalar(loader, yaml.ScalarNode(tag=tag, value="foo"))
+    val = TaggedString(loader, yaml.ScalarNode(tag=tag, value="foo"))
     assert jinja2._deref_convert(val=val) == val
     assert not regex_logged(caplog, "Converted")
     assert regex_logged(caplog, "Conversion failed")
@@ -245,7 +245,7 @@ def test__deref_convert_no(caplog, tag):
 def test__deref_convert_ok(caplog, converted, tag, value):
     log.setLevel(logging.DEBUG)
     loader = yaml.SafeLoader(os.devnull)
-    val = TaggedScalar(loader, yaml.ScalarNode(tag=tag, value=value))
+    val = TaggedString(loader, yaml.ScalarNode(tag=tag, value=value))
     assert jinja2._deref_convert(val=val) == converted
     assert regex_logged(caplog, "Converted")
     assert not regex_logged(caplog, "Conversion failed")

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -64,17 +64,6 @@ def validate(template):
 # Tests
 
 
-def test_dereference_dict():
-    val = {"n": "{{ int }}"}
-    assert jinja2.dereference(val=val, context={"int": 88}) == {"n": "88"}
-
-
-@pytest.mark.skip("PM FIX")
-def test_dereference_list():
-    val = ["{{ n }}", "{{ s }}"]
-    assert jinja2.dereference(val=val, context={"n": 88, "s": "foo"}) == [88, "foo"]
-
-
 def test_dereference_local_values():
     # Rendering can use values from the local contents of the enclosing dict, but are shadowed by
     # values from the top-level context object.
@@ -132,15 +121,6 @@ def test_dereference_str_expression_rendered():
 def test_dereference_str_filter_rendered():
     val = "{{ ['hello', recipient] | join(', ') }}"
     assert jinja2.dereference(val=val, context={"recipient": "world"}) == "hello, world"
-
-
-@pytest.mark.skip("PM FIX")
-def test_dereference_str_variable_rendered_int():
-    # Due to reification, the value of a result parsable as an int is an int. The same holds for
-    # other results parsable by YAML as Python values, but this is only a representative, non-
-    # exhaustive test.
-    val = "{{ number }}"
-    assert jinja2.dereference(val=val, context={"number": "88"}) == 88
 
 
 def test_derefrence_str_variable_rendered_mixed():

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -64,11 +64,13 @@ def validate(template):
 # Tests
 
 
+@pytest.mark.skip("PM FIX")
 def test_dereference_dict():
     val = {"n": "{{ int }}"}
     assert jinja2.dereference(val=val, context={"int": 88}) == {"n": 88}
 
 
+@pytest.mark.skip("PM FIX")
 def test_dereference_list():
     val = ["{{ n }}", "{{ s }}"]
     assert jinja2.dereference(val=val, context={"n": 88, "s": "foo"}) == [88, "foo"]
@@ -133,6 +135,7 @@ def test_dereference_str_filter_rendered():
     assert jinja2.dereference(val=val, context={"recipient": "world"}) == "hello, world"
 
 
+@pytest.mark.skip("PM FIX")
 def test_dereference_str_variable_rendered_int():
     # Due to reification, the value of a result parsable as an int is an int. The same holds for
     # other results parsable by YAML as Python values, but this is only a representative, non-

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -262,14 +262,14 @@ def test__deref_debug(caplog):
 
 def test__deref_render_no(caplog, deref_render_assets):
     val, context, _ = deref_render_assets
-    assert val == jinja2._deref_render(val=val, context=context)
+    assert jinja2._deref_render(val=val, context=context) == val
     assert not regex_logged(caplog, "Rendered")
     assert regex_logged(caplog, "Rendering failed")
 
 
 def test__deref_render_ok(caplog, deref_render_assets):
     val, context, local = deref_render_assets
-    assert "hello world" == jinja2._deref_render(val=val, context=context, local=local)
+    assert jinja2._deref_render(val=val, context=context, local=local) == "hello world"
     assert regex_logged(caplog, "Rendered")
     assert not regex_logged(caplog, "Rendering failed")
 

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -165,21 +165,6 @@ def test_register_filters_path_join(key):
             template.render(**context)  # path_join filter fails
 
 
-def test_reify_scalar_str():
-    for x in ["true", "yes", "TRUE"]:
-        assert jinja2._reify_scalar_str(x) is True
-    for x in ["false", "no", "FALSE"]:
-        assert jinja2._reify_scalar_str(x) is False
-    assert jinja2._reify_scalar_str("88") == 88
-    assert jinja2._reify_scalar_str("'88'") == "88"  # quoted int not converted
-    assert jinja2._reify_scalar_str("3.14") == 3.14
-    assert jinja2._reify_scalar_str("NA") == "NA"  # no conversion
-    assert jinja2._reify_scalar_str("@[foo]") == "@[foo]"  # no conversion for YAML exceptions
-    with raises(AttributeError) as e:
-        jinja2._reify_scalar_str([1, 2, 3])  # type: ignore
-    assert "'list' object has no attribute 'read'" in str(e.value)  # Exception on unintended list
-
-
 def test_render(values_file, template, tmp_path):
     outfile = str(tmp_path / "out.txt")
     render_helper(input_file=template, values_file=values_file, output_file=outfile)

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -44,7 +44,7 @@ roses_color: red
 violets_color: blue
 cannot:
     override: this
-"""
+""".strip()
     with open(path, "w", encoding="utf-8") as f:
         f.write(yaml)
     return str(path)

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -241,10 +241,7 @@ def test__deref_convert_no(caplog, tag):
     assert regex_logged(caplog, "Conversion failed")
 
 
-@pytest.mark.parametrize(
-    "converted,tag,value",
-    [(3.14, "!float", "3.14"), (88, "!int", "88"), ("48:00:00", "!str", "48:00:00")],
-)
+@pytest.mark.parametrize("converted,tag,value", [(3.14, "!float", "3.14"), (88, "!int", "88")])
 def test__deref_convert_ok(caplog, converted, tag, value):
     log.setLevel(logging.DEBUG)
     loader = yaml.SafeLoader(os.devnull)

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -90,3 +90,7 @@ class Test_TaggedString:
         ts = support.TaggedString(loader, yaml.ScalarNode(tag="!int", value="88"))
         assert ts.convert() == 88
         self.comp(ts, "!int '88'")
+
+    def test___repr__(self, loader):
+        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!int", value="88"))
+        assert str(ts) == "!int 88"

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -90,19 +90,3 @@ class Test_TaggedScalar:
         ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!int", value="88"))
         assert ts.convert() == 88
         self.comp(ts, "!int '88'")
-
-    def test_str_no(self):
-        # Everything has a string representation.
-        pass
-
-    def test_str_ok(self, loader):
-        # Compare
-        #   >>> yaml.safe_load("48:00:00") # <-- YAML parsees this as an int
-        #   172800
-        # to
-        #   >>> yaml.safe_load("'48:00:00'") # <-- note interior quotes
-        #   '48:00:00'
-        # So a YAML input could either quote the value, or tag it with !str.
-        ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!str", value="48:00:00"))
-        assert ts.convert() == "48:00:00"
-        self.comp(ts, "!str '48:00:00'")

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -54,17 +54,17 @@ def test_log_and_error(caplog):
     assert logged(caplog, msg)
 
 
-class Test_TaggedScalar:
+class Test_TaggedString:
     """
-    Tests for class uwtools.config.support.TaggedScalar.
+    Tests for class uwtools.config.support.TaggedString.
     """
 
-    def comp(self, ts: support.TaggedScalar, s: str):
+    def comp(self, ts: support.TaggedString, s: str):
         assert yaml.dump(ts, default_flow_style=True).strip() == s
 
     @fixture
     def loader(self):
-        yaml.add_representer(support.TaggedScalar, support.TaggedScalar.represent)
+        yaml.add_representer(support.TaggedString, support.TaggedString.represent)
         return YAMLConfig(config={})._yaml_loader
 
     # These tests bypass YAML parsing, constructing nodes with explicit string values. They then
@@ -72,21 +72,21 @@ class Test_TaggedScalar:
     # by the tag.
 
     def test_float_no(self, loader):
-        ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!float", value="foo"))
+        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!float", value="foo"))
         with raises(ValueError):
             ts.convert()
 
     def test_float_ok(self, loader):
-        ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!float", value="3.14"))
+        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!float", value="3.14"))
         assert ts.convert() == 3.14
         self.comp(ts, "!float '3.14'")
 
     def test_int_no(self, loader):
-        ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!int", value="foo"))
+        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!int", value="foo"))
         with raises(ValueError):
             ts.convert()
 
     def test_int_ok(self, loader):
-        ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!int", value="88"))
+        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!int", value="88"))
         assert ts.convert() == 88
         self.comp(ts, "!int '88'")

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -61,7 +61,15 @@ class Test_TaggedScalar:
 
     @fixture
     def loader(self):
+        yaml.add_representer(support.TaggedScalar, support.TaggedScalar.represent)
         return YAMLConfig(config={})._yaml_loader
+
+    # These tests bypass YAML parsing, constructing nodes with explicit string values. They then
+    # demonstrate that those nodes' convert() methods return representations in type type specified
+    # by the tag.
+
+    def comp(self, ts: support.TaggedScalar, s: str):
+        assert yaml.dump(ts, default_flow_style=True).strip() == s
 
     def test_float_no(self, loader):
         ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!float", value="foo"))
@@ -71,6 +79,7 @@ class Test_TaggedScalar:
     def test_float_ok(self, loader):
         ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!float", value="3.14"))
         assert ts.convert() == 3.14
+        self.comp(ts, "!float '3.14'")
 
     def test_int_no(self, loader):
         ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!int", value="foo"))
@@ -80,6 +89,7 @@ class Test_TaggedScalar:
     def test_int_ok(self, loader):
         ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!int", value="88"))
         assert ts.convert() == 88
+        self.comp(ts, "!int '88'")
 
     def test_str_no(self):
         # Everything has a string representation.
@@ -95,3 +105,4 @@ class Test_TaggedScalar:
         # So a YAML input could either quote the value, or tag it with !str.
         ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!str", value="48:00:00"))
         assert ts.convert() == "48:00:00"
+        self.comp(ts, "!str '48:00:00'")

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -59,6 +59,9 @@ class Test_TaggedScalar:
     Tests for class uwtools.config.support.TaggedScalar.
     """
 
+    def comp(self, ts: support.TaggedScalar, s: str):
+        assert yaml.dump(ts, default_flow_style=True).strip() == s
+
     @fixture
     def loader(self):
         yaml.add_representer(support.TaggedScalar, support.TaggedScalar.represent)
@@ -67,9 +70,6 @@ class Test_TaggedScalar:
     # These tests bypass YAML parsing, constructing nodes with explicit string values. They then
     # demonstrate that those nodes' convert() methods return representations in type type specified
     # by the tag.
-
-    def comp(self, ts: support.TaggedScalar, s: str):
-        assert yaml.dump(ts, default_flow_style=True).strip() == s
 
     def test_float_no(self, loader):
         ts = support.TaggedScalar(loader, yaml.ScalarNode(tag="!float", value="foo"))

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -240,31 +240,6 @@ def test_realize_config_field_table(tmp_path):
                 assert line1 in line2
 
 
-@pytest.mark.skip("Updating typed Fortran namelist from untyped INI data is unsound")
-def test_realize_config_file_conversion(tmp_path):
-    """
-    Test using an ini object to configure nml input -> nml output.
-    """
-    infile = fixture_path("simple2.nml")
-    cfgfile = fixture_path("simple2.ini")
-    outfile = str(tmp_path / "test_config_conversion.nml")
-    tools.realize_config(
-        input_config=infile,
-        input_format=FORMAT.nml,
-        output_file=outfile,
-        output_format=FORMAT.nml,
-        supplemental_configs=[cfgfile],
-    )
-    expected = NMLConfig(infile)
-    config_obj = INIConfig(cfgfile)
-    expected.update_values(config_obj)
-    expected_file = tmp_path / "expected.nml"
-    expected.dump(expected_file)
-    assert compare_files(expected_file, outfile)
-    with open(outfile, "r", encoding="utf-8") as f:
-        assert f.read()[-1] == "\n"
-
-
 def test_realize_config_fmt2fmt_nml2nml(tmp_path):
     """
     Test that providing a namelist base input file and a config file will create and update namelist


### PR DESCRIPTION
**Synopsis**

This PR adds support for YAML tags `!float` and `!int` to support conversion of `str` values arising from Jinja2 rendering to desired Python types. For example, consider the YAML fragment
```
n: "{{ 2 + 2 }}"
```
The quotes around the Jinja2 expression `{{ 2 + 2 }}` are required to allow YAML to parse this fragment, as otherwise it would interpret the opening `{` as the start of a YAML mapping, leading to a syntax error and a failed parse. With the the quotes in place, the value of `n` will be of type `str` and, after Jinja2 rendering, the Python `dict` fragment corresponding to this input will be
```
n: "4"
```
If `n` were subsequently used to generate a Fortran namelist value where an `integer` value is expected for `n`, the namelist would instead contain e.g.
```
n = '4'
```
and the Fortran code reading the namelist would fail. So it is important that value types in Python config `dict` objects are correct. This PR adds support for the following syntax:
```
n: !int "{{ 2 + 2 }}"
```
leading to the (conceptual) transformations `n: !int "{{ 2 + 2 }}"` (original) -> `n: !int "4"` (Jinja2 rendering) -> `n: 4` (conversion via the `!int` tag). The tag `!float` provides similar conversion to `float` values.

Currently, the above example would already work because a reification step re-processes values with the YAML parser, leading to the (conceptual) transformations `n: "{{ 2 + 2 }}"` (original) -> `n: "4"` (Jinja2 rendering) -> `n: 4` (reification via `yaml.load()`). However, this creates a problem, demonstrated by the example
```
n: "48:00:00"
```
Without quotes, YAML parses the string `48:00:00` as an `int`:
```
>>> yaml.safe_load('48:00:00')
172800
```
Quoting avoids this:
```
>>> yaml.safe_load('"48:00:00"')
'48:00:00'
```
But the current reification step parses this value a _second_ time, converting it again to an int. So, reification via YAML parsing has undesirable side effects and is eliminated in this PR.

This work is a prelude to [UW-419](https://jira.epic.oarcloud.noaa.gov/browse/UW-419). Documentation will be added/updated in a separate PR as a prerequisite to completion of that ticket.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
