### PR TITLE
nml-updates

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -35,7 +35,7 @@ class Config(ABC, UserDict):
             self.update(config)
         else:
             self._config_file = str(config) if config else None
-            self.update(self._load(self._config_file))
+            self.data = self._load(self._config_file)
         if self.get_depth_threshold() and self.depth != self.get_depth_threshold():
             raise UWConfigError(
                 "Cannot instantiate depth-%s %s with depth-%s config"

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -19,7 +19,7 @@ def depth(d: dict) -> int:
     :param d: The dictionary whose depth to calculate.
     :return: The length of the longest path to a value in the dictionary.
     """
-    return (max(map(depth, d.values())) + 1) if isinstance(d, dict) else 0
+    return (max(map(depth, d.values()), default=0) + 1) if isinstance(d, dict) else 0
 
 
 def format_to_config(fmt: str) -> Type:

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -180,24 +180,6 @@ def test_parse_include(config):
     assert len(config["config"]) == 2
 
 
-@pytest.mark.parametrize("fmt1", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
-@pytest.mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
-def test_transform_config(fmt1, fmt2, tmp_path):
-    """
-    Test that transforms config objects to objects of other config subclasses.
-    """
-    outfile = tmp_path / f"test_{fmt1}to{fmt2}_dump.{fmt2}"
-    reference = fixture_path(f"simple.{fmt2}")
-    cfgin = tools.format_to_config(fmt1)(fixture_path(f"simple.{fmt1}"))
-    tools.format_to_config(fmt2).dump_dict(cfg=cfgin.data, path=outfile)
-    with open(reference, "r", encoding="utf-8") as f1:
-        reflines = [line.strip().replace("'", "") for line in f1]
-    with open(outfile, "r", encoding="utf-8") as f2:
-        outlines = [line.strip().replace("'", "") for line in f2]
-    for line1, line2 in zip(reflines, outlines):
-        assert line1 == line2
-
-
 def test_update_values(config):
     """
     Test that a config object can be updated.

--- a/src/uwtools/tests/drivers/test_forecast.py
+++ b/src/uwtools/tests/drivers/test_forecast.py
@@ -13,7 +13,6 @@ import pytest
 from pytest import fixture, raises
 
 from uwtools import scheduler
-from uwtools.config.formats.nml import NMLConfig
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.drivers import forecast
 from uwtools.drivers.driver import Driver
@@ -167,20 +166,29 @@ def test_create_model_configure_call_private(tmp_path):
 
 @fixture
 def create_namelist_assets(tmp_path):
-    return NMLConfig(fixture_path("simple.nml")), tmp_path / "create_out.nml"
+    update_values = {
+        "salad": {
+            "base": "kale",
+            "fruit": "banana",
+            "vegetable": "tomato",
+            "how_many": 12,
+            "dressing": "balsamic",
+        }
+    }
+    return update_values, tmp_path / "create_out.nml"
 
 
 def test_create_namelist_with_base_file(create_namelist_assets, tmp_path):
     """
     Tests create_namelist method with optional base file.
     """
-    update_obj, outnml_file = create_namelist_assets
+    update_values, outnml_file = create_namelist_assets
     base_file = fixture_path("simple3.nml")
     fcst_config = {
         "forecast": {
             "namelist": {
                 "base_file": base_file,
-                "update_values": update_obj.data,
+                "update_values": update_values,
             },
         },
     }
@@ -208,11 +216,11 @@ def test_create_namelist_without_base_file(create_namelist_assets, tmp_path):
     """
     Tests create_namelist method without optional base file.
     """
-    update_obj, outnml_file = create_namelist_assets
+    update_values, outnml_file = create_namelist_assets
     fcst_config = {
         "forecast": {
             "namelist": {
-                "update_values": update_obj.data,
+                "update_values": update_values,
             },
         },
     }


### PR DESCRIPTION
**Synopsis**

Update `NMLConfig` to use, when instantiated from a namelist file, the `Namelist` object provided by `f90nml` as its `data` member, instead of converting the `Namelist` to a `dict`.

Behavior given the namelist file `a.nml`
```
&namsfc
  fsmcl(2) = 99999
  fsmcl(3) = 99999
  fsmcl(4) = 99999
/
```
Before:
```
% uw config realize --input-file a.nml --output-format nml
Cannot instantiate depth-2 NMLConfig with depth-3 config
```
After:
```
% uw config realize --input-file a.nml --output-format nml
&namsfc
    fsmcl(2:4) = 99999, 99999, 99999
/
```

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a breaking change (changes existing functionality)

See inline notes.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
