### PR TITLE
UW-523 Support Jinja2 template loading

### DIFF
--- a/docs/sections/user_guide/cli/tools/mode_template.rst
+++ b/docs/sections/user_guide/cli/tools/mode_template.rst
@@ -30,8 +30,8 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
    $ uw template render --help
    usage: uw template render [-h] [--input-file PATH] [--output-file PATH] [--values-file PATH]
-                             [--values-format {ini,nml,sh,yaml}] [--values-needed] [--partial]
-                             [--dry-run] [--debug] [--quiet] [--verbose]
+                             [--values-format {ini,nml,sh,yaml}] [--env] [--values-needed]
+                             [--partial] [--dry-run] [--quiet] [--verbose]
                              [KEY=VALUE ...]
 
    Render a template
@@ -47,14 +47,14 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
          Path to file providing override or interpolation values
      --values-format {ini,nml,sh,yaml}
          Values format
+     --env
+         Use environment variables
      --values-needed
          Print report of values needed to render template
      --partial
          Permit partial template rendering
      --dry-run
          Only log info, making no changes
-     --debug
-         Print all log messages, plus any unhandled exception's stack trace (implies --verbose)
      --quiet, -q
          Print no logging messages
      --verbose, -v
@@ -84,8 +84,8 @@ and a YAML file called ``values.yaml`` with the following contents:
 
      $ uw template render --input-file template --values-needed
      [2023-12-18T19:16:08]     INFO Value(s) needed to render this template are:
-     [2023-12-18T19:16:08]     INFO greeting
-     [2023-12-18T19:16:08]     INFO recipient
+     [2023-12-18T19:16:08]     INFO   greeting
+     [2023-12-18T19:16:08]     INFO   recipient
 
 * To render the template to ``stdout``:
 
@@ -135,35 +135,6 @@ and a YAML file called ``values.yaml`` with the following contents:
 
      $ uw template render --input-file template --values-file values.txt --values-format yaml
      Hello, World!
-
-* It is an error to render a template without providing all needed values. For example, with ``recipient: World`` removed from ``values.yaml``:
-
-  .. code-block:: text
-
-     $ uw template render --input-file template --values-file values.yaml
-     [2023-12-18T19:30:05]    ERROR Required value(s) not provided:
-     [2023-12-18T19:30:05]    ERROR recipient
-
-  But the ``--partial`` switch may be used to render as much as possible while passing expressions containing missing values through unchanged:
-
-  .. code-block:: text
-
-     $ uw template render --input-file template --values-file values.yaml --partial
-     Hello, {{ recipient }}!
-
-  Values may also be supplemented by ``key=value`` command-line arguments. For example:
-
-  .. code-block:: text
-
-     $ uw template render --input-file template --values-file values.yaml recipient=Reader
-     Hello, Reader!
-
-  Such ``key=value`` arguments may also be used to *override* file-based values:
-
-  .. code-block:: text
-
-     $ uw template render --input-file template --values-file values.yaml recipient=Reader greeting="Good day"
-     Good day, Reader!
 
 * To request verbose log output:
 
@@ -215,6 +186,48 @@ and a YAML file called ``values.yaml`` with the following contents:
      [2023-12-18T23:27:04]    DEBUG ---------------------------------------------------------------------
      [2023-12-18T23:27:04]    DEBUG Read initial values from values.yaml
 
