### PR TITLE
UW-512: Add render_to_str() to API

### DIFF
--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -222,7 +222,7 @@ Recognized file extensions are: {extensions}
 :param values_needed: Report complete, missing, and template values
 :param total: Require rendering of all Jinja2 variables/expressions
 :param dry_run: Log output instead of writing to output
-:raises: UWConfigError if ``total`` is ``True`` and any Jinja2 variable/expression was not rendered
+:raises: UWConfigRealizeError if ``total`` is ``True`` and any Jinja2 variable/expression was not rendered
 :return: ``True``
 """.format(
     extensions=", ".join(_FORMAT.extensions())

--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -115,7 +115,7 @@ def realize(
     )
 
 
-def realize_to_dict(
+def realize_to_dict(  # pylint: disable=unused-argument
     input_config: Union[dict, _Config, Optional[Path]] = None,
     input_format: Optional[str] = None,
     supplemental_configs: Optional[List[Union[dict, _Config, Path]]] = None,
@@ -123,17 +123,11 @@ def realize_to_dict(
     dry_run: bool = False,
 ) -> dict:
     """
-    NB: This docstring is dynamically replaced: See realize_to_dict.__doc__ definition below.
+    Realize an output config to a dict, based on an input config and optional supplemental configs.
+
+    See ``realize()`` for details on arguments, etc.
     """
-    return _realize(
-        input_config=_ensure_config_arg_type(input_config),
-        input_format=input_format,
-        output_file=Path(os.devnull),
-        output_format=None,
-        supplemental_configs=supplemental_configs,
-        values_needed=values_needed,
-        dry_run=dry_run,
-    )
+    return _realize(**{**locals(), "output_file": Path(os.devnull), "output_format": None})
 
 
 def validate(
@@ -222,34 +216,6 @@ Recognized file extensions are: {extensions}
 :param total: Require rendering of all Jinja2 variables/expressions
 :param dry_run: Log output instead of writing to output
 :raises: UWConfigRealizeError if ``total`` is ``True`` and any Jinja2 variable/expression was not rendered
-""".format(
-    extensions=", ".join(_FORMAT.extensions())
-).strip()
-
-
-realize_to_dict.__doc__ = """
-Realize an output config based on an input config and optional supplemental configs.
-
-If no input is specified, ``stdin`` is read. A ``dict`` or ``Config`` object may also be provided as
-input. When an input filename is specified, its format will be deduced from its extension, if
-possible. This can be overridden by specifying the format explicitly, and it is required to do so for
-reads from ``stdin``, as no attempt is made to deduce the format of streamed data.
-
-If optional supplemental configs (which may likewise be file paths or ``Config`` / ``dict`` objects)
-are provided, they will be merged, in the order specified, onto the input config. The format of all
-input configs must match.
-
-If ``values_needed`` is ``True``, a report of values needed to realize the config is logged. In
-``dry_run`` mode, output is written to ``stderr``.
-
-Recognized file extensions are: {extensions}
-
-:param input_config: Input config file (``None`` or unspecified => read ``stdin``)
-:param input_format: Format of the input config (optional if file's extension is recognized)
-:param supplemental_configs: Configs to merge, in order, onto the input
-:param values_needed: Report complete, missing, and template values
-:param dry_run: Log output instead of writing to output
-:return: A ``dict`` representing the realized config
 """.format(
     extensions=", ".join(_FORMAT.extensions())
 ).strip()

--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -99,7 +99,7 @@ def realize(
     values_needed: bool = False,
     total: bool = False,
     dry_run: bool = False,
-) -> bool:
+) -> None:
     """
     NB: This docstring is dynamically replaced: See realize.__doc__ definition below.
     """
@@ -113,7 +113,6 @@ def realize(
         total=total,
         dry_run=dry_run,
     )
