### PR TITLE
UW-479: add uw --debug CLI option

### DIFF
--- a/docs/sections/user_guide/cli/mode_config.rst
+++ b/docs/sections/user_guide/cli/mode_config.rst
@@ -116,7 +116,7 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
      [2024-01-08T16:57:28]     INFO ---------------------------------------------------------------------
      [2024-01-08T16:57:28]     INFO values:       recipient:  - None + World
 
-  If additional information is needed, ``--debug`` can be used which will return the the stack trace from any unhandled exception as well.
+  If additional information is needed, ``--debug`` can be used which will return the stack trace from any unhandled exception as well.
   
   Note that ``uw`` logs to ``stderr``, so the stream can be redirected:
 

--- a/docs/sections/user_guide/cli/mode_config.rst
+++ b/docs/sections/user_guide/cli/mode_config.rst
@@ -50,6 +50,8 @@ The ``uw`` mode for handling configs.
            Format of file 1
      --file-2-format {ini,nml,sh,yaml}
            Format of file 2
+     --debug
+           Print all logging messages and the stack trace
      --quiet, -q
            Print no logging messages
      --verbose, -v
@@ -114,6 +116,8 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
      [2024-01-08T16:57:28]     INFO ---------------------------------------------------------------------
      [2024-01-08T16:57:28]     INFO values:       recipient:  - None + World
 
+  If additional information is needed, ``--debug`` can be used which will return the stack trace as well.
+  
   Note that ``uw`` logs to ``stderr``, so the stream can be redirected:
 
   .. code-block:: text
@@ -166,6 +170,8 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
           Print report of values needed to render template
     --dry-run
           Only log info, making no changes
+    --debug
+          Print all logging messages and the stack trace
     --quiet, -q
           Print no logging messages
     --verbose, -v
@@ -424,6 +430,8 @@ and additional supplemental YAML file ``values2.yaml`` with content
          Show help and exit
      --input-file PATH, -i PATH
          Path to input file (defaults to stdin)
+     --debug
+         Print all logging messages and the stack trace
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_config.rst
+++ b/docs/sections/user_guide/cli/mode_config.rst
@@ -51,7 +51,7 @@ The ``uw`` mode for handling configs.
      --file-2-format {ini,nml,sh,yaml}
            Format of file 2
      --debug
-           Print all logging messages and the stack trace
+           Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
            Print no logging messages
      --verbose, -v
@@ -116,7 +116,7 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
      [2024-01-08T16:57:28]     INFO ---------------------------------------------------------------------
      [2024-01-08T16:57:28]     INFO values:       recipient:  - None + World
 
-  If additional information is needed, ``--debug`` can be used which will return the stack trace as well.
+  If additional information is needed, ``--debug`` can be used which will return the the stack trace from any unhandled exception as well.
   
   Note that ``uw`` logs to ``stderr``, so the stream can be redirected:
 
@@ -171,7 +171,7 @@ The examples that follow use namelist files ``values1.nml`` and ``values2.nml``,
     --dry-run
           Only log info, making no changes
     --debug
-          Print all logging messages and the stack trace
+          Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
     --quiet, -q
           Print no logging messages
     --verbose, -v
@@ -431,7 +431,7 @@ and additional supplemental YAML file ``values2.yaml`` with content
      --input-file PATH, -i PATH
          Path to input file (defaults to stdin)
      --debug
-         Print all logging messages and the stack trace
+         Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_forecast.rst
+++ b/docs/sections/user_guide/cli/mode_forecast.rst
@@ -46,7 +46,7 @@ The ``uw`` mode for configuring and running forecasts.
      --dry-run
          Only log info, making no changes
      --debug
-         Print all logging messages and the stack trace
+         Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_forecast.rst
+++ b/docs/sections/user_guide/cli/mode_forecast.rst
@@ -45,6 +45,8 @@ The ``uw`` mode for configuring and running forecasts.
          Path to output batch file (defaults to stdout)
      --dry-run
          Only log info, making no changes
