### PR TITLE
UW-510 Add uw template render --partial switch

### DIFF
--- a/docs/sections/user_guide/cli/tools/mode_template.rst
+++ b/docs/sections/user_guide/cli/tools/mode_template.rst
@@ -30,9 +30,8 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
    $ uw template render --help
    usage: uw template render [-h] [--input-file PATH] [--output-file PATH] [--values-file PATH]
-                             [--values-format {atparse,bash,cfg,fieldtable,ini,jinja2,nml,sh,yaml,yml}]
-                             [--values-needed] [--partial] [--dry-run] [--debug] [--quiet]
-                             [--verbose]
+                             [--values-format {ini,nml,sh,yaml}] [--values-needed] [--partial]
+                             [--dry-run] [--debug] [--quiet] [--verbose]
                              [KEY=VALUE ...]
 
    Render a template
@@ -46,7 +45,7 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
          Path to output file (defaults to stdout)
      --values-file PATH
          Path to file providing override or interpolation values
-     --values-format {atparse,bash,cfg,fieldtable,ini,jinja2,nml,sh,yaml,yml}
+     --values-format {ini,nml,sh,yaml}
          Values format
      --values-needed
          Print report of values needed to render template

--- a/docs/sections/user_guide/cli/tools/mode_template.rst
+++ b/docs/sections/user_guide/cli/tools/mode_template.rst
@@ -30,8 +30,9 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
    $ uw template render --help
    usage: uw template render [-h] [--input-file PATH] [--output-file PATH] [--values-file PATH]
-                             [--values-format {ini,nml,sh,yaml}] [--values-needed] [--dry-run]
-                             [--quiet] [--verbose]
+                             [--values-format {atparse,bash,cfg,fieldtable,ini,jinja2,nml,sh,yaml,yml}]
+                             [--values-needed] [--partial] [--dry-run] [--debug] [--quiet]
+                             [--verbose]
                              [KEY=VALUE ...]
 
    Render a template
@@ -45,10 +46,12 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
          Path to output file (defaults to stdout)
      --values-file PATH
          Path to file providing override or interpolation values
-     --values-format {ini,nml,sh,yaml}
+     --values-format {atparse,bash,cfg,fieldtable,ini,jinja2,nml,sh,yaml,yml}
          Values format
      --values-needed
          Print report of values needed to render template
+     --partial
+         Permit partial template rendering
      --dry-run
          Only log info, making no changes
      --debug
@@ -142,7 +145,14 @@ and a YAML file called ``values.yaml`` with the following contents:
      [2023-12-18T19:30:05]    ERROR Required value(s) not provided:
      [2023-12-18T19:30:05]    ERROR recipient
 
-  But values may be supplemented by ``key=value`` command-line arguments. For example:
+  But the ``--partial`` switch may be used to render as much as possible while passing expressions containing missing values through unchanged:
+
+  .. code-block:: text
+
+     $ uw template render --input-file template --values-file values.yaml --partial
+     Hello, {{ recipient }}!
+
+  Values may also be supplemented by ``key=value`` command-line arguments. For example:
 
   .. code-block:: text
 

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -15,6 +15,7 @@ def render(
     output_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
     values_needed: bool = False,
+    partial: bool = False,
     dry_run: bool = False,
 ) -> bool:
     """
@@ -34,6 +35,7 @@ def render(
         to ``stdout``)
     :param overrides: Supplemental override values
     :param values_needed: Just report variables needed to render the template?
+    :param partial: OK to leave unrendered expressions in template?
     :param dry_run: Run in dry-run mode?
     :return: ``True`` if Jinja2 template was successfully rendered, ``False`` otherwise
     """
@@ -44,6 +46,7 @@ def render(
         output_file=output_file,
         overrides=overrides,
         values_needed=values_needed,
+        partial=partial,
         dry_run=dry_run,
     )
 

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -35,7 +35,7 @@ def render(
         to ``stdout``)
     :param overrides: Supplemental override values
     :param values_needed: Just report variables needed to render the template?
-    :param partial: Permit unrendered expressions in template?
+    :param partial: Permit unrendered expressions in output?
     :param dry_run: Run in dry-run mode?
     :return: ``True`` if Jinja2 template was successfully rendered, ``False`` otherwise
     """

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -35,7 +35,7 @@ def render(
         to ``stdout``)
     :param overrides: Supplemental override values
     :param values_needed: Just report variables needed to render the template?
-    :param partial: OK to leave unrendered expressions in template?
+    :param partial: Permit unrendered expressions in template?
     :param dry_run: Run in dry-run mode?
     :return: ``True`` if Jinja2 template was successfully rendered, ``False`` otherwise
     """

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -23,7 +23,7 @@ import uwtools.rocoto
 from uwtools.logging import log, setup_logging
 from uwtools.utils.file import FORMAT, get_file_format
 
-FORMATS = list(FORMAT.formats().keys())
+FORMATS = FORMAT.extensions()
 TITLE_REQ_ARG = "Required arguments"
 
 Args = Dict[str, Any]

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -426,6 +426,7 @@ def _add_subparser_template_render(subparsers: Subparsers) -> ActionChecks:
     _add_arg_values_file(optional)
     _add_arg_values_format(optional, choices=FORMATS)
     _add_arg_values_needed(optional)
+    _add_arg_partial(optional)
     _add_arg_dry_run(optional)
     checks = _add_args_verbosity(optional)
     _add_arg_key_eq_val_pairs(optional)
@@ -459,6 +460,7 @@ def _dispatch_template_render(args: Args) -> bool:
         output_file=args[STR.outfile],
         overrides=_dict_from_key_eq_val_strings(args[STR.keyvalpairs]),
         values_needed=args[STR.valsneeded],
