### PR TITLE
UW-522 Improve handling of missing variables in template render mode

### DIFF
--- a/docs/sections/user_guide/cli/tools/template.rst
+++ b/docs/sections/user_guide/cli/tools/template.rst
@@ -202,7 +202,7 @@ and a YAML file called ``values.yaml`` with the following contents:
    $ uw template render --input-file template --values-file values.yaml
    [2024-03-02T16:42:48]    ERROR Required value(s) not provided:
    [2024-03-02T16:42:48]    ERROR   recipient
-   [2024-03-02T16:42:48]    ERROR Template could not be rendered.
+   [2024-03-02T16:42:48]    ERROR Template could not be rendered
 
   But the ``--partial`` switch may be used to render as much as possible while passing expressions containing missing values through unchanged:
 

--- a/docs/sections/user_guide/cli/tools/template.rst
+++ b/docs/sections/user_guide/cli/tools/template.rst
@@ -218,7 +218,7 @@ and a YAML file called ``values.yaml`` with the following contents:
      $ uw template render --input-file template --values-file values.yaml recipient=Reader
      Hello, Reader!
 
-  The optional ``-env`` switch allows environment variables to be used to supply values:
+  The optional ``--env`` switch allows environment variables to be used to supply values:
 
   .. code-block:: text
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -643,7 +643,7 @@ def _dispatch_template_render(args: Args) -> bool:
     except UWTemplateRenderError:
         if args[STR.valsneeded]:
             return True
-        log.error("Template could not be rendered.")
+        log.error("Template could not be rendered")
         return False
     return True
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -196,7 +196,11 @@ def render(
         if missing:
             _log_missing_values(missing)
             return None
-        rendered = template.render()
+        try:
+            rendered = template.render()
+        except UndefinedError as e:
+            log.error("Render failed with error: %s", str(e))
+            return None
 
     # Log (dry-run mode) or write the rendered template.
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -308,9 +308,7 @@ def _register_filters(env: Environment) -> Environment:
             raise UndefinedError()
         return os.path.join(*path_components)
 
-    filters = dict(
-        path_join=path_join,
-    )
+    filters = dict(path_join=path_join)
     env.filters.update(filters)
     return env
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -55,7 +55,8 @@ class J2Template:
                         else []
                     )
                 )
-            )
+            ),
+            undefined=StrictUndefined,
         )
         _register_filters(self._j2env)
         self._template = self._j2env.from_string(self._template_str)

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -197,9 +197,7 @@ def test_render_calls__log_missing(template_file, tmp_path, values_file):
         f.write(yaml.dump(cfgobj))
 
     with patch.object(jinja2, "_log_missing_values") as lmv:
-        render_helper(
-            input_file=template_file, values_src=values_file, output_file=outfile, dry_run=True
-        )
+        render_helper(input_file=template_file, values_src=values_file, output_file=outfile)
         lmv.assert_called_once_with(["roses_color"])
 
 
@@ -225,9 +223,7 @@ def test_render_calls__write(template_file, tmp_path, values_file):
 def test_render_dry_run(caplog, template_file, values_file):
     log.setLevel(logging.INFO)
     expected = "roses are red, violets are blue"
-    result = render_helper(
-        input_file=template_file, values_src=values_file, output_file="/dev/null", dry_run=True
-    )
+    result = render_helper(input_file=template_file, values_src=values_file, dry_run=True)
     assert result == expected
     assert logged(caplog, expected)
 
@@ -266,19 +262,14 @@ def test_render_values_missing(caplog, template_file, values_file):
     del cfgobj["roses_color"]
     with open(values_file, "w", encoding="utf-8") as f:
         f.write(yaml.dump(cfgobj))
-    render_helper(input_file=template_file, values_src=values_file, output_file="/dev/null")
+    render_helper(input_file=template_file, values_src=values_file)
     assert logged(caplog, "Required value(s) not provided:")
     assert logged(caplog, "  roses_color")
 
 
 def test_render_values_needed(caplog, template_file, values_file):
     log.setLevel(logging.INFO)
-    render_helper(
-        input_file=template_file,
-        values_src=values_file,
-        output_file="/dev/null",
-        values_needed=True,
-    )
+    render_helper(input_file=template_file, values_src=values_file, values_needed=True)
     for var in ("roses_color", "violets_color"):
         assert logged(caplog, f"  {var}")
 


### PR DESCRIPTION
**Synopsis**

Given `template.yaml`
```
roses: "{{ colors.color1 }}"
violets: "{{ colors.color2 }}"
```
and `values.yaml`
```
colors:
  color1: red
```
Old behavior:
```
% uw template render --input-file template.yaml --values-file values.yaml
roses: "red"
violets: ""
```
New behavior:
```
% uw template render --input-file template.yaml --values-file values.yaml
[2024-03-28T18:49:30]    ERROR Render failed with error: 'dict object' has no attribute 'color2'
[2024-03-28T18:49:30]    ERROR Template could not be rendered
```

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