-    return True
 
 
 def realize_to_dict(
@@ -223,7 +222,6 @@ Recognized file extensions are: {extensions}
 :param total: Require rendering of all Jinja2 variables/expressions
 :param dry_run: Log output instead of writing to output
 :raises: UWConfigRealizeError if ``total`` is ``True`` and any Jinja2 variable/expression was not rendered
-:return: ``True``
 """.format(
     extensions=", ".join(_FORMAT.extensions())
 ).strip()

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional, Union
 
 from uwtools.config.atparse_to_jinja2 import convert as _convert_atparse_to_jinja2
 from uwtools.config.jinja2 import render as _render
+from uwtools.exceptions import UWTemplateRenderError
 
 
 def render(
@@ -17,7 +18,7 @@ def render(
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,
-) -> bool:
+) -> None:
     """
     Render a Jinja2 template based on specified values.
 
@@ -37,18 +38,22 @@ def render(
     :param values_needed: Just report variables needed to render the template?
     :param partial: Permit unrendered Jinja2 variables/expressions in output?
     :param dry_run: Run in dry-run mode?
-    :return: ``True`` if Jinja2 template was successfully rendered, ``False`` otherwise
+    :raises: UWTemplateRenderError if template could not be rendered
     """
-    return _render(
-        values=values,
-        values_format=values_format,
-        input_file=input_file,
-        output_file=output_file,
-        overrides=overrides,
-        values_needed=values_needed,
-        partial=partial,
-        dry_run=dry_run,
-    )
+    if (
+        _render(
+            values=values,
+            values_format=values_format,
+            input_file=input_file,
+            output_file=output_file,
+            overrides=overrides,
+            values_needed=values_needed,
+            partial=partial,
+            dry_run=dry_run,
+        )
+        is None
+    ):
+        raise UWTemplateRenderError("Could not render template")
 
 
 # def render_to_str(

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -51,6 +51,21 @@ def render(
     )
 
 
+# def render_to_str(
+#     values: Union[dict, Path],
+#     values_format: Optional[str] = None,
+#     input_file: Optional[Path] = None,
+#     overrides: Optional[Dict[str, str]] = None,
+#     values_needed: bool = False,
+#     partial: bool = False,
+#     dry_run: bool = False,
+# ) -> str:
+#     """
+#     ???
+#     """
+#     pass
+
+
 def translate(
     input_file: Optional[Path] = None,
     output_file: Optional[Path] = None,

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -21,7 +21,7 @@ def render(
     dry_run: bool = False,
 ) -> str:
     """
-    Render a Jinja2 template based on specified values.
+    Render a Jinja2 template to a file, based on specified values.
 
     Primary values used to render the template are taken from the specified file. The format of the
     values source will be deduced from the filename extension, if possible. This can be overridden
@@ -67,7 +67,9 @@ def render_to_str(  # pylint: disable=unused-argument
     dry_run: bool = False,
 ) -> str:
     """
-    ???
+    Render a Jinja2 template to a string, based on specified values.
+
+    See ``render()`` for details on arguments, etc.
     """
     return render({**locals(), "output_file": Path(os.devnull)})
 

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -71,7 +71,7 @@ def render_to_str(  # pylint: disable=unused-argument
 
     See ``render()`` for details on arguments, etc.
     """
-    return render({**locals(), "output_file": Path(os.devnull)})
+    return render(**{**locals(), "output_file": Path(os.devnull)})
 
 
 def translate(

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -1,6 +1,7 @@
 """
 API access to uwtools templating logic.
 """
+import os
 from pathlib import Path
 from typing import Dict, Optional, Union
 
@@ -18,7 +19,7 @@ def render(
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,
-) -> None:
+) -> str:
     """
     Render a Jinja2 template based on specified values.
 
@@ -38,37 +39,37 @@ def render(
     :param values_needed: Just report variables needed to render the template?
     :param partial: Permit unrendered Jinja2 variables/expressions in output?
     :param dry_run: Run in dry-run mode?
+    :return: The rendered template string
     :raises: UWTemplateRenderError if template could not be rendered
     """
-    if (
-        _render(
-            values=values,
-            values_format=values_format,
-            input_file=input_file,
-            output_file=output_file,
-            overrides=overrides,
-            values_needed=values_needed,
-            partial=partial,
-            dry_run=dry_run,
-        )
-        is None
-    ):
+    result = _render(
+        values=values,
+        values_format=values_format,
+        input_file=input_file,
+        output_file=output_file,
+        overrides=overrides,
+        values_needed=values_needed,
+        partial=partial,
+        dry_run=dry_run,
+    )
+    if result is None:
         raise UWTemplateRenderError("Could not render template")
+    return result
 
 
-# def render_to_str(
-#     values: Union[dict, Path],
-#     values_format: Optional[str] = None,
-#     input_file: Optional[Path] = None,
-#     overrides: Optional[Dict[str, str]] = None,
-#     values_needed: bool = False,
-#     partial: bool = False,
-#     dry_run: bool = False,
-# ) -> str:
-#     """
-#     ???
-#     """
-#     pass
+def render_to_str(  # pylint: disable=unused-argument
+    values: Union[dict, Path],
+    values_format: Optional[str] = None,
+    input_file: Optional[Path] = None,
+    overrides: Optional[Dict[str, str]] = None,
+    values_needed: bool = False,
+    partial: bool = False,
+    dry_run: bool = False,
+) -> str:
+    """
+    ???
+    """
+    return render({**locals(), "output_file": Path(os.devnull)})
 
 
 def translate(

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -20,7 +20,7 @@ import uwtools.api.sfc_climo_gen
 import uwtools.api.template
 import uwtools.config.jinja2
 import uwtools.rocoto
-from uwtools.exceptions import UWConfigRealizeError
+from uwtools.exceptions import UWConfigRealizeError, UWTemplateRenderError
 from uwtools.logging import log, setup_logging
 from uwtools.utils.file import FORMAT, get_file_format
 
@@ -183,7 +183,7 @@ def _dispatch_config_realize(args: Args) -> bool:
     :param args: Parsed command-line args.
     """
     try:
-        return uwtools.api.config.realize(
+        uwtools.api.config.realize(
             input_config=args[STR.infile],
             input_format=args[STR.infmt],
             output_file=args[STR.outfile],
@@ -195,9 +195,10 @@ def _dispatch_config_realize(args: Args) -> bool:
         )
     except UWConfigRealizeError:
         log.error(
-            "Config could not be realized. Try again with %s for details." % _switch(STR.valsneeded)
+            "Config could not be realized. Try with %s for details." % _switch(STR.valsneeded)
         )
-        sys.exit(1)
+        return False
+    return True
 
 
 def _dispatch_config_validate(args: Args) -> bool:
@@ -466,16 +467,22 @@ def _dispatch_template_render(args: Args) -> bool:
 
     :param args: Parsed command-line args.
     """
-    return uwtools.api.template.render(
-        values=args[STR.valsfile],
-        values_format=args[STR.valsfmt],
-        input_file=args[STR.infile],
-        output_file=args[STR.outfile],
-        overrides=_dict_from_key_eq_val_strings(args[STR.keyvalpairs]),
-        values_needed=args[STR.valsneeded],
-        partial=args[STR.partial],
-        dry_run=args[STR.dryrun],
-    )
+    try:
+        uwtools.api.template.render(
+            values=args[STR.valsfile],
+            values_format=args[STR.valsfmt],
+            input_file=args[STR.infile],
+            output_file=args[STR.outfile],
+            overrides=_dict_from_key_eq_val_strings(args[STR.keyvalpairs]),
+            values_needed=args[STR.valsneeded],
+            partial=args[STR.partial],
+            dry_run=args[STR.dryrun],
+        )
+    except UWTemplateRenderError:
+        msg = "Template could not be rendered. Try with %s for details." % _switch(STR.valsneeded)
+        log.error(msg)
+        return False
+    return True
 
 
 def _dispatch_template_translate(args: Args) -> bool:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -20,7 +20,7 @@ import uwtools.api.sfc_climo_gen
 import uwtools.api.template
 import uwtools.config.jinja2
 import uwtools.rocoto
-from uwtools.exceptions import UWConfigError
+from uwtools.exceptions import UWConfigRealizeError
 from uwtools.logging import log, setup_logging
 from uwtools.utils.file import FORMAT, get_file_format
 
@@ -193,7 +193,7 @@ def _dispatch_config_realize(args: Args) -> bool:
             total=args[STR.total],
             dry_run=args[STR.dryrun],
         )
-    except UWConfigError:
+    except UWConfigRealizeError:
         log.error(
             "Config could not be realized. Try again with %s for details." % _switch(STR.valsneeded)
         )

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -9,7 +9,7 @@ from uwtools.config.formats.base import Config
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.jinja2 import unrendered
 from uwtools.config.support import depth, format_to_config, log_and_error
-from uwtools.exceptions import UWConfigError, UWError
+from uwtools.exceptions import UWConfigRealizeError, UWError
 from uwtools.logging import MSGWIDTH, log
 from uwtools.utils.file import FORMAT, get_file_format
 
@@ -108,7 +108,7 @@ def realize_config(
         _realize_config_values_needed(input_obj)
         return {}
     if total and unrendered(str(input_obj)):
-        raise UWConfigError("Config could not be totally realized")
+        raise UWConfigRealizeError("Config could not be totally realized")
     output_class = format_to_config(output_format)
     output_class.dump_dict(cfg=input_obj.data, path=output_file)
     return input_obj.data
@@ -319,7 +319,7 @@ Recognized file extensions are: {extensions}
 :param values_needed: Report complete, missing, and template values.
 :param total: Require rendering of all Jinja2 variables/expressions.
 :param dry_run: Log output instead of writing to output.
-:raises: UWConfigError if ``total`` is ``True`` and config cannot be totally realized.
+:raises: UWConfigRealizeError if ``total`` is ``True`` and config cannot be totally realized.
 :return: The realized config (or an empty-dict for no-op modes).
 """.format(
     extensions=", ".join(FORMAT.extensions())

--- a/src/uwtools/exceptions.py
+++ b/src/uwtools/exceptions.py
@@ -1,21 +1,27 @@
 """
-Custom exceptions for the UWTools package.
+Custom uwtools exceptions.
 """
 
 
 class UWError(Exception):
     """
-    A class representing generic exceptions for UWTools.
+    A class representing generic uwtools exceptions.
     """
 
 
 class UWConfigError(UWError):
     """
-    UWTools exception for general Config object error handling.
+    Exception for generic config error handling.
     """
 
 
 class UWConfigRealizeError(UWConfigError):
     """
-    UWTools exception arising from issues realizing configs.
+    Exception for issues arising from config realization.
+    """
+
+
+class UWTemplateRenderError(UWError):
+    """
+    Exception for issues arising from template rendering.
     """

--- a/src/uwtools/exceptions.py
+++ b/src/uwtools/exceptions.py
@@ -11,5 +11,11 @@ class UWError(Exception):
 
 class UWConfigError(UWError):
     """
-    UWTools exception for Config Object error handling.
+    UWTools exception for general Config object error handling.
+    """
+
+
+class UWConfigRealizeError(UWConfigError):
+    """
+    UWTools exception arising from issues realizing configs.
     """

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -1,12 +1,16 @@
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring,redefined-outer-name
 
 from unittest.mock import patch
 
+from pytest import fixture, raises
+
 from uwtools.api import template
+from uwtools.exceptions import UWTemplateRenderError
 
 
-def test_render():
-    kwargs: dict = {
+@fixture
+def kwargs():
+    return {
         "input_file": "infile",
         "output_file": "outfile",
         "values": "valsfile",
@@ -16,9 +20,18 @@ def test_render():
         "values_needed": True,
         "dry_run": True,
     }
+
+
+def test_render(kwargs):
     with patch.object(template, "_render") as _render:
         template.render(**kwargs)
     _render.assert_called_once_with(**kwargs)
+
+
+def test_render_fail(kwargs):
+    with patch.object(template, "_render", return_value=None):
+        with raises(UWTemplateRenderError):
+            template.render(**kwargs)
 
 
 def test_translate():

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-function-docstring,redefined-outer-name
 
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 from pytest import fixture, raises
@@ -32,6 +34,13 @@ def test_render_fail(kwargs):
     with patch.object(template, "_render", return_value=None):
         with raises(UWTemplateRenderError):
             template.render(**kwargs)
+
+
+def test_render_to_str(kwargs):
+    del kwargs["output_file"]
+    with patch.object(template, "render") as render:
+        template.render_to_str(**kwargs)
+        render.assert_called_once_with(**{**kwargs, "output_file": Path(os.devnull)})
 
 
 def test_translate():

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -222,7 +222,7 @@ def test_render_partial(caplog, capsys, partial):
     content = StringIO(initial_value="{{ greeting }} {{ recipient }}")
     with patch.object(jinja2, "readable") as readable:
         readable.return_value.__enter__.return_value = content
-        assert jinja2.render(values={"greeting": "Hello"}, partial=partial) is partial
+        jinja2.render(values={"greeting": "Hello"}, partial=partial)
     if partial:
         assert "Hello {{ recipient }}" in capsys.readouterr().out
     else:
@@ -305,8 +305,7 @@ def test__dry_run_template(caplog):
 
 def test__log_missing_values(caplog):
     missing = ["roses_color", "violets_color"]
-    result = jinja2._log_missing_values(missing)
-    assert result is False
+    jinja2._log_missing_values(missing)
     assert logged(caplog, "Required value(s) not provided:")
     assert logged(caplog, "roses_color")
     assert logged(caplog, "violets_color")
@@ -341,8 +340,7 @@ def test__set_up_config_obj_file(values_file):
 
 def test__values_needed(caplog):
     undeclared_variables = {"roses_color", "lavender_smell"}
-    result = jinja2._values_needed(undeclared_variables)
-    assert result is True
+    jinja2._values_needed(undeclared_variables)
     assert logged(caplog, "Value(s) needed to render this template are:")
     assert logged(caplog, "roses_color")
     assert logged(caplog, "lavender_smell")

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -55,7 +55,7 @@ cannot:
 
 
 def render_helper(input_file, values_file, **kwargs):
-    jinja2.render(
+    return jinja2.render(
         input_file=input_file,
         values=values_file,
         **kwargs,
@@ -163,9 +163,11 @@ def test_register_filters_path_join(key):
 
 def test_render(values_file, template, tmp_path):
     outfile = str(tmp_path / "out.txt")
-    render_helper(input_file=template, values_file=values_file, output_file=outfile)
+    expected = "roses are red, violets are blue"
+    result = render_helper(input_file=template, values_file=values_file, output_file=outfile)
+    assert result == expected
     with open(outfile, "r", encoding="utf-8") as f:
-        assert f.read().strip() == "roses are red, violets are blue"
+        assert f.read().strip() == expected
 
 
 def test_render_calls__dry_run(template, tmp_path, values_file):
@@ -210,10 +212,12 @@ def test_render_calls__write(template, tmp_path, values_file):
 
 def test_render_dry_run(caplog, template, values_file):
     log.setLevel(logging.INFO)
-    render_helper(
+    expected = "roses are red, violets are blue"
+    result = render_helper(
         input_file=template, values_file=values_file, output_file="/dev/null", dry_run=True
     )
-    assert logged(caplog, "roses are red, violets are blue")
+    assert result == expected
+    assert logged(caplog, expected)
 
 
 @pytest.mark.parametrize("partial", [False, True])

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -19,7 +19,7 @@ import uwtools.drivers.fv3
 import uwtools.drivers.sfc_climo_gen
 from uwtools import cli
 from uwtools.cli import STR
-from uwtools.exceptions import UWConfigError, UWError
+from uwtools.exceptions import UWConfigRealizeError, UWError
 from uwtools.logging import log
 from uwtools.tests.support import logged, regex_logged
 from uwtools.utils.file import FORMAT
@@ -300,7 +300,7 @@ def test__dispatch_config_realize_fail(caplog):
             STR.dryrun,
         )
     }
-    with patch.object(cli.uwtools.api.config, "realize", side_effect=UWConfigError):
+    with patch.object(cli.uwtools.api.config, "realize", side_effect=UWConfigRealizeError):
         with raises(SystemExit):
             cli._dispatch_config_realize(args)
     assert regex_logged(caplog, "Config could not be realized")

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -301,8 +301,7 @@ def test__dispatch_config_realize_fail(caplog):
         )
     }
     with patch.object(cli.uwtools.api.config, "realize", side_effect=UWConfigRealizeError):
-        with raises(SystemExit):
-            cli._dispatch_config_realize(args)
+        assert cli._dispatch_config_realize(args) is False
     assert regex_logged(caplog, "Config could not be realized")
 
 


### PR DESCRIPTION
**Synopsis**

Supplement `uwtools.api.template.render()` with a new `uwtools.api.template.render_to_str()` for API users who would like not to create intermediate disk files.

**Type**

- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