+        partial=args[STR.partial],
         dry_run=args[STR.dryrun],
     )
 
@@ -597,6 +599,14 @@ def _add_arg_output_format(group: Group, choices: List[str], required: bool = Fa
         help="Output format",
         required=required,
         type=str,
+    )
+
+
+def _add_arg_partial(group: Group) -> None:
+    group.add_argument(
+        _switch(STR.partial),
+        action="store_true",
+        help="Permit partial template rendering",
     )
 
 
@@ -840,6 +850,7 @@ class STR:
     model: str = "model"
     outfile: str = "output_file"
     outfmt: str = "output_format"
+    partial: str = "partial"
     quiet: str = "quiet"
     realize: str = "realize"
     render: str = "render"

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -166,9 +166,6 @@ def render(
     :param dry_run: Run in dry-run mode?
     :return: True if Jinja2 template was successfully rendered, False otherwise.
     """
-
-    # Render template.
-
     _report(locals())
     if not isinstance(values, dict):
         values = _set_up_values_obj(

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -162,7 +162,7 @@ def render(
     :param output_file: Path to write rendered Jinja2 template to (None => write to stdout).
     :param overrides: Supplemental override values.
     :param values_needed: Just report variables needed to render the template?
-    :param partial: OK to leave unrendered expressions in template?
+    :param partial: Permit unrendered expressions in template?
     :param dry_run: Run in dry-run mode?
     :return: True if Jinja2 template was successfully rendered, False otherwise.
     """

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -149,6 +149,7 @@ def render(
     output_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
     values_needed: bool = False,
+    partial: bool = False,
     dry_run: bool = False,
 ) -> bool:
     """
@@ -160,6 +161,7 @@ def render(
     :param output_file: Path to write rendered Jinja2 template to (None => write to stdout).
     :param overrides: Supplemental override values.
     :param values_needed: Just report variables needed to render the template?
+    :param partial: OK to leave unrendered expressions in template?
     :param dry_run: Run in dry-run mode?
     :return: Jinja2 template was successfully rendered.
     """
@@ -191,11 +193,12 @@ def render(
 
     # In dry-run mode, log the rendered template. Otherwise, write the rendered template.
 
-    return (
-        _dry_run_template(template.render())
-        if dry_run
-        else _write_template(output_file, template.render())
+    rendered = (
+        Environment(undefined=StrictUndefined).from_string(template_str).render(values)
+        if partial
+        else template.render()
     )
+    return _dry_run_template(rendered) if dry_run else _write_template(output_file, rendered)
 
 
 # Private functions

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -162,7 +162,7 @@ def render(
     :param output_file: Path to write rendered Jinja2 template to (None => write to stdout).
     :param overrides: Supplemental override values.
     :param values_needed: Just report variables needed to render the template?
-    :param partial: Permit unrendered expressions in template?
+    :param partial: Permit unrendered expressions in output?
     :param dry_run: Run in dry-run mode?
     :return: True if Jinja2 template was successfully rendered, False otherwise.
     """

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -182,8 +182,8 @@ def render(
     if values_needed:
         return _values_needed(undeclared_variables)
 
-    # If partial rendering has not been requested, check for missing values required to render the
-    # template, report any found, then return False.
+    # If partial rendering has been requested, do a best-effort render. Otherwise, report any
+    # missing values and return an error to the caller.
 
     if partial:
         rendered = Environment(undefined=DebugUndefined).from_string(template_str).render(values)
@@ -193,7 +193,7 @@ def render(
             return _log_missing_values(missing)
         rendered = template.render()
 
-    # In dry-run mode, log the rendered template. Otherwise, write the rendered template.
+    # Log (dry-run mode) or write the rendered template.
 
     return _dry_run_template(rendered) if dry_run else _write_template(output_file, rendered)
 

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -12,6 +12,7 @@ def test_render():
         "values": "valsfile",
         "values_format": "format",
         "overrides": {"key": "val"},
+        "partial": True,
         "values_needed": True,
         "dry_run": True,
     }

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -382,6 +382,7 @@ def test__dispatch_template_render_no_optional():
         STR.valsfmt: None,
         STR.keyvalpairs: [],
         STR.valsneeded: False,
+        STR.partial: False,
         STR.dryrun: False,
     }
     with patch.object(uwtools.api.template, "render") as render:
@@ -393,6 +394,7 @@ def test__dispatch_template_render_no_optional():
         values_format=None,
         overrides={},
         values_needed=False,
+        partial=False,
         dry_run=False,
     )
 
@@ -405,7 +407,8 @@ def test__dispatch_template_render_yaml():
         STR.valsfmt: 4,
         STR.keyvalpairs: ["foo=88", "bar=99"],
         STR.valsneeded: 6,
-        STR.dryrun: 7,
+        STR.partial: 7,
+        STR.dryrun: 8,
     }
     with patch.object(uwtools.api.template, "render") as render:
         cli._dispatch_template_render(args)
@@ -416,7 +419,8 @@ def test__dispatch_template_render_yaml():
         values_format=4,
         overrides={"foo": "88", "bar": "99"},
         values_needed=6,
-        dry_run=7,
+        partial=7,
+        dry_run=8,
     )
 
 


### PR DESCRIPTION
**Synopsis**

A new `--partial` flag for the `uw template render` mode/action permits partial rendering of templates, i.e., unrenderable values are passed through unchanged and without error.

Old behavior:
```
% echo "{{ greeting }} {{ recipient }}" | greeting=Hello uw template render
[2024-02-27T22:19:18]    ERROR Required value(s) not provided:
[2024-02-27T22:19:18]    ERROR recipient
```

New behavior:
```
% echo "{{ greeting }} {{ recipient }}" | greeting=Hello uw template render --partial
Hello {{ recipient }}
```
**Type**

- [x] Documentation
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
