### PR TITLE
Make it clearer that batch argument is a boolean switch

### DIFF
--- a/src/uwtools/api/chgres_cube.py
+++ b/src/uwtools/api/chgres_cube.py
@@ -28,7 +28,7 @@ def execute(
     :param task: The task to execute.
     :param cycle: The cycle.
     :param config: Path to config file (read stdin if missing or None).
-    :param batch: Submit run to the batch system.
+    :param batch: Submit run to the batch system?
     :param dry_run: Do not run the executable, just report what would have been done.
     :param graph_file: Write Graphviz DOT output here.
     :return: ``True`` if task completes without raising an exception.

--- a/src/uwtools/api/fv3.py
+++ b/src/uwtools/api/fv3.py
@@ -26,7 +26,7 @@ def execute(
     :param task: The task to execute.
     :param cycle: The cycle.
     :param config: Path to config file (read stdin if missing or None).
-    :param batch: Submit run to the batch system.
+    :param batch: Submit run to the batch system?
     :param dry_run: Do not run forecast, just report what would have been done.
     :param graph_file: Write Graphviz DOT output here.
     :return: ``True`` if task completes without raising an exception.

--- a/src/uwtools/api/sfc_climo_gen.py
+++ b/src/uwtools/api/sfc_climo_gen.py
@@ -21,12 +21,12 @@ def execute(
     If ``batch`` is specified, a runscript will be written and submitted to the batch system.
     Otherwise, the forecast will be run directly on the current system.
 
-    :param task: The task to execute
+    :param task: The task to execute.
     :param config: Path to config file (read stdin if missing or None).
-    :param batch: Submit run to the batch system
-    :param dry_run: Do not run forecast, just report what would have been done
-    :param graph_file: Write Graphviz DOT output here
-    :return: ``True`` if task completes without raising an exception
+    :param batch: Submit run to the batch system?
+    :param dry_run: Do not run forecast, just report what would have been done.
+    :param graph_file: Write Graphviz DOT output here.
+    :return: ``True`` if task completes without raising an exception.
     """
     obj = _SfcClimoGen(config=config, batch=batch, dry_run=dry_run)
     getattr(obj, task)()

--- a/src/uwtools/api/ungrib.py
+++ b/src/uwtools/api/ungrib.py
@@ -26,7 +26,7 @@ def execute(
     :param task: The task to execute.
     :param cycle: The cycle.
     :param config: Path to config file (read stdin if missing or None).
-    :param batch: Submit run to the batch system.
+    :param batch: Submit run to the batch system?
     :param dry_run: Do not run the executable, just report what would have been done.
     :param graph_file: Write Graphviz DOT output here.
     :return: ``True`` if task completes without raising an exception.


### PR DESCRIPTION
**Synopsis**

We could make it clearer, in the docstring -- and therefore in the API docs -- that the `batch` parameter to task `execute()` functions is a boolean switch.

**Type**

- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
