### PR TITLE
UW-475 Support for YAML !remove tag

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import json
 import os
 import re
 from abc import ABC, abstractmethod
 from collections import UserDict
 from copy import deepcopy
+from io import StringIO
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -46,7 +46,9 @@ class Config(ABC, UserDict):
         """
         Returns the string representation of a Config object.
         """
-        return json.dumps(self.data)
+        s = StringIO()
+        yaml.dump(self.data, s)
+        return s.getvalue()
 
     # Private methods
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -5,7 +5,13 @@ from typing import Optional
 import yaml
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import INCLUDE_TAG, TaggedString, add_yaml_representers, log_and_error
+from uwtools.config.support import (
+    INCLUDE_TAG,
+    UWYAMLConvert,
+    UWYAMLRemove,
+    add_yaml_representers,
+    log_and_error,
+)
 from uwtools.strings import FORMAT
 from uwtools.utils.file import readable, writable
 
@@ -94,8 +100,9 @@ class YAMLConfig(Config):
         """
         loader = yaml.SafeLoader
         loader.add_constructor(INCLUDE_TAG, self._yaml_include)
-        for tag in TaggedString.TAGS:
-            loader.add_constructor(tag, TaggedString)
+        for tag_class in (UWYAMLConvert, UWYAMLRemove):
+            for tag in getattr(tag_class, "TAGS"):
+                loader.add_constructor(tag, tag_class)
         return loader
 
     # Public methods

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -18,11 +18,11 @@ from jinja2 import (
 )
 from jinja2.exceptions import UndefinedError
 
-from uwtools.config.support import TaggedString, format_to_config
+from uwtools.config.support import UWYAMLConvert, UWYAMLRemove, format_to_config
 from uwtools.logging import MSGWIDTH, log
 from uwtools.utils.file import get_file_format, readable, writable
 
-_ConfigVal = Union[bool, dict, float, int, list, str, TaggedString]
+_ConfigVal = Union[bool, dict, float, int, list, str, UWYAMLConvert, UWYAMLRemove]
 
 
 class J2Template:
@@ -109,7 +109,9 @@ class J2Template:
 # Public functions
 
 
-def dereference(val: _ConfigVal, context: dict, local: Optional[dict] = None) -> _ConfigVal:
+def dereference(
+    val: _ConfigVal, context: dict, local: Optional[dict] = None, keys: Optional[List[str]] = None
+) -> _ConfigVal:
     """
     Render Jinja2 syntax, wherever possible.
 
@@ -126,20 +128,29 @@ def dereference(val: _ConfigVal, context: dict, local: Optional[dict] = None) ->
     :param val: A value possibly containing Jinja2 syntax.
     :param context: Values to use when rendering Jinja2 syntax.
     :param local: Local sibling values to use if a match is not found in context.
+    :param keys: The dict keys leading to this value.
     :return: The input value, with Jinja2 syntax rendered.
     """
     rendered: _ConfigVal = val  # fall-back value
     if isinstance(val, dict):
-        return {dereference(k, context): dereference(v, context, local=val) for k, v in val.items()}
+        return {
+            dereference(k, context): dereference(v, context, local=val, keys=[*(keys or []), k])
+            for k, v in val.items()
+        }
     if isinstance(val, list):
         return [dereference(v, context) for v in val]
     if isinstance(val, str):
         _deref_debug("Rendering", val)
         rendered = _deref_render(val, context, local)
-    elif isinstance(val, TaggedString):
+    elif isinstance(val, UWYAMLConvert):
         _deref_debug("Rendering", val.value)
         val.value = _deref_render(val.value, context, local)
         rendered = _deref_convert(val)
+    elif isinstance(val, UWYAMLRemove):
+        assert keys
+        assert local
+        _deref_debug("Removing value at", ".".join(keys))
+        del local[keys[-1]]
     else:
         _deref_debug("Accepting", val)
     return rendered
@@ -224,7 +235,7 @@ def unrendered(s: str) -> bool:
 # Private functions
 
 
-def _deref_convert(val: TaggedString) -> _ConfigVal:
+def _deref_convert(val: UWYAMLConvert) -> _ConfigVal:
     """
     Convert a string tagged with an explicit type.
 

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from importlib import import_module
-from typing import Dict, Type, Union
+from typing import Dict, NoReturn, Type, Union
 
 import yaml
 from f90nml import Namelist  # type: ignore
 
-from uwtools.exceptions import UWConfigError
+from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import log
 from uwtools.strings import FORMAT
 
@@ -21,7 +21,7 @@ def add_yaml_representers() -> None:
     """
     Add representers to the YAML dumper for custom types.
     """
-    yaml.add_representer(TaggedString, TaggedString.represent)
+    yaml.add_representer(UWYAMLConvert, UWYAMLConvert.represent)
     yaml.add_representer(Namelist, _represent_namelist)
     yaml.add_representer(OrderedDict, _represent_ordereddict)
 