+     --debug
+         Print all logging messages and the stack trace
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_rocoto.rst
+++ b/docs/sections/user_guide/cli/mode_rocoto.rst
@@ -45,7 +45,7 @@ More information about the structured UW YAML file for Rocoto can be found :any:
      --output-file PATH, -o PATH
          Path to output file (defaults to stdout)
      --debug
-         Print all logging messages and the stack trace
+         Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
          Print no logging messages
      --verbose, -v
@@ -219,7 +219,7 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
      --input-file PATH, -i PATH
          Path to input file (defaults to stdin)
      --debug
-         Print all logging messages and the stack trace
+         Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_rocoto.rst
+++ b/docs/sections/user_guide/cli/mode_rocoto.rst
@@ -44,6 +44,8 @@ More information about the structured UW YAML file for Rocoto can be found :any:
          Path to input file (defaults to stdin)
      --output-file PATH, -o PATH
          Path to output file (defaults to stdout)
+     --debug
+         Print all logging messages and the stack trace
      --quiet, -q
          Print no logging messages
      --verbose, -v
@@ -216,6 +218,8 @@ The examples that follow use a UW YAML file ``rocoto.yaml`` with content
          Show help and exit
      --input-file PATH, -i PATH
          Path to input file (defaults to stdin)
+     --debug
+         Print all logging messages and the stack trace
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -51,6 +51,8 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
          Print report of values needed to render template
      --dry-run
          Only log info, making no changes
+     --debug
+         Print all logging messages and the stack trace
      --quiet, -q
          Print no logging messages
      --verbose, -v
@@ -173,6 +175,8 @@ and YAML file ``values.yaml`` with content
      [2023-12-18T23:25:01]    DEBUG Read initial values from values.yaml
      Hello, World!
 
+  If additional information is needed, ``--debug`` can be used which will return the stack trace as well.
+  
   Note that ``uw`` logs to ``stderr`` and writes non-log output to ``stdout``, so the streams can be redirected separately:
 
   .. code-block:: text
@@ -248,6 +252,8 @@ and YAML file ``values.yaml`` with content
          Path to output file (defaults to stdout)
      --dry-run
          Only log info, making no changes
+     --debug
+         Print all logging messages and the stack trace
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -52,7 +52,7 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
      --dry-run
          Only log info, making no changes
      --debug
-         Print all logging messages and the stack trace
+         Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
          Print no logging messages
      --verbose, -v
@@ -175,7 +175,7 @@ and YAML file ``values.yaml`` with content
      [2023-12-18T23:25:01]    DEBUG Read initial values from values.yaml
      Hello, World!
 
-  If additional information is needed, ``--debug`` can be used which will return the stack trace as well.
+  If additional information is needed, ``--debug`` can be used which will return the the stack trace from any unhandled exception as well.
   
   Note that ``uw`` logs to ``stderr`` and writes non-log output to ``stdout``, so the streams can be redirected separately:
 
@@ -253,7 +253,7 @@ and YAML file ``values.yaml`` with content
      --dry-run
          Only log info, making no changes
      --debug
-         Print all logging messages and the stack trace
+         Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
          Print no logging messages
      --verbose, -v

--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -175,7 +175,7 @@ and YAML file ``values.yaml`` with content
      [2023-12-18T23:25:01]    DEBUG Read initial values from values.yaml
      Hello, World!
 
-  If additional information is needed, ``--debug`` can be used which will return the the stack trace from any unhandled exception as well.
+  If additional information is needed, ``--debug`` can be used which will return the stack trace from any unhandled exception as well.
   
   Note that ``uw`` logs to ``stderr`` and writes non-log output to ``stdout``, so the streams can be redirected separately:
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -102,7 +102,7 @@ def _add_subparser_config_compare(subparsers: Subparsers) -> SubmodeChecks:
         helpmsg="Format of file 2",
         choices=FORMATS,
     )
