### PR TITLE
UW-518: Add schema tests for new drivers

### DIFF
--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -307,7 +307,7 @@ def test_schema_fv3_namelist_update_values(fv3_fcstprop):
     )
     # At least one namelist entry is required:
     assert "does not have enough properties" in errors({})
-    # At least one val/var pair are required:
+    # At least one val/var pair is required:
     assert "does not have enough properties" in errors({"nml": {}})
 
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -7,7 +7,7 @@ from functools import partial
 
 from pytest import fixture
 
-from uwtools.tests.drivers import test_sfc_climo_gen
+from uwtools.tests.drivers import test_chgres_cube, test_sfc_climo_gen
 from uwtools.tests.support import schema_validator, with_del, with_set
 
 # execution
@@ -459,6 +459,18 @@ def test_schema_rocoto_workflow_cycledef():
 def test_schema_sfc_climo_gen():
     errors = schema_validator("sfc-climo-gen", "properties", "sfc_climo_gen")
     d = test_sfc_climo_gen.config["sfc_climo_gen"]
+    # Basic correctness:
+    assert not errors(d)
+    # Additional properties are not allowed:
+    assert "Additional properties are not allowed" in errors({**d, "foo": "bar"})
+
+
+# chgres-cube
+
+
+def test_schema_chgres_cube():
+    errors = schema_validator("chgres-cube", "properties", "chgres_cube")
+    d = test_chgres_cube.config["chgres_cube"]
     # Basic correctness:
     assert not errors(d)
     # Additional properties are not allowed:

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -9,7 +9,7 @@ from pytest import fixture
 
 from uwtools.tests.support import schema_validator, with_del, with_set
 
-# fixtures
+# Fixtures
 
 
 @fixture


### PR DESCRIPTION
**Synopsis**

Continuation of [UW-518](https://github.com/christinaholtNOAA/workflow-tools/pull/1)
Adding further testing of sfc_climo_gen and chgres_cube schemas. Tests kept consistent with those of fv3

**Type**

- [ ] Bug fix (corrects a known issue)
- [x] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds a new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)
- [ ] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
