### PR TITLE
Obtain iotaa from conda-forge

### DIFF
--- a/recipe/channels
+++ b/recipe/channels
@@ -1,2 +1,1 @@
 conda-forge
-maddenp

--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -8,7 +8,7 @@
       "coverage =7.3.*",
       "docformatter =1.7.*",
       "f90nml =1.4.*",
-      "iotaa =0.7.1.*",
+      "iotaa =0.7.2.*",
       "isort =5.13.*",
       "jinja2 =3.1.*",
       "jq =1.7.*",
@@ -24,7 +24,7 @@
     ],
     "run": [
       "f90nml =1.4.*",
-      "iotaa =0.7.1.*",
+      "iotaa =0.7.2.*",
       "jinja2 =3.1.*",
       "jsonschema =4.20.*",
       "lxml =4.9.*",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - pip
   run:
     - f90nml 1.4.*
-    - iotaa 0.7.1.*
+    - iotaa 0.7.2.*
     - jinja2 3.1.*
     - jsonschema 4.20.*
     - lxml 4.9.*


### PR DESCRIPTION
**Synopsis**

Now that `iotaa` is available from `conda-forge`, obtain it from there.

Note that this works, too:
```
~/git/uwtools/src % python3 -m venv uw
~/git/uwtools/src % source uw/bin/activate
(uw) ~/git/uwtools/src % pip install .
...
(uw) ~/git/uwtools/src % uw --help
usage: uw [-h] MODE ...

Unified Workflow Tools

Optional arguments:
  -h, --help
      Show help and exit

Positional arguments:
  MODE
    config
      Handle configs
    fv3
      Execute FV3 tasks
    rocoto
      Realize and validate Rocoto XML Documents
    sfc_climo_gen
      Execute sfc_climo_gen tasks
    template
      Handle templates
```
Note that no `conda` is involved there -- that's pure `python` / `pip`.

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