+**NB**: The following examples are based on a ``values.yaml`` file with ``recipient: World`` removed.
+
+* It is an error to render a template without providing all needed values.
+
+  .. code-block:: text
+
+   $ uw template render --input-file template --values-file values.yaml
+   [2024-03-02T16:42:48]    ERROR Required value(s) not provided:
+   [2024-03-02T16:42:48]    ERROR   recipient
+   [2024-03-02T16:42:48]    ERROR Template could not be rendered.
+
+  But the ``--partial`` switch may be used to render as much as possible while passing expressions containing missing values through unchanged:
+
+  .. code-block:: text
+
+     $ uw template render --input-file template --values-file values.yaml --partial
+     Hello, {{ recipient }}!
+
+  Values may also be supplemented by ``key=value`` command-line arguments:
+
+  .. code-block:: text
+
+     $ uw template render --input-file template --values-file values.yaml recipient=Reader
+     Hello, Reader!
+
+  The optional ``-env`` switch allows environment variables to be used to supply values:
+
+  .. code-block:: text
+
+     $ export recipient=You
+     $ uw template render --input-file template --values-file values.yaml --env
+     Hello, You!
+
+  Values from ``key=value`` arguments override values from file, and environment variables override both:
+
+  .. code-block:: text
+
+     $ recipient=Sunshine uw template render --input-file template --values-file values.yaml recipient=Reader greeting="Good day" --env
+     Good day, Sunshine!
+
+  Note that ``recipient=Sunshine`` is shell syntax for exporting environment variable ``recipient`` only for the duration of the command that follows. It should not be confused with the two ``key=value`` pairs later on the command line, which are arguments to ``uw``.
+
 * Non-YAML-formatted files may also be used as value sources. For example, ``template``
 
   .. code-block:: jinja
@@ -236,8 +249,6 @@ and a YAML file called ``values.yaml`` with the following contents:
 
      $ uw template render --input-file template --values-file values.nml
      Hello, World!
-
-  Note that ``ini`` and ``nml`` configs are, by definition, depth-2 configs, while ``sh`` configs are depth-1, and ``yaml`` configs have arbitrary depth.
 
 .. _cli_template_translate_examples:
 

--- a/docs/sections/user_guide/cli/tools/mode_template.rst
+++ b/docs/sections/user_guide/cli/tools/mode_template.rst
@@ -188,9 +188,9 @@ and a YAML file called ``values.yaml`` with the following contents:
      [2023-12-18T23:27:04]    DEBUG ---------------------------------------------------------------------
      [2023-12-18T23:27:04]    DEBUG Read initial values from values.yaml
 
-**NB**: The following examples are based on a ``values.yaml`` file with ``recipient: World`` removed.
+* **NB**: This set of examples is based on a ``values.yaml`` file with ``recipient: World`` removed.
 
-* It is an error to render a template without providing all needed values.
+  It is an error to render a template without providing all needed values.
 
   .. code-block:: text
 

--- a/docs/sections/user_guide/cli/tools/mode_template.rst
+++ b/docs/sections/user_guide/cli/tools/mode_template.rst
@@ -30,8 +30,9 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
 
    $ uw template render --help
    usage: uw template render [-h] [--input-file PATH] [--output-file PATH] [--values-file PATH]
