### PR TITLE
GH-406

### DIFF
--- a/docs/sections/user_guide/cli/mode_template.rst
+++ b/docs/sections/user_guide/cli/mode_template.rst
@@ -273,7 +273,7 @@ The examples in this section use atparse-formatted template file ``atparse.txt``
   .. code-block:: text
 
      $ uw template translate --input-file atparse.txt
-     {{greeting}}, {{recipient}}!
+     {{ greeting }}, {{ recipient }}!
 
   Shell redirection via ``|``, ``>``, et al. may also be used to stream output to a file, another process, etc.
 
@@ -287,11 +287,11 @@ The examples in this section use atparse-formatted template file ``atparse.txt``
 
   .. code-block:: jinja
 
-     {{greeting}}, {{recipient}}!
+     {{ greeting }}, {{ recipient }}!
 
 * With the ``--dry-run`` flag specified, nothing is written to ``stdout`` (or to a file if ``--output-file`` is specified), but a report of what would have been written is logged to ``stderr``:
 
   .. code-block:: text
 
      $ uw template translate --input-file atparse.txt --dry-run
-     [2024-01-03T16:41:13]     INFO {{greeting}}, {{recipient}}!
+     [2024-02-06T21:53:43]     INFO {{ greeting }}, {{ recipient }}!

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -29,8 +29,7 @@ def convert(
                 yield _replace(line)
 
     def write(f_out: IO) -> None:
-        for line in lines():
-            print(_replace(line), file=f_out)
+        f_out.write("\n".join(lines()))
 
     if dry_run:
         for line in lines():

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -24,7 +24,7 @@ def convert(
 
     with readable(input_file) as f:
         lines = f.read().split("\n")
-    jinja2 = "\n".join(_replace(line) for line in lines).rstrip()
+    jinja2 = re.sub(r"\n$", "", "\n".join(_replace(line) for line in lines), count=1)
     if dry_run:
         for line in jinja2.split("\n"):
             log.info(line)

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -3,7 +3,6 @@ Convert atparse templates to Jinja2 templates.
 """
 
 import re
-from typing import IO, Any, Generator
 
 from uwtools.logging import log
 from uwtools.utils.file import OptionalPath, readable, writable
@@ -23,20 +22,15 @@ def convert(
     :param dry_run: Run in dry-run mode?
     """
 
-    def lines() -> Generator[str, Any, Any]:
-        with readable(input_file) as f_in:
-            for line in f_in.read().split("\n"):
-                yield _replace(line)
-
-    def write(f_out: IO) -> None:
-        f_out.write("\n".join(lines()))
-
+    with readable(input_file) as f:
+        lines = f.read().split("\n")
+    jinja2 = "\n".join(_replace(line) for line in lines).rstrip()
     if dry_run:
-        for line in "\n".join(lines()).strip().split("\n"):
+        for line in jinja2.split("\n"):
             log.info(line)
     else:
         with writable(output_file) as f:
-            write(f)
+            print(jinja2, file=f)
 
 
 def _replace(atline: str) -> str:

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -23,14 +23,14 @@ def convert(
     """
 
     with readable(input_file) as f:
-        lines = f.read().split("\n")
-    jinja2 = re.sub(r"\n$", "", "\n".join(_replace(line) for line in lines), count=1)
+        lines = f.readlines()
+    jinja2 = "".join(_replace(line) for line in lines)
     if dry_run:
-        for line in jinja2.split("\n"):
+        for line in jinja2.removesuffix("\n").split("\n"):
             log.info(line)
     else:
         with writable(output_file) as f:
-            print(jinja2, file=f)
+            f.write(jinja2)
 
 
 def _replace(atline: str) -> str:

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -32,7 +32,7 @@ def convert(
         f_out.write("\n".join(lines()))
 
     if dry_run:
-        for line in lines():
+        for line in "\n".join(lines()).strip().split("\n"):
             log.info(line)
     else:
         with writable(output_file) as f:

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -25,12 +25,12 @@ def convert(
 
     def lines() -> Generator[str, Any, Any]:
         with readable(input_file) as f_in:
-            for line in f_in.read().strip().split("\n"):
-                yield _replace(line.strip())
+            for line in f_in.read().split("\n"):
+                yield _replace(line)
 
     def write(f_out: IO) -> None:
         for line in lines():
-            print(_replace(line.strip()), file=f_out)
+            print(_replace(line), file=f_out)
 
     if dry_run:
         for line in lines():
@@ -54,5 +54,5 @@ def _replace(atline: str) -> str:
         # Set maxsplits to 1 so only first ] is captured, which should be the
         # bracket closing @[.
         after_atparse = atline.split("@[", 1)[1].split("]", 1)[1]
-        atline = "".join([before_atparse, "{{", within_atparse, "}}", after_atparse])
+        atline = "".join([before_atparse, "{{ ", within_atparse, " }}", after_atparse])
     return atline

--- a/src/uwtools/tests/config/test_atparse_to_jinja2.py
+++ b/src/uwtools/tests/config/test_atparse_to_jinja2.py
@@ -119,7 +119,7 @@ def test_convert_stdin_to_logging(txt_atparse, caplog, txt_jinja2, tmp_path):
     _stdinproxy.cache_clear()
     with patch.object(sys, "stdin", new=StringIO(txt_atparse)):
         atparse_to_jinja2.convert(output_file=outfile, dry_run=True)
-    assert "\n".join(record.message for record in caplog.records) == txt_jinja2.strip()
+    assert "\n".join(record.message for record in caplog.records) == txt_jinja2
     assert not outfile.is_file()
 
 

--- a/src/uwtools/tests/config/test_atparse_to_jinja2.py
+++ b/src/uwtools/tests/config/test_atparse_to_jinja2.py
@@ -79,7 +79,7 @@ def test_convert_preserve_whitespace(tmp_path):
   @[third_entry]
     @[fourth_entry]
 
-        @[fifth_entry]
+        @[fifth_entry] @[sixth_entry]
 
 """
     infile = tmp_path / "atparse"
@@ -94,7 +94,7 @@ def test_convert_preserve_whitespace(tmp_path):
   {{ third_entry }}
     {{ fourth_entry }}
 
-        {{ fifth_entry }}
+        {{ fifth_entry }} {{ sixth_entry }}
 
 """
     with open(outfile, "r", encoding="utf-8") as f:

--- a/src/uwtools/tests/config/test_atparse_to_jinja2.py
+++ b/src/uwtools/tests/config/test_atparse_to_jinja2.py
@@ -73,28 +73,32 @@ def test_convert_input_file_to_stdout(atparsefile, capsys, txt_jinja2):
 
 def test_convert_preserve_whitespace(tmp_path):
     atparse = """
+
 @[first_entry]
   @[second_entry]
   @[third_entry]
     @[fourth_entry]
 
         @[fifth_entry]
-""".strip()
+
+"""
     infile = tmp_path / "atparse"
     with open(infile, "w", encoding="utf-8") as f:
         f.write(atparse)
     outfile = tmp_path / "jinja2"
     atparse_to_jinja2.convert(input_file=infile, output_file=outfile)
     expected = """
+
 {{ first_entry }}
   {{ second_entry }}
   {{ third_entry }}
     {{ fourth_entry }}
 
         {{ fifth_entry }}
-""".strip()
+
+"""
     with open(outfile, "r", encoding="utf-8") as f:
-        assert f.read().strip() == expected
+        assert f.read() == expected
 
 
 def test_convert_stdin_to_file(txt_atparse, capsys, txt_jinja2, tmp_path):


### PR DESCRIPTION
**Synopsis**

Fix bug that stripped whitespace from lines of an atparse input when translating to Jinja2. Fixes #406.

Demo:
```
% cat atparse
@[first_entry]
  @[second_entry]
  @[third_entry]
    @[fourth_entry]

        @[fifth entry]
```
```
% cat atparse | uw template translate
{{ first_entry }}
  {{ second_entry }}
  {{ third_entry }}
    {{ fourth_entry }}

        {{ fifth entry }}
```

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