-    checks = _add_args_quiet_and_verbose(optional)
+    checks = _add_args_verbosity(optional)
     return checks + [
         partial(_check_file_vs_format, STR.file1path, STR.file1fmt),
         partial(_check_file_vs_format, STR.file2path, STR.file2fmt),
@@ -123,7 +123,7 @@ def _add_subparser_config_realize(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_output_format(optional, choices=FORMATS)
     _add_arg_values_needed(optional)
     _add_arg_dry_run(optional)
-    checks = _add_args_quiet_and_verbose(optional)
+    checks = _add_args_verbosity(optional)
     _add_arg_supplemental_files(optional)
     return checks + [
         partial(_check_file_vs_format, STR.infile, STR.infmt),
@@ -144,7 +144,7 @@ def _add_subparser_config_translate(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_output_file(optional)
     _add_arg_output_format(optional, choices=[FORMAT.jinja2])
     _add_arg_dry_run(optional)
-    checks = _add_args_quiet_and_verbose(optional)
+    checks = _add_args_verbosity(optional)
     return checks + [
         partial(_check_file_vs_format, STR.infile, STR.infmt),
         partial(_check_file_vs_format, STR.outfile, STR.outfmt),
@@ -162,7 +162,7 @@ def _add_subparser_config_validate(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_schema_file(required)
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
-    return _add_args_quiet_and_verbose(optional)
+    return _add_args_verbosity(optional)
 
 
 def _dispatch_config(args: Args) -> bool:
@@ -265,7 +265,7 @@ def _add_subparser_forecast_run(subparsers: Subparsers) -> SubmodeChecks:
     optional = _basic_setup(parser)
     _add_arg_batch_script(optional)
     _add_arg_dry_run(optional)
-    checks = _add_args_quiet_and_verbose(optional)
+    checks = _add_args_verbosity(optional)
     return checks
 
 
@@ -321,7 +321,7 @@ def _add_subparser_rocoto_realize(subparsers: Subparsers) -> SubmodeChecks:
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
     _add_arg_output_file(optional)
-    checks = _add_args_quiet_and_verbose(optional)
+    checks = _add_args_verbosity(optional)
     return checks
 
 
@@ -334,7 +334,7 @@ def _add_subparser_rocoto_validate(subparsers: Subparsers) -> SubmodeChecks:
     parser = _add_subparser(subparsers, STR.validate, "Validate Rocoto XML")
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
-    checks = _add_args_quiet_and_verbose(optional)
+    checks = _add_args_verbosity(optional)
     return checks
 
 
@@ -401,7 +401,7 @@ def _add_subparser_template_render(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_values_format(optional, choices=FORMATS)
     _add_arg_values_needed(optional)
     _add_arg_dry_run(optional)
-    checks = _add_args_quiet_and_verbose(optional)
+    checks = _add_args_verbosity(optional)
     _add_arg_key_eq_val_pairs(optional)
     return checks + [_check_template_render_vals_args]
 
@@ -651,7 +651,7 @@ def _abort(msg: str) -> None:
     sys.exit(1)
 
 
-def _add_args_quiet_and_verbose(group: Group) -> SubmodeChecks:
+def _add_args_verbosity(group: Group) -> SubmodeChecks:
     """
     Add debug, quiet and verbose arguments.
 
@@ -661,7 +661,7 @@ def _add_args_quiet_and_verbose(group: Group) -> SubmodeChecks:
     _add_arg_debug(group)
     _add_arg_quiet(group)
     _add_arg_verbose(group)
-    return [_check_quiet_vs_verbose]
+    return [_check_verbosity]
 
 
 def _add_subparser(subparsers: Subparsers, name: str, helpmsg: str) -> Parser:
@@ -709,7 +709,7 @@ def _check_file_vs_format(file_arg: str, format_arg: str, args: Args) -> Args:
     return args
 
 
-def _check_quiet_vs_verbose(args) -> Args:
+def _check_verbosity(args) -> Args:
     if sum([args.get(STR.debug, 0), args.get(STR.quiet, 0), args.get(STR.verbose, 0)]) > 1:
         _abort(
             "Specify at most one of %s, %s, or %s"

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -46,7 +46,7 @@ def main() -> None:
         args, checks = _parse_args(sys.argv[1:])
         for check in checks[args[STR.mode]][args[STR.submode]]:
             check(args)
-        setup_logging(quiet=args[STR.quiet], verbose=args[STR.debug or STR.verbose])
+        setup_logging(quiet=args[STR.quiet], verbose=args[STR.verbose])
         log.debug("Command: %s %s", Path(sys.argv[0]).name, " ".join(sys.argv[1:]))
         modes = {
             STR.config: _dispatch_config,
@@ -362,7 +362,7 @@ def _add_subparser_template_translate(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_input_file(optional)
     _add_arg_output_file(optional)
     _add_arg_dry_run(optional)
-    return _add_args_quiet_and_verbose(optional)
+    return _add_args_verbosity(optional)
 
 
 def _add_subparser_template_render(subparsers: Subparsers) -> SubmodeChecks:
@@ -641,7 +641,7 @@ def _abort(msg: str) -> None:
 
     :param msg: The message to print.
     """
-    if STR.debug in sys.argv:
+    if _switch(STR.debug) in sys.argv:
         log.exception(msg)
     print(msg, file=sys.stderr)
     sys.exit(1)
@@ -649,10 +649,10 @@ def _abort(msg: str) -> None:
 
 def _add_args_verbosity(group: Group) -> SubmodeChecks:
     """
-    Add debug, quiet and verbose arguments.
+    Add debug, quiet, and verbose arguments.
 
     :param group: The group to add the arguments to.
-    :return: Check for mutual exclusivity of debug/quiet/verbose arguments.
+    :return: Check for mutual exclusivity of quiet/verbose arguments.
     """
     _add_arg_debug(group)
     _add_arg_quiet(group)
@@ -706,7 +706,7 @@ def _check_file_vs_format(file_arg: str, format_arg: str, args: Args) -> Args:
 
 
 def _check_verbosity(args) -> Args:
-    if sum([args.get(STR.debug, 0), args.get(STR.quiet, 0), args.get(STR.verbose, 0)]) > 1:
+    if args.get(STR.quiet) and (args.get(STR.debug) or args.get(STR.verbose)):
         _abort(
             "Specify at most one of %s, %s, or %s"
             % (_switch(STR.debug), _switch(STR.quiet), _switch(STR.verbose))

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -471,7 +471,9 @@ def _add_arg_debug(group: Group) -> None:
         _switch(STR.debug),
         "--debug",
         action="store_true",
-        help="Print all logging messages and the stack trace",
+        help="""
+        Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
+        """,
     )
 
 
@@ -707,10 +709,7 @@ def _check_file_vs_format(file_arg: str, format_arg: str, args: Args) -> Args:
 
 def _check_verbosity(args) -> Args:
     if args.get(STR.quiet) and (args.get(STR.debug) or args.get(STR.verbose)):
-        _abort(
-            "Specify at most one of %s, %s, or %s"
-            % (_switch(STR.debug), _switch(STR.quiet), _switch(STR.verbose))
-        )
+        _abort("--quiet may not be used with --debug or --verbose")
     return args
 
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -468,7 +468,6 @@ def _add_arg_cycle(group: Group) -> None:
 
 def _add_arg_debug(group: Group) -> None:
     group.add_argument(
-        _switch(STR.debug),
         "--debug",
         action="store_true",
         help="""
@@ -649,7 +648,7 @@ def _abort(msg: str) -> None:
     sys.exit(1)
 
 
-def _add_args_verbosity(group: Group) -> SubmodeChecks:
+def _add_args_verbosity(group: Group) -> ActionChecks:
     """
     Add debug, quiet, and verbose arguments.
 
@@ -709,7 +708,10 @@ def _check_file_vs_format(file_arg: str, format_arg: str, args: Args) -> Args:
 
 def _check_verbosity(args) -> Args:
     if args.get(STR.quiet) and (args.get(STR.debug) or args.get(STR.verbose)):
-        _abort("--quiet may not be used with --debug or --verbose")
+        _abort(
+            "%s may not be used with %s or %s"
+            % (_switch(STR.quiet), _switch(STR.debug), _switch(STR.verbose))
+        )
     return args
 
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -56,6 +56,8 @@ def main() -> None:
         }
         sys.exit(0 if modes[args[STR.mode]](args) else 1)
     except Exception as e:  # pylint: disable=broad-exception-caught
+        if _switch(STR.debug) in sys.argv:
+            log.exception(str(e))
         _abort(str(e))
 
 
@@ -641,8 +643,6 @@ def _abort(msg: str) -> None:
 
     :param msg: The message to print.
     """
-    if _switch(STR.debug) in sys.argv:
-        log.exception(msg)
     print(msg, file=sys.stderr)
     sys.exit(1)
 

--- a/src/uwtools/logging.py
+++ b/src/uwtools/logging.py
@@ -49,7 +49,7 @@ def setup_logging(quiet: bool = False, verbose: bool = False) -> None:
     for handler in logger.handlers:
         logger.removeHandler(handler)
     if quiet and verbose:
-        print("Specify at most one of 'quiet' and 'verbose'", file=sys.stderr)
+        print("--quiet may not be used with --debug or --verbose", file=sys.stderr)
         sys.exit(1)
     kwargs: dict = {
         "datefmt": "%Y-%m-%dT%H:%M:%S",

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -422,7 +422,7 @@ def test_main_debug_logs_stacktrace(caplog):
         with patch.object(sys, "argv", cli._switch(STR.debug)):
             with raises(SystemExit):
                 cli.main()
-    assert logged(caplog, "Traceback (most recent call last):")
+                assert logged(caplog, "Traceback (most recent call last):")
 
 
 @pytest.mark.parametrize("debug", [False])

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -30,6 +30,14 @@ def test__abort(capsys):
     assert msg in capsys.readouterr().err
 
 
+def test__abort_debug_logs_stacktrace(capsys):
+    msg = "Traceback (most recent call last)"
+    with patch.object(sys, "argv", STR.debug):
+        with raises(SystemExit):
+            cli._abort(msg)
+    assert msg in capsys.readouterr().err
+
+
 def test__add_subparser_config(subparsers):
     cli._add_subparser_config(subparsers)
     assert submodes(subparsers.choices[STR.config]) == [
@@ -133,7 +141,8 @@ def test__check_quiet_vs_verbose_fail(capsys):
     with raises(SystemExit):
         cli._check_quiet_vs_verbose(args)
     assert (
-        "Specify at most one of %s, %s" % (cli._switch(STR.quiet), cli._switch(STR.verbose))
+        "Specify at most one of %s, %s, or %s"
+        % (cli._switch(STR.debug), cli._switch(STR.quiet), cli._switch(STR.verbose))
         in capsys.readouterr().err
     )
 
@@ -425,11 +434,14 @@ def test__dispatch_template_render_yaml():
     )
 
 
+@pytest.mark.parametrize("debug", [False])
 @pytest.mark.parametrize("quiet", [True])
 @pytest.mark.parametrize("verbose", [False])
-def test_main_fail_checks(capsys, quiet, verbose):
+def test_main_fail_checks(capsys, debug, quiet, verbose):
     # Using mode 'template render' for testing.
     raw_args = ["testing", STR.template, STR.render]
+    if debug:
+        raw_args.append(cli._switch(STR.debug))
     if quiet:
         raw_args.append(cli._switch(STR.quiet))
     if verbose:

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -135,23 +135,6 @@ def test__check_file_vs_format_pass_implicit(fmt):
     assert args[STR.infmt] == vars(FORMAT)[fmt]
 
 
-def test__check_quiet_vs_verbose_fail(capsys):
-    log.setLevel(logging.INFO)
-    args = {STR.quiet: True, STR.verbose: True}
-    with raises(SystemExit):
-        cli._check_quiet_vs_verbose(args)
-    assert (
-        "Specify at most one of %s, %s, or %s"
-        % (cli._switch(STR.debug), cli._switch(STR.quiet), cli._switch(STR.verbose))
-        in capsys.readouterr().err
-    )
-
-
-def test__check_quiet_vs_verbose_ok():
-    args = {"foo": 88}
-    assert cli._check_quiet_vs_verbose(args) == args
-
-
 def test__check_template_render_vals_args_implicit_fail():
     # The values-file format cannot be deduced from the filename.
     args = {STR.valsfile: "a.jpg"}
@@ -177,6 +160,23 @@ def test__check_template_render_vals_args_noop_explicit_valsfmt():
     # An explicit values format is honored, valid or not.
     args = {STR.valsfile: "a.txt", STR.valsfmt: "jpg"}
     assert cli._check_template_render_vals_args(args) == args
+
+
+def test__check_verbosity_fail(capsys):
+    log.setLevel(logging.INFO)
+    args = {STR.quiet: True, STR.verbose: True}
+    with raises(SystemExit):
+        cli._check_verbosity(args)
+    assert (
+        "Specify at most one of %s, %s, or %s"
+        % (cli._switch(STR.debug), cli._switch(STR.quiet), cli._switch(STR.verbose))
+        in capsys.readouterr().err
+    )
+
+
+def test__check_verbosity_ok():
+    args = {"foo": 88}
+    assert cli._check_verbosity(args) == args
 
 
 def test__dict_from_key_eq_val_strings():

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -31,11 +31,12 @@ def test__abort(capsys):
 
 
 def test__abort_debug_logs_stacktrace(capsys):
-    msg = "Traceback (most recent call last)"
-    with patch.object(sys, "argv", STR.debug):
+    msg = "Aborting..."
+    trace = "Traceback (most recent call last)"
+    with patch.object(sys, "argv", cli._switch(STR.debug)):
         with raises(SystemExit):
             cli._abort(msg)
-    assert msg in capsys.readouterr().err
+    assert trace in capsys.readouterr().err
 
 
 def test__add_subparser_config(subparsers):
@@ -394,6 +395,35 @@ def test__dispatch_template_render_yaml():
     )
 
 
+def test__dispatch_template_translate():
+    args = {
+        STR.infile: 1,
+        STR.outfile: 2,
+        STR.dryrun: 3,
+    }
+    with patch.object(
+        uwtools.api.template, "_convert_atparse_to_jinja2"
+    ) as _convert_atparse_to_jinja2:
+        cli._dispatch_template_translate(args)
+    _convert_atparse_to_jinja2.assert_called_once_with(input_file=1, output_file=2, dry_run=3)
+
+
+def test__dispatch_template_translate_no_optional():
+    args = {
+        STR.dryrun: False,
+        STR.infile: None,
+        STR.outfile: None,
+    }
+    with patch.object(
+        uwtools.api.template, "_convert_atparse_to_jinja2"
+    ) as _convert_atparse_to_jinja2:
+        cli._dispatch_template_translate(args)
+    _convert_atparse_to_jinja2.assert_called_once_with(
+        input_file=None, output_file=None, dry_run=False
+    )
+
+
+@pytest.mark.parametrize("debug", [False])
 @pytest.mark.parametrize("quiet", [True])
 @pytest.mark.parametrize("verbose", [False])
 def test_main_fail_checks(capsys, debug, quiet, verbose):


### PR DESCRIPTION
**Synopsis**

Adds a --debug option to the CLI to also print the stack trace for an error.

Fixes issue #390 

**Type**

- [x] Documentation
- [ ] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)
- [ ] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