-                             [--values-format {ini,nml,sh,yaml}] [--env] [--search-path SEARCH_PATH]
-                             [--values-needed] [--partial] [--dry-run] [--quiet] [--verbose]
+                             [--values-format {ini,nml,sh,yaml}] [--env]
+                             [--search-path PATH[:PATH:...]] [--values-needed] [--partial]
+                             [--dry-run] [--quiet] [--verbose]
                              [KEY=VALUE ...]
 
    Render a template

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -3,7 +3,7 @@ API access to uwtools templating logic.
 """
 import os
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from uwtools.config.atparse_to_jinja2 import convert as _convert_atparse_to_jinja2
 from uwtools.config.jinja2 import render as _render
@@ -17,7 +17,7 @@ def render(
     output_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
     env: bool = False,
-    searchpath: Optional[str] = None,
+    searchpath: Optional[List[str]] = None,
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,
@@ -39,7 +39,7 @@ def render(
         to ``stdout``)
     :param overrides: Supplemental override values
     :param env: Supplement values with environment variables?
-    :param searchpath: Colon-separated paths to search for extra templates
+    :param searchpath: Paths to search for extra templates
     :param values_needed: Just report variables needed to render the template?
     :param partial: Permit unrendered Jinja2 variables/expressions in output?
     :param dry_run: Run in dry-run mode?
@@ -69,7 +69,7 @@ def render_to_str(  # pylint: disable=unused-argument
     input_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
     env: bool = False,
-    searchpath: Optional[str] = None,
+    searchpath: Optional[List[str]] = None,
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -11,11 +11,12 @@ from uwtools.exceptions import UWTemplateRenderError
 
 
 def render(
-    values: Union[dict, Path],
+    values_src: Optional[Union[dict, Path]] = None,
     values_format: Optional[str] = None,
     input_file: Optional[Path] = None,
     output_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
+    env: bool = False,
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,
@@ -29,13 +30,14 @@ def render(
     primary values source. If no input file is specified, ``stdin`` is read. If no output file is
     specified, ``stdout`` is written to.
 
-    :param values: Source of values to render the template
+    :param values_src: Source of values to render the template
     :param values_format: Format of values when sourced from file
     :param input_file: Path to read raw Jinja2 template from (``None`` or unspecified => read
         ``stdin``)
     :param output_file: Path to write rendered Jinja2 template to (``None`` or unspecified => write
         to ``stdout``)
     :param overrides: Supplemental override values
+    :param env: Supplement values with environment variables?
     :param values_needed: Just report variables needed to render the template?
     :param partial: Permit unrendered Jinja2 variables/expressions in output?
     :param dry_run: Run in dry-run mode?
@@ -43,11 +45,12 @@ def render(
     :raises: UWTemplateRenderError if template could not be rendered
     """
     result = _render(
-        values=values,
+        values_src=values_src,
         values_format=values_format,
         input_file=input_file,
         output_file=output_file,
         overrides=overrides,
+        env=env,
         values_needed=values_needed,
         partial=partial,
         dry_run=dry_run,
@@ -58,10 +61,11 @@ def render(
 
 
 def render_to_str(  # pylint: disable=unused-argument
-    values: Union[dict, Path],
+    values_src: Optional[Union[dict, Path]] = None,
     values_format: Optional[str] = None,
     input_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
+    env: bool = False,
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -17,6 +17,7 @@ def render(
     output_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
     env: bool = False,
+    searchpath: Optional[str] = None,
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,
@@ -38,6 +39,7 @@ def render(
         to ``stdout``)
     :param overrides: Supplemental override values
     :param env: Supplement values with environment variables?
+    :param searchpath: Colon-separated paths to search for extra templates
     :param values_needed: Just report variables needed to render the template?
     :param partial: Permit unrendered Jinja2 variables/expressions in output?
     :param dry_run: Run in dry-run mode?
@@ -51,6 +53,7 @@ def render(
         output_file=output_file,
         overrides=overrides,
         env=env,
+        searchpath=searchpath,
         values_needed=values_needed,
         partial=partial,
         dry_run=dry_run,
@@ -66,6 +69,7 @@ def render_to_str(  # pylint: disable=unused-argument
     input_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
     env: bool = False,
+    searchpath: Optional[str] = None,
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -669,7 +669,7 @@ def _add_arg_search_path(group: Group) -> None:
         help="Colon-separated paths to search for extra templates",
         metavar="PATH[:PATH:...]",
         required=False,
-        type=str,
+        type=lambda s: s.split(":"),
     )
 
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -442,6 +442,7 @@ def _add_subparser_template_render(subparsers: Subparsers) -> ActionChecks:
     _add_arg_values_file(optional)
     _add_arg_values_format(optional, choices=FORMATS)
     _add_arg_env(optional)
+    _add_arg_search_path(optional)
     _add_arg_values_needed(optional)
     _add_arg_partial(optional)
     _add_arg_dry_run(optional)
@@ -658,6 +659,15 @@ def _add_arg_schema_file(group: Group) -> None:
         metavar="PATH",
         required=True,
         type=Path,
+    )
+
+
+def _add_arg_search_path(group: Group) -> None:
+    group.add_argument(
+        _switch(STR.searchpath),
+        help="Colon-separated paths to search for extra templates",
+        required=False,
+        type=str,
     )
 
 
@@ -894,6 +904,7 @@ class STR:
     rocoto: str = "rocoto"
     run: str = "run"
     schemafile: str = "schema_file"
+    searchpath: str = "search_path"
     sfcclimogen: str = "sfc_climo_gen"
     suppfiles: str = "supplemental_files"
     task: str = "task"

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -479,6 +479,7 @@ def _dispatch_template_render(args: Args) -> bool:
             output_file=args[STR.outfile],
             overrides=_dict_from_key_eq_val_strings(args[STR.keyvalpairs]),
             env=args[STR.env],
+            searchpath=args[STR.searchpath],
             values_needed=args[STR.valsneeded],
             partial=args[STR.partial],
             dry_run=args[STR.dryrun],
@@ -666,6 +667,7 @@ def _add_arg_search_path(group: Group) -> None:
     group.add_argument(
         _switch(STR.searchpath),
         help="Colon-separated paths to search for extra templates",
+        metavar="PATH[:PATH:...]",
         required=False,
         type=str,
     )

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -7,15 +7,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
-from jinja2 import (
-    BaseLoader,
-    DebugUndefined,
-    Environment,
-    FileSystemLoader,
-    StrictUndefined,
-    Undefined,
-    meta,
-)
+from jinja2 import DebugUndefined, Environment, FileSystemLoader, StrictUndefined, Undefined, meta
 from jinja2.exceptions import UndefinedError
 
 from uwtools.config.support import TaggedString, format_to_config
@@ -46,10 +38,12 @@ class J2Template:
         self._template_source = template_source
         self._j2env = Environment(
             loader=FileSystemLoader(
-                searchpath=searchpath.split(":") if searchpath else self._template_source.parent
+                searchpath=searchpath.split(":")
+                if searchpath
+                else self._template_source.parent
+                if isinstance(self._template_source, Path)
+                else []
             )
-            if isinstance(self._template_source, Path)
-            else BaseLoader()  # PM FIX THIS
         )
         _register_filters(self._j2env)
         self._template = self._j2env.from_string(self._template_str)

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -49,7 +49,7 @@ class J2Template:
                 searchpath=searchpath.split(":") if searchpath else self._template_source.parent
             )
             if isinstance(self._template_source, Path)
-            else BaseLoader()
+            else BaseLoader()  # PM FIX THIS
         )
         _register_filters(self._j2env)
         self._template = self._j2env.from_string(self._template_str)

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -26,7 +26,7 @@ class J2Template:
         self,
         values: dict,
         template_source: Optional[Union[str, Path]] = None,
-        searchpath: Optional[str] = None,
+        searchpath: Optional[List[str]] = None,
     ) -> None:
         """
         :param values: Values needed to render the provided template.
@@ -38,7 +38,7 @@ class J2Template:
         self._template_source = template_source
         self._j2env = Environment(
             loader=FileSystemLoader(
-                searchpath=searchpath.split(":")
+                searchpath=searchpath
                 if searchpath
                 else self._template_source.parent
                 if isinstance(self._template_source, Path)
@@ -139,7 +139,7 @@ def render(
     output_file: Optional[Path] = None,
     overrides: Optional[Dict[str, str]] = None,
     env: bool = False,
-    searchpath: Optional[str] = None,
+    searchpath: Optional[List[str]] = None,
     values_needed: bool = False,
     partial: bool = False,
     dry_run: bool = False,
@@ -153,7 +153,7 @@ def render(
     :param output_file: Path to write rendered Jinja2 template to (None => write to stdout).
     :param overrides: Supplemental override values.
     :param env: Supplement values with environment variables?
-    :param searchpath: Colon-separated paths to search for extra templates.
+    :param searchpath: Paths to search for extra templates.
     :param values_needed: Just report variables needed to render the template?
     :param partial: Permit unrendered Jinja2 variables/expressions in output?
     :param dry_run: Run in dry-run mode?

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -25,7 +25,7 @@ class J2Template:
     def __init__(
         self,
         values: dict,
-        template_source: Optional[Union[str, Path]],
+        template_source: Optional[Union[str, Path]] = None,
         searchpath: Optional[str] = None,
     ) -> None:
         """

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -39,7 +39,7 @@ class J2Template:
         self._values = values
         self._template_source = template_source
         self._j2env = Environment(
-            loader=FileSystemLoader(searchpath="/FIXME")
+            loader=FileSystemLoader(searchpath=[self._template_source.parent])
             if isinstance(self._template_source, Path)
             else BaseLoader()
         )

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -15,9 +15,10 @@ def kwargs():
     return {
         "input_file": "infile",
         "output_file": "outfile",
-        "values": "valsfile",
+        "values_src": "valsfile",
         "values_format": "format",
         "overrides": {"key": "val"},
+        "env": True,
         "partial": True,
         "values_needed": True,
         "dry_run": True,

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -18,6 +18,7 @@ def kwargs():
         "values_src": "valsfile",
         "values_format": "format",
         "overrides": {"key": "val"},
+        "searchpath": None,
         "env": True,
         "partial": True,
         "values_needed": True,

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -507,12 +507,12 @@ class Test_Jinja2Template:
     def test_searchpath_file_one_path(self, searchpath_assets):
         # If a search path is specified, it will suppress use of the default path:
         a = searchpath_assets
-        assert J2Template(values={}, template_source=a.t1, searchpath=f"{a.d1}").render() == "2"
+        assert J2Template(values={}, template_source=a.t1, searchpath=[a.d1]).render() == "2"
 
     def test_searchpath_file_two_paths(self, searchpath_assets):
         # Multiple search paths can be specified:
         a = searchpath_assets
-        result = J2Template(values={}, template_source=a.t2, searchpath=f"{a.d1}:{a.d2}").render()
+        result = J2Template(values={}, template_source=a.t2, searchpath=[a.d1, a.d2]).render()
         assert result == "23"
 
     def test_searchpath_stdin_default(self, searchpath_assets):
@@ -528,4 +528,4 @@ class Test_Jinja2Template:
         a = searchpath_assets
         with patch.object(jinja2, "readable") as readable:
             readable.return_value.__enter__.return_value = StringIO(a.s1)
-            assert J2Template(values={}, searchpath=f"{a.d1}").render() == "2"
+            assert J2Template(values={}, searchpath=[a.d1]).render() == "2"

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -449,6 +449,27 @@ class Test_Jinja2Template:
     """
 
     @fixture
+    def searchpath_assets(self, tmp_path):
+        def write(s, *args):
+            path = tmp_path.joinpath(*list(args))
+            path.parent.mkdir(exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                print(s, file=f)
+            return path
+
+        write("{% macro double(x) %}{{ x }}{{ x }}{% endmacro %}", "m1.jinja")
+        d1 = write("{% macro double(x) %}{{ x * 2 }}{% endmacro %}", "d1", "m1.jinja").parent
+        d2 = write("{% macro triple(x) %}{{ x * 3 }}{% endmacro %}", "d2", "m2.jinja").parent
+        t1 = write("{% import 'm1.jinja' as m1 %}{{ m1.double(1) }}", "t1.jinja")
+        t2s = (
+            "{% import 'm1.jinja' as m1 %}"
+            "{% import 'm2.jinja' as m2 %}"
+            "{{ m1.double(1) }}{{ m2.triple(1) }}"
+        )
+        t2 = write(t2s, "t2.jinja")
+        return d1, d2, t1, t2
+
+    @fixture
     def testdata(self):
         return ns(
             config={"greeting": "Hello", "recipient": "the world"},
@@ -457,8 +478,8 @@ class Test_Jinja2Template:
 
     def test_dump(self, testdata, tmp_path):
         path = tmp_path / "rendered.txt"
-        j2template = J2Template(values=testdata.config, template_source=testdata.template)
-        j2template.dump(output_path=path)
+        obj = J2Template(values=testdata.config, template_source=testdata.template)
+        obj.dump(output_path=path)
         with open(path, "r", encoding="utf-8") as f:
             assert f.read().strip() == "Hello to the world"
 
@@ -470,3 +491,18 @@ class Test_Jinja2Template:
 
     def test_render_string(self, testdata):
         validate(J2Template(values=testdata.config, template_source=testdata.template))
+
+    def test_searchpath_file_default(self, searchpath_assets):
+        # By default, the template search path will be the directory containing the main template:
+        _, _, t1, _ = searchpath_assets
+        assert J2Template(values={}, template_source=t1).render() == "11"
+
+    def test_searchpath_file_one_path(self, searchpath_assets):
+        # If a search path is specified, it will suppress use of the default path:
+        d1, _, t1, _ = searchpath_assets
+        assert J2Template(values={}, template_source=t1, searchpath=f"{d1}").render() == "2"
+
+    def test_searchpath_file_two_paths(self, searchpath_assets):
+        # Multiple search paths can be specified:
+        d1, d2, _, t2 = searchpath_assets
+        assert J2Template(values={}, template_source=t2, searchpath=f"{d1}:{d2}").render() == "23"

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -30,11 +30,20 @@ def deref_render_assets():
 
 
 @fixture
+def supplemental_values(tmp_path):
+    d = {"foo": "bar", "another": "value"}
+    valsfile = tmp_path / "values.yaml"
+    with open(valsfile, "w", encoding="utf-8") as f:
+        yaml.dump(d, f)
+    return ns(d=d, e={"CYCLE": "2024030112"}, f=valsfile, o={"baz": "qux"})
+
+
+@fixture
 def template(tmp_path):
     path = tmp_path / "template.jinja2"
     with open(path, "w", encoding="utf-8") as f:
         f.write("roses are {{roses_color}}, violets are {{violets_color}}")
-    return str(path)
+    return path
 
 
 @fixture
@@ -48,7 +57,7 @@ cannot:
 """.strip()
     with open(path, "w", encoding="utf-8") as f:
         f.write(yaml)
-    return str(path)
+    return path
 
 
 # Helpers
@@ -57,7 +66,7 @@ cannot:
 def render_helper(input_file, values_file, **kwargs):
     return jinja2.render(
         input_file=input_file,
-        values=values_file,
+        values_src=values_file,
         **kwargs,
     )
 
@@ -226,12 +235,12 @@ def test_render_partial(caplog, capsys, partial):
     content = StringIO(initial_value="{{ greeting }} {{ recipient }}")
     with patch.object(jinja2, "readable") as readable:
         readable.return_value.__enter__.return_value = content
-        jinja2.render(values={"greeting": "Hello"}, partial=partial)
+        jinja2.render(values_src={"greeting": "Hello"}, partial=partial)
     if partial:
         assert "Hello {{ recipient }}" in capsys.readouterr().out
     else:
         assert logged(caplog, "Required value(s) not provided:")
-        assert logged(caplog, "recipient")
+        assert logged(caplog, "  recipient")
 
 
 def test_render_values_missing(caplog, template, values_file):
@@ -244,7 +253,7 @@ def test_render_values_missing(caplog, template, values_file):
         f.write(yaml.dump(cfgobj))
     render_helper(input_file=template, values_file=values_file, output_file="/dev/null")
     assert logged(caplog, "Required value(s) not provided:")
-    assert logged(caplog, "roses_color")
+    assert logged(caplog, "  roses_color")
 
 
 def test_render_values_needed(caplog, template, values_file):
@@ -253,7 +262,7 @@ def test_render_values_needed(caplog, template, values_file):
         input_file=template, values_file=values_file, output_file="/dev/null", values_needed=True
     )
     for var in ("roses_color", "violets_color"):
-        assert logged(caplog, var)
+        assert logged(caplog, f"  {var}")
 
 
 @pytest.mark.parametrize("s,status", [("foo: bar", False), ("foo: '{{ bar }} {{ baz }}'", True)])
@@ -311,8 +320,8 @@ def test__log_missing_values(caplog):
     missing = ["roses_color", "violets_color"]
     jinja2._log_missing_values(missing)
     assert logged(caplog, "Required value(s) not provided:")
-    assert logged(caplog, "roses_color")
-    assert logged(caplog, "violets_color")
+    assert logged(caplog, "  roses_color")
+    assert logged(caplog, "  violets_color")
 
 
 def test__report(caplog):
@@ -328,26 +337,96 @@ longish_variable: 88
     assert "\n".join(record.message for record in caplog.records) == expected
 
 
-def test__set_up_config_obj_env():
-    expected = {"roses_color": "white", "violets_color": "blue"}
-    with patch.dict(os.environ, expected, clear=True):
-        actual = jinja2._set_up_values_obj()
-    assert actual["roses_color"] == "white"
-    assert actual["violets_color"] == "blue"
+def test__supplement_values():
+    assert jinja2._supplement_values() == {}
 
 
-def test__set_up_config_obj_file(values_file):
-    expected = {"roses_color": "white", "violets_color": "blue", "cannot": {"override": "this"}}
-    actual = jinja2._set_up_values_obj(values_file=values_file, overrides={"roses_color": "white"})
-    assert actual == expected
+def test__supplement_values_dict(supplemental_values):
+    sv = supplemental_values
+    assert jinja2._supplement_values(values_src=sv.d) == sv.d
+
+
+def test__supplement_values_dict_plus_env(supplemental_values):
+    sv = supplemental_values
+    with patch.dict(os.environ, sv.e, clear=True):
+        assert jinja2._supplement_values(values_src=sv.d, env=True) == {**sv.d, **sv.e}
+
+
+def test__supplement_values_dict_plus_env_plus_overrides(supplemental_values):
+    sv = supplemental_values
+    with patch.dict(os.environ, sv.e, clear=True):
+        assert jinja2._supplement_values(values_src=sv.d, env=True, overrides=sv.o) == {
+            **sv.d,
+            **sv.e,
+            **sv.o,
+        }
+
+
+def test__supplement_values_dict_plus_overrides(supplemental_values):
+    sv = supplemental_values
+    assert jinja2._supplement_values(values_src=sv.d, overrides=sv.o) == {**sv.d, **sv.o}
+
+
+def test__supplement_values_env(supplemental_values):
+    sv = supplemental_values
+    with patch.dict(os.environ, sv.e, clear=True):
+        assert jinja2._supplement_values(env=True) == sv.e
+
+
+def test__supplement_values_env_plus_overrides(supplemental_values):
+    sv = supplemental_values
+    with patch.dict(os.environ, sv.e, clear=True):
+        assert jinja2._supplement_values(env=True, overrides=sv.o) == {**sv.o, **sv.e}
+
+
+def test__supplement_values_overrides(supplemental_values):
+    sv = supplemental_values
+    assert jinja2._supplement_values(overrides=sv.o) == sv.o
+
+
+def test__supplement_values_file(supplemental_values):
+    sv = supplemental_values
+    assert jinja2._supplement_values(values_src=sv.f) == sv.d
+
+
+def test__supplement_values_file_plus_env(supplemental_values):
+    sv = supplemental_values
+    with patch.dict(os.environ, sv.e, clear=True):
+        assert jinja2._supplement_values(values_src=sv.f, env=True) == {**sv.d, **sv.e}
+
+
+def test__supplement_values_file_plus_env_plus_overrides(supplemental_values):
+    sv = supplemental_values
+    with patch.dict(os.environ, sv.e, clear=True):
+        assert jinja2._supplement_values(values_src=sv.f, env=True, overrides=sv.o) == {
+            **sv.d,
+            **sv.e,
+            **sv.o,
+        }
+
+
+def test__supplement_values_file_plus_overrides(supplemental_values):
+    sv = supplemental_values
+    assert jinja2._supplement_values(values_src=sv.d, overrides=sv.o) == {**sv.d, **sv.o}
+
+
+def test__supplement_values_priority(supplemental_values):
+    # Test environment variable > CLI key=value overrides > file value priority.
+    sv = supplemental_values
+    assert jinja2._supplement_values(values_src=sv.f)["foo"] == "bar"
+    o = {"foo": "bar-cli"}
+    assert jinja2._supplement_values(values_src=sv.f, overrides=o)["foo"] == o["foo"]
+    e = {"foo": "bar-env"}
+    with patch.dict(os.environ, e, clear=True):
+        assert jinja2._supplement_values(values_src=sv.f, env=True, overrides=o)["foo"] == e["foo"]
 
 
 def test__values_needed(caplog):
     undeclared_variables = {"roses_color", "lavender_smell"}
     jinja2._values_needed(undeclared_variables)
     assert logged(caplog, "Value(s) needed to render this template are:")
-    assert logged(caplog, "roses_color")
-    assert logged(caplog, "lavender_smell")
+    assert logged(caplog, "  roses_color")
+    assert logged(caplog, "  lavender_smell")
 
 
 def test__write_template_to_file(tmp_path):

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -407,6 +407,7 @@ def test__dispatch_template_render_fail(valsneeded):
         STR.valsfmt: 4,
         STR.keyvalpairs: ["foo=88", "bar=99"],
         STR.env: 5,
+        STR.searchpath: 6,
         STR.valsneeded: valsneeded,
         STR.partial: 7,
         STR.dryrun: 8,
@@ -423,6 +424,7 @@ def test__dispatch_template_render_no_optional():
         STR.valsfmt: None,
         STR.keyvalpairs: [],
         STR.env: False,
+        STR.searchpath: None,
         STR.valsneeded: False,
         STR.partial: False,
         STR.dryrun: False,
@@ -436,6 +438,7 @@ def test__dispatch_template_render_no_optional():
         values_format=None,
         overrides={},
         env=False,
+        searchpath=None,
         values_needed=False,
         partial=False,
         dry_run=False,
@@ -450,9 +453,10 @@ def test__dispatch_template_render_yaml():
         STR.valsfmt: 4,
         STR.keyvalpairs: ["foo=88", "bar=99"],
         STR.env: 5,
-        STR.valsneeded: 6,
-        STR.partial: 7,
-        STR.dryrun: 8,
+        STR.searchpath: 6,
+        STR.valsneeded: 7,
+        STR.partial: 8,
+        STR.dryrun: 9,
     }
     with patch.object(uwtools.api.template, "render") as render:
         cli._dispatch_template_render(args)
@@ -463,9 +467,10 @@ def test__dispatch_template_render_yaml():
         values_format=4,
         overrides={"foo": "88", "bar": "99"},
         env=5,
-        values_needed=6,
-        partial=7,
-        dry_run=8,
+        searchpath=6,
+        values_needed=7,
+        partial=8,
+        dry_run=9,
     )
 
 


### PR DESCRIPTION
**Synopsis**

Provide support for informing Jinja2 about paths to search for templates to load via `import` et al. template expressions. By default, the directory containing the primary template will be searched for loadable templates (when `-i` / `--input-file` is specified). A `--search-path` CLI option / `searchpath` API argument can be used to suppress this default and provide a set of colon-separated paths to search.

**Type**

- [x] Documentation
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