@@ -95,7 +95,7 @@ def _represent_ordereddict(dumper: yaml.Dumper, data: OrderedDict) -> yaml.nodes
     return dumper.represent_mapping("tag:yaml.org,2002:map", from_od(data))
 
 
-class TaggedString:
+class UWYAMLConvert:
     """
     A class supporting custom YAML tags specifying type conversions.
 
@@ -103,7 +103,7 @@ class TaggedString:
     method. See the pyyaml documentation for details.
     """
 
-    TAGS: Dict[str, type] = {"!float": float, "!int": int}
+    TAGS = ("!float", "!int")
 
     def __init__(self, _: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> None:
         self.tag: str = node.tag
@@ -122,7 +122,7 @@ class TaggedString:
         return converters[self.tag](self.value)
 
     @staticmethod
-    def represent(dumper: yaml.Dumper, data: TaggedString) -> yaml.nodes.ScalarNode:
+    def represent(dumper: yaml.Dumper, data: UWYAMLConvert) -> yaml.nodes.ScalarNode:
         """
         Serialize a tagged scalar as "!type value".
 
@@ -130,3 +130,30 @@ class TaggedString:
         documentation for details.
         """
         return dumper.represent_scalar(data.tag, data.value)
+
+
+class UWYAMLRemove:
+    """
+    A class supporting a custom YAML tag to remove a YAML key/value pair.
+
+    The constructor implements the interface required by a pyyaml Loader object's add_consructor()
+    method. See the pyyaml documentation for details.
+    """
+
+    TAGS = ("!remove",)
+
+    def __init__(self, _: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> None:
+        self.tag: str = node.tag
+        self.value: str = node.value
+
+    def __repr__(self) -> str:
+        return "%s %s" % (self.tag, self.value)
+
+    @staticmethod
+    def represent(dumper: yaml.Dumper, data: UWYAMLConvert) -> NoReturn:
+        """
+        Removed items must not be represented in output.
+
+        :raises: UWError
+        """
+        raise UWError("Values tagged %s are unrepresentable" % ", ".join(UWYAMLRemove.TAGS))

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -17,7 +17,7 @@ from pytest import fixture, raises
 
 from uwtools.config import jinja2
 from uwtools.config.jinja2 import J2Template
-from uwtools.config.support import TaggedString
+from uwtools.config.support import UWYAMLConvert
 from uwtools.logging import log
 from uwtools.tests.support import logged, regex_logged
 
@@ -284,7 +284,7 @@ def test_unrendered(s, status):
 def test__deref_convert_no(caplog, tag):
     log.setLevel(logging.DEBUG)
     loader = yaml.SafeLoader(os.devnull)
-    val = TaggedString(loader, yaml.ScalarNode(tag=tag, value="foo"))
+    val = UWYAMLConvert(loader, yaml.ScalarNode(tag=tag, value="foo"))
     assert jinja2._deref_convert(val=val) == val
     assert not regex_logged(caplog, "Converted")
     assert regex_logged(caplog, "Conversion failed")
@@ -294,7 +294,7 @@ def test__deref_convert_no(caplog, tag):
 def test__deref_convert_ok(caplog, converted, tag, value):
     log.setLevel(logging.DEBUG)
     loader = yaml.SafeLoader(os.devnull)
-    val = TaggedString(loader, yaml.ScalarNode(tag=tag, value=value))
+    val = UWYAMLConvert(loader, yaml.ScalarNode(tag=tag, value=value))
     assert jinja2._deref_convert(val=val) == converted
     assert regex_logged(caplog, "Converted")
     assert not regex_logged(caplog, "Conversion failed")

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -136,10 +136,12 @@ def test_dereference_no_op_due_to_error(caplog, logmsg, val):
     assert regex_logged(caplog, logmsg)
 
 
-def test_dereference_remove():
+def test_dereference_remove(caplog):
+    log.setLevel(logging.DEBUG)
     remove = UWYAMLRemove(yaml.SafeLoader(""), yaml.ScalarNode(tag="!remove", value=""))
     val = {"a": {"b": {"c": "cherry", "d": remove}}}
     assert jinja2.dereference(val=val, context={}) == {"a": {"b": {"c": "cherry"}}}
+    assert regex_logged(caplog, "Removing value at: a > b > d")
 
 
 def test_dereference_str_expression_rendered():

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -17,7 +17,7 @@ from pytest import fixture, raises
 
 from uwtools.config import jinja2
 from uwtools.config.jinja2 import J2Template
-from uwtools.config.support import UWYAMLConvert
+from uwtools.config.support import UWYAMLConvert, UWYAMLRemove
 from uwtools.logging import log
 from uwtools.tests.support import logged, regex_logged
 
@@ -134,6 +134,12 @@ def test_dereference_no_op_due_to_error(caplog, logmsg, val):
     log.setLevel(logging.DEBUG)
     assert jinja2.dereference(val=val, context={}) == val
     assert regex_logged(caplog, logmsg)
+
+
+def test_dereference_remove():
+    remove = UWYAMLRemove(yaml.SafeLoader(""), yaml.ScalarNode(tag="!remove", value=""))
+    val = {"a": {"b": {"c": "cherry", "d": remove}}}
+    assert jinja2.dereference(val=val, context={}) == {"a": {"b": {"c": "cherry"}}}
 
 
 def test_dereference_str_expression_rendered():

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -89,7 +89,7 @@ class Test_UWYAMLConvert:
 
     @fixture
     def loader(self):
-        yaml.add_representer(support.UWYAMLConvert, support.UWYAMLConvert.represent)
+        yaml.add_representer(support.UWYAMLConvert, support.UWYAMLTag.represent)
         return YAMLConfig(config={})._yaml_loader
 
     # These tests bypass YAML parsing, constructing nodes with explicit string values. They then
@@ -128,17 +128,12 @@ class Test_UWYAMLRemove:
 
     @fixture
     def loader(self):
-        yaml.add_representer(support.UWYAMLRemove, support.UWYAMLRemove.represent)
+        yaml.add_representer(support.UWYAMLRemove, support.UWYAMLTag.represent)
         return YAMLConfig(config={})._yaml_loader
 
     @fixture
     def node(self, loader):
         return support.UWYAMLRemove(loader, yaml.ScalarNode(tag="!remove", value=""))
-
-    def test_represent(self, node):
-        with raises(UWError) as e:
-            yaml.dump(node)
-        assert str(e.value) == "Value tagged !remove is unrepresentable"
 
     def test___repr__(self, node):
         assert str(node) == "!remove"

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -18,7 +18,7 @@ from uwtools.config.formats.ini import INIConfig
 from uwtools.config.formats.nml import NMLConfig
 from uwtools.config.formats.sh import SHConfig
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.exceptions import UWConfigError
+from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import log
 from uwtools.tests.support import logged
 from uwtools.utils.file import FORMAT
@@ -119,3 +119,26 @@ class Test_UWYAMLConvert:
     def test___repr__(self, loader):
         ts = support.UWYAMLConvert(loader, yaml.ScalarNode(tag="!int", value="88"))
         assert str(ts) == "!int 88"
+
+
+class Test_UWYAMLRemove:
+    """
+    Tests for class uwtools.config.support.UWYAMLRemove.
+    """
+
+    @fixture
+    def loader(self):
+        yaml.add_representer(support.UWYAMLRemove, support.UWYAMLRemove.represent)
+        return YAMLConfig(config={})._yaml_loader
+
+    @fixture
+    def node(self, loader):
+        return support.UWYAMLRemove(loader, yaml.ScalarNode(tag="!remove", value=""))
+
+    def test_represent(self, node):
+        with raises(UWError) as e:
+            yaml.dump(node)
+        assert str(e.value) == "Value tagged !remove is unrepresentable"
+
+    def test___repr__(self, node):
+        assert str(node) == "!remove"

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -27,7 +27,7 @@ from uwtools.utils.file import FORMAT
 def test_add_yaml_representers():
     support.add_yaml_representers()
     representers = yaml.Dumper.yaml_representers
-    assert support.TaggedString in representers
+    assert support.UWYAMLConvert in representers
     assert OrderedDict in representers
     assert Namelist in representers
 
@@ -79,17 +79,17 @@ def test_represent_ordereddict():
     )
 
 
-class Test_TaggedString:
+class Test_UWYAMLConvert:
     """
-    Tests for class uwtools.config.support.TaggedString.
+    Tests for class uwtools.config.support.UWYAMLConvert.
     """
 
-    def comp(self, ts: support.TaggedString, s: str):
+    def comp(self, ts: support.UWYAMLConvert, s: str):
         assert yaml.dump(ts, default_flow_style=True).strip() == s
 
     @fixture
     def loader(self):
-        yaml.add_representer(support.TaggedString, support.TaggedString.represent)
+        yaml.add_representer(support.UWYAMLConvert, support.UWYAMLConvert.represent)
         return YAMLConfig(config={})._yaml_loader
 
     # These tests bypass YAML parsing, constructing nodes with explicit string values. They then
@@ -97,25 +97,25 @@ class Test_TaggedString:
     # by the tag.
 
     def test_float_no(self, loader):
-        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!float", value="foo"))
+        ts = support.UWYAMLConvert(loader, yaml.ScalarNode(tag="!float", value="foo"))
         with raises(ValueError):
             ts.convert()
 
     def test_float_ok(self, loader):
-        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!float", value="3.14"))
+        ts = support.UWYAMLConvert(loader, yaml.ScalarNode(tag="!float", value="3.14"))
         assert ts.convert() == 3.14
         self.comp(ts, "!float '3.14'")
 
     def test_int_no(self, loader):
-        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!int", value="foo"))
+        ts = support.UWYAMLConvert(loader, yaml.ScalarNode(tag="!int", value="foo"))
         with raises(ValueError):
             ts.convert()
 
     def test_int_ok(self, loader):
-        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!int", value="88"))
+        ts = support.UWYAMLConvert(loader, yaml.ScalarNode(tag="!int", value="88"))
         assert ts.convert() == 88
         self.comp(ts, "!int '88'")
 
     def test___repr__(self, loader):
-        ts = support.TaggedString(loader, yaml.ScalarNode(tag="!int", value="88"))
+        ts = support.UWYAMLConvert(loader, yaml.ScalarNode(tag="!int", value="88"))
         assert str(ts) == "!int 88"

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -18,7 +18,7 @@ from uwtools.config.formats.ini import INIConfig
 from uwtools.config.formats.nml import NMLConfig
 from uwtools.config.formats.sh import SHConfig
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.exceptions import UWConfigError, UWError
+from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.tests.support import logged
 from uwtools.utils.file import FORMAT
@@ -90,7 +90,7 @@ class Test_UWYAMLConvert:
     @fixture
     def loader(self):
         yaml.add_representer(support.UWYAMLConvert, support.UWYAMLTag.represent)
-        return YAMLConfig(config={})._yaml_loader
+        return yaml.SafeLoader("")
 
     # These tests bypass YAML parsing, constructing nodes with explicit string values. They then
     # demonstrate that those nodes' convert() methods return representations in type type specified
@@ -127,13 +127,9 @@ class Test_UWYAMLRemove:
     """
 
     @fixture
-    def loader(self):
+    def node(self):
         yaml.add_representer(support.UWYAMLRemove, support.UWYAMLTag.represent)
-        return YAMLConfig(config={})._yaml_loader
-
-    @fixture
-    def node(self, loader):
-        return support.UWYAMLRemove(loader, yaml.ScalarNode(tag="!remove", value=""))
+        return support.UWYAMLRemove(yaml.SafeLoader(""), yaml.ScalarNode(tag="!remove", value=""))
 
     def test___repr__(self, node):
         assert str(node) == "!remove"

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -126,10 +126,7 @@ class Test_UWYAMLRemove:
     Tests for class uwtools.config.support.UWYAMLRemove.
     """
 
-    @fixture
-    def node(self):
+    def test___repr__(self):
         yaml.add_representer(support.UWYAMLRemove, support.UWYAMLTag.represent)
-        return support.UWYAMLRemove(yaml.SafeLoader(""), yaml.ScalarNode(tag="!remove", value=""))
-
-    def test___repr__(self, node):
+        node = support.UWYAMLRemove(yaml.SafeLoader(""), yaml.ScalarNode(tag="!remove", value=""))
         assert str(node) == "!remove"

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -312,7 +312,7 @@ def test_realize_config_remove_nml_to_nml(tmp_path):
     tools.realize_config(
         input_config=nml,
         output_file=cfg,
-        supplemental_configs=[YAMLConfig(config=sup)],
+        supplemental_configs=[sup],
     )
     assert f90nml.read(cfg) == {"constants": {"pi": 3.141}}
 
@@ -330,7 +330,7 @@ def test_realize_config_remove_yaml_to_yaml_scalar(tmp_path):
     assert {"a": {"b": {"c": 11, "e": 33}}} == tools.realize_config(
         input_config=yml,
         output_format="yaml",
-        supplemental_configs=[YAMLConfig(config=sup)],
+        supplemental_configs=[sup],
     )
 
 
@@ -346,7 +346,7 @@ def test_realize_config_remove_yaml_to_yaml_subtree(tmp_path):
     assert {"a": {}} == tools.realize_config(
         input_config=yml,
         output_format="yaml",
-        supplemental_configs=[YAMLConfig(config=sup)],
+        supplemental_configs=[sup],
     )
 
 


### PR DESCRIPTION
**Synopsis**

Add support for a YAML `!remove` tag.

Given `config.yaml`
```
fruit:
  a: apple
  b: banana
  c: cherry
```
and `remove.yaml`
```
fruit:
  b: !remove
```
we can
```
% uw config realize --input-file config.yaml --output-format yaml remove.yaml
fruit:
  a: apple
  c: cherry
```
Similarly with `config.nml`
```
&fruit
  a = "apple"
  b = "banana"
  c = "cherry"
/
```
we can
```
% uw config realize --input-file config.nml --output-format nml remove.yaml
&fruit
    a = 'apple'
    c = 'cherry'
/
```

**Type**

- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
