### PR TITLE
Omnibus 2024-03-01

### DIFF
--- a/src/uwtools/api/fv3.py
+++ b/src/uwtools/api/fv3.py
@@ -5,8 +5,7 @@ import datetime as dt
 from pathlib import Path
 from typing import Dict, Optional
 
-import iotaa as _iotaa
-
+from uwtools.drivers import support
 from uwtools.drivers.fv3 import FV3
 
 
@@ -30,7 +29,7 @@ def execute(
     :param batch: Submit run to the batch system
     :param dry_run: Do not run forecast, just report what would have been done
     :param graph_file: Write Graphviz DOT output here
-    :return: True if task completes without raising an exception
+    :return: ``True`` if task completes without raising an exception
     """
     obj = FV3(config_file=config_file, cycle=cycle, batch=batch, dry_run=dry_run)
     getattr(obj, task)()
@@ -44,13 +43,11 @@ def graph() -> str:
     """
     Returns Graphviz DOT code for the most recently executed task.
     """
-    return _iotaa.graph()
+    return support.graph()
 
 
 def tasks() -> Dict[str, str]:
     """
     Returns a mapping from task names to their one-line descriptions.
     """
-    return {
-        task: getattr(FV3, task).__doc__.strip().split("\n")[0] for task in _iotaa.tasknames(FV3)
-    }
+    return support.tasks(FV3)

--- a/src/uwtools/api/sfc_climo_gen.py
+++ b/src/uwtools/api/sfc_climo_gen.py
@@ -4,8 +4,7 @@ API access to the uwtools sfc_climo_gen driver.
 from pathlib import Path
 from typing import Dict, Optional
 
-import iotaa as _iotaa
-
+from uwtools.drivers import support
 from uwtools.drivers.sfc_climo_gen import SfcClimoGen
 
 
@@ -27,7 +26,7 @@ def execute(
     :param batch: Submit run to the batch system
     :param dry_run: Do not run forecast, just report what would have been done
     :param graph_file: Write Graphviz DOT output here
-    :return: True if task completes without raising an exception
+    :return: ``True`` if task completes without raising an exception
     """
     obj = SfcClimoGen(config_file=config_file, batch=batch, dry_run=dry_run)
     getattr(obj, task)()
@@ -41,14 +40,11 @@ def graph() -> str:
     """
     Returns Graphviz DOT code for the most recently executed task.
     """
-    return _iotaa.graph()
+    return support.graph()
 
 
 def tasks() -> Dict[str, str]:
     """
     Returns a mapping from task names to their one-line descriptions.
     """
-    return {
-        task: getattr(SfcClimoGen, task).__doc__.strip().split("\n")[0]
-        for task in _iotaa.tasknames(SfcClimoGen)
-    }
+    return support.tasks(SfcClimoGen)

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -5,7 +5,7 @@ from typing import Optional
 import yaml
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import INCLUDE_TAG, TaggedString, add_representers, log_and_error
+from uwtools.config.support import INCLUDE_TAG, TaggedString, add_yaml_representers, log_and_error
 from uwtools.utils.file import FORMAT, readable, writable
 
 _MSGS = ns(
@@ -44,7 +44,7 @@ class YAMLConfig(Config):
         """
         The string representation of a YAMLConfig object.
         """
-        add_representers()
+        add_yaml_representers()
         return yaml.dump(self.data, default_flow_style=False).strip()
 
     # Private methods
@@ -115,7 +115,7 @@ class YAMLConfig(Config):
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to.
         """
-        add_representers()
+        add_yaml_representers()
         with writable(path) as f:
             yaml.dump(cfg, f, sort_keys=False)
 

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -17,7 +17,7 @@ INCLUDE_TAG = "!INCLUDE"
 # Public functions
 
 
-def add_representers() -> None:
+def add_yaml_representers() -> None:
     """
     Add representers to the YAML dumper for custom types.
     """

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -72,27 +72,22 @@ def log_and_error(msg: str) -> Exception:
 
 def _represent_namelist(dumper: yaml.Dumper, data: Namelist) -> yaml.nodes.MappingNode:
     """
-    Convert f90nml Namelist to OrderedDict and serialize.
+    Convert an f90nml Namelist to an OrderedDict, then represent as a YAML mapping.
 
     :param dumper: The YAML dumper.
     :param data: The f90nml Namelist to serialize.
     """
-
-    # Convert the f90nml Namelist to an OrderedDict, then represent as a YAML mapping.
-
     namelist_dict = data.todict()
     return dumper.represent_mapping("tag:yaml.org,2002:map", namelist_dict)
 
 
 def _represent_ordereddict(dumper: yaml.Dumper, data: OrderedDict) -> yaml.nodes.MappingNode:
     """
-    Convert OrderedDict to dict and serialize.
+    Recursrively convert an OrderedDict to a dict, then represent as a YAML mapping.
 
     :param dumper: The YAML dumper.
     :param data: The OrderedDict to serialize.
     """
-
-    # Recursrively convert an OrderedDict to a dict, then represent as a YAML mapping.
 
     def from_od(d: Union[OrderedDict, Dict]) -> dict:
         return {key: from_od(val) if isinstance(val, dict) else val for key, val in d.items()}

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -15,6 +15,8 @@ INCLUDE_TAG = "!INCLUDE"
 
 
 # Public functions
+
+
 def add_representers() -> None:
     """
     Add representers to the YAML dumper for custom types.
@@ -66,6 +68,8 @@ def log_and_error(msg: str) -> Exception:
 
 
 # Private functions
+
+
 def _represent_namelist(dumper: yaml.Dumper, data: Namelist) -> yaml.nodes.MappingNode:
     """
     Convert f90nml Namelist to OrderedDict and serialize.
@@ -73,10 +77,10 @@ def _represent_namelist(dumper: yaml.Dumper, data: Namelist) -> yaml.nodes.Mappi
     :param dumper: The YAML dumper.
     :param data: The f90nml Namelist to serialize.
     """
-    # Convert the f90nml Namelist to an OrderedDict.
-    namelist_dict = data.todict()
 
-    # Represent the OrderedDict as a YAML mapping.
+    # Convert the f90nml Namelist to an OrderedDict, then represent as a YAML mapping.
+
+    namelist_dict = data.todict()
     return dumper.represent_mapping("tag:yaml.org,2002:map", namelist_dict)
 
 
@@ -88,11 +92,11 @@ def _represent_ordereddict(dumper: yaml.Dumper, data: OrderedDict) -> yaml.nodes
     :param data: The OrderedDict to serialize.
     """
 
-    # Convert the OrderedDict to a dict.
+    # Recursrively convert an OrderedDict to a dict, then represent as a YAML mapping.
+
     def from_od(d: Union[OrderedDict, Dict]) -> dict:
         return {key: from_od(val) if isinstance(val, dict) else val for key, val in d.items()}
 
-    # Represent the dict as a YAML mapping.
     return dumper.represent_mapping("tag:yaml.org,2002:map", from_od(data))
 
 

--- a/src/uwtools/drivers/support.py
+++ b/src/uwtools/drivers/support.py
@@ -1,0 +1,22 @@
+from typing import Dict
+
+import iotaa as _iotaa
+
+from uwtools.drivers.driver import Driver
+
+
+def graph() -> str:
+    """
+    Returns Graphviz DOT code for the most recently executed task.
+    """
+    return _iotaa.graph()
+
+
+def tasks(driver_class: type[Driver]) -> Dict[str, str]:
+    """
+    Returns a mapping from task names to their one-line descriptions.
+    """
+    return {
+        task: getattr(driver_class, task).__doc__.strip().split("\n")[0]
+        for task in _iotaa.tasknames(driver_class)
+    }

--- a/src/uwtools/tests/api/test_fv3.py
+++ b/src/uwtools/tests/api/test_fv3.py
@@ -3,8 +3,6 @@
 import datetime as dt
 from unittest.mock import patch
 
-from iotaa import asset, external, task, tasks
-
 from uwtools.api import fv3
 
 
@@ -25,30 +23,12 @@ def test_execute(tmp_path):
 
 
 def test_graph():
-    @external
-    def ready():
-        yield "ready"
-        yield asset("ready", lambda: True)
-
-    ready()
-    assert fv3.graph().startswith("digraph")
+    with patch.object(fv3.support, "graph") as graph:
+        fv3.graph()
+    graph.assert_called_once_with()
 
 
 def test_tasks():
-    @external
-    def t1():
-        "@external t1"
-
-    @task
-    def t2():
-        "@task t2"
-
-    @tasks
-    def t3():
-        "@tasks t3"
-
-    with patch.object(fv3, "FV3") as FV3:
-        FV3.t1 = t1
-        FV3.t2 = t2
-        FV3.t3 = t3
-        assert fv3.tasks() == {"t2": "@task t2", "t3": "@tasks t3", "t1": "@external t1"}
+    with patch.object(fv3.support, "tasks") as _tasks:
+        fv3.tasks()
+    _tasks.assert_called_once_with(fv3.FV3)

--- a/src/uwtools/tests/api/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/api/test_sfc_climo_gen.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import patch
 
-from iotaa import asset, external, task, tasks
-
 from uwtools.api import sfc_climo_gen
 
 
@@ -23,30 +21,12 @@ def test_execute(tmp_path):
 
 
 def test_graph():
-    @external
-    def ready():
-        yield "ready"
-        yield asset("ready", lambda: True)
-
-    ready()
-    assert sfc_climo_gen.graph().startswith("digraph")
+    with patch.object(sfc_climo_gen.support, "graph") as graph:
+        sfc_climo_gen.graph()
+    graph.assert_called_once_with()
 
 
 def test_tasks():
-    @external
-    def t1():
-        "@external t1"
-
-    @task
-    def t2():
-        "@task t2"
-
-    @tasks
-    def t3():
-        "@tasks t3"
-
-    with patch.object(sfc_climo_gen, "SfcClimoGen") as SfcClimoGen:
-        SfcClimoGen.t1 = t1
-        SfcClimoGen.t2 = t2
-        SfcClimoGen.t3 = t3
-        assert sfc_climo_gen.tasks() == {"t2": "@task t2", "t3": "@tasks t3", "t1": "@external t1"}
+    with patch.object(sfc_climo_gen.support, "tasks") as _tasks:
+        sfc_climo_gen.tasks()
+    _tasks.assert_called_once_with(sfc_climo_gen.SfcClimoGen)

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -6,9 +6,10 @@ Tests for uwtools.config.jinja2 module.
 import logging
 from collections import OrderedDict
 
+import f90nml  # type: ignore
 import pytest
 import yaml
-from f90nml import Namelist, reads  # type: ignore
+from f90nml import Namelist
 from pytest import fixture, raises
 
 from uwtools.config import support
@@ -67,7 +68,7 @@ def test_log_and_error(caplog):
 
 
 def test_represent_namelist():
-    namelist = reads("&namelist\n key = value\n/\n")
+    namelist = f90nml.reads("&namelist\n key = value\n/\n")
     assert yaml.dump(namelist, default_flow_style=True).strip() == "{namelist: {key: value}}"
 
 

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -24,8 +24,8 @@ from uwtools.tests.support import logged
 from uwtools.utils.file import FORMAT
 
 
-def test_add_representers():
-    support.add_representers()
+def test_add_yaml_representers():
+    support.add_yaml_representers()
     representers = yaml.Dumper.yaml_representers
     assert support.TaggedString in representers
     assert OrderedDict in representers

--- a/src/uwtools/tests/drivers/test_support.py
+++ b/src/uwtools/tests/drivers/test_support.py
@@ -1,0 +1,46 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring
+"""
+Tests for uwtools.drivers.support module.
+"""
+from iotaa import asset, external, task, tasks
+
+from uwtools.drivers import support
+from uwtools.drivers.driver import Driver
+
+
+def test_graph():
+    @external
+    def ready():
+        yield "ready"
+        yield asset("ready", lambda: True)
+
+    ready()
+    assert support.graph().startswith("digraph")
+
+
+def test_tasks():
+    class SomeDriver(Driver):
+        @external
+        def t1(self):
+            "@external t1"
+
+        @task
+        def t2(self):
+            "@task t2"
+
+        @tasks
+        def t3(self):
+            "@tasks t3"
+
+        @property
+        def _driver_config(self):
+            pass
+
+        @property
+        def _resources(self):
+            pass
+
+        def _validate(self):
+            pass
+
+    assert support.tasks(SomeDriver) == {"t2": "@task t2", "t3": "@tasks t3", "t1": "@external t1"}


### PR DESCRIPTION
**Synopsis**

Several minor updates:

- Remove the `--debug` CLI switch and do not try to catch raised exceptions.
- DRY out some graph-related logic in two drivers to a support module, and update tests.
- Rename `add_representers()` -> `add_yaml_representers()` as the YAML part may not be clear from context.
- Tweak some whitespace and comments.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a breaking change (changes existing functionality)

i.e. the `--debug` switch is removed, but the behavior it provided is now the default.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
