### PR TITLE
UW-549 Remove --partial option from template render mode

### DIFF
--- a/docs/sections/user_guide/cli/tools/template.rst
+++ b/docs/sections/user_guide/cli/tools/template.rst
@@ -36,9 +36,9 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
                              [--search-path PATH[:PATH:...]] [--values-needed] [--dry-run] [--quiet]
                              [--verbose]
                              [KEY=VALUE ...]
-   
+
    Render a template
-   
+
    Optional arguments:
      -h, --help
          Show help and exit

--- a/docs/sections/user_guide/cli/tools/template.rst
+++ b/docs/sections/user_guide/cli/tools/template.rst
@@ -33,12 +33,12 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
    $ uw template render --help
    usage: uw template render [-h] [--version] [--input-file PATH] [--output-file PATH]
                              [--values-file PATH] [--values-format {ini,nml,sh,yaml}] [--env]
-                             [--search-path PATH[:PATH:...]] [--values-needed] [--partial]
-                             [--dry-run] [--quiet] [--verbose]
+                             [--search-path PATH[:PATH:...]] [--values-needed] [--dry-run] [--quiet]
+                             [--verbose]
                              [KEY=VALUE ...]
-
+   
    Render a template
-
+   
    Optional arguments:
      -h, --help
          Show help and exit
@@ -58,8 +58,6 @@ The ``uw`` mode for handling :jinja2:`Jinja2 templates<templates>`.
          Colon-separated paths to search for extra templates
      --values-needed
          Print report of values needed to render template
-     --partial
-         Permit partial template rendering
      --dry-run
          Only log info, making no changes
      --quiet, -q
@@ -203,13 +201,6 @@ and a YAML file called ``values.yaml`` with the following contents:
    [2024-03-02T16:42:48]    ERROR Required value(s) not provided:
    [2024-03-02T16:42:48]    ERROR   recipient
    [2024-03-02T16:42:48]    ERROR Template could not be rendered
-
-  But the ``--partial`` switch may be used to render as much as possible while passing expressions containing missing values through unchanged:
-
-  .. code-block:: text
-
-     $ uw template render --input-file template --values-file values.yaml --partial
-     Hello, {{ recipient }}!
 
   Values may also be supplemented by ``key=value`` command-line arguments:
 

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -20,7 +20,6 @@ def render(
     env: bool = False,
     searchpath: Optional[List[str]] = None,
     values_needed: bool = False,
-    partial: bool = False,
     dry_run: bool = False,
 ) -> str:
     """
@@ -42,7 +41,6 @@ def render(
     :param env: Supplement values with environment variables?
     :param searchpath: Paths to search for extra templates
     :param values_needed: Just report variables needed to render the template?
-    :param partial: Permit unrendered Jinja2 variables/expressions in output?
     :param dry_run: Run in dry-run mode?
     :return: The rendered template string
     :raises: UWTemplateRenderError if template could not be rendered
@@ -56,7 +54,6 @@ def render(
         env=env,
         searchpath=searchpath,
         values_needed=values_needed,
-        partial=partial,
         dry_run=dry_run,
     )
     if result is None:
@@ -72,7 +69,6 @@ def render_to_str(  # pylint: disable=unused-argument
     env: bool = False,
     searchpath: Optional[List[str]] = None,
     values_needed: bool = False,
-    partial: bool = False,
     dry_run: bool = False,
 ) -> str:
     """

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -713,7 +713,6 @@ def _add_subparser_template_render(subparsers: Subparsers) -> ActionChecks:
     _add_arg_env(optional)
     _add_arg_search_path(optional)
     _add_arg_values_needed(optional)
-    _add_arg_partial(optional)
     _add_arg_dry_run(optional)
     checks = _add_args_verbosity(optional)
     _add_arg_key_eq_val_pairs(optional)
@@ -749,7 +748,6 @@ def _dispatch_template_render(args: Args) -> bool:
             env=args[STR.env],
             searchpath=args[STR.searchpath],
             values_needed=args[STR.valsneeded],
-            partial=args[STR.partial],
             dry_run=args[STR.dryrun],
         )
     except UWTemplateRenderError:
@@ -965,14 +963,6 @@ def _add_arg_output_format(group: Group, choices: List[str], required: bool = Fa
         help="Output format",
         required=required,
         type=str,
-    )
-
-
-def _add_arg_partial(group: Group) -> None:
-    group.add_argument(
-        _switch(STR.partial),
-        action="store_true",
-        help="Permit partial template rendering",
     )
 
 

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -90,7 +90,6 @@ class STR:
     mpasinit: str = "mpas_init"
     outfile: str = "output_file"
     outfmt: str = "output_format"
-    partial: str = "partial"
     quiet: str = "quiet"
     realize: str = "realize"
     render: str = "render"

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -20,7 +20,6 @@ def kwargs():
         "overrides": {"key": "val"},
         "searchpath": None,
         "env": True,
-        "partial": True,
         "values_needed": True,
         "dry_run": True,
     }

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -537,3 +537,11 @@ class Test_J2Template:
         s = "{{ a }} {{ b.c }} {{ d.e.f[g] }} {{ h[i] }} {{ j[88] }} {{ k|default(l) }}"
         uvs = {"a", "b", "d", "g", "h", "i", "j", "k", "l"}
         assert J2Template(values={}, template_source=s).undeclared_variables == uvs
+
+    def test__template_str(self, testdata):
+        obj = J2Template(values=testdata.config, template_source=testdata.template)
+        assert obj._template_str == "{{greeting}} to {{recipient}}"
+
+    def test___repr__(self, testdata):
+        obj = J2Template(values=testdata.config, template_source=testdata.template)
+        assert str(obj) == "{{greeting}} to {{recipient}}"

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -249,20 +249,6 @@ def test_render_fails(caplog, tmp_path):
     assert logged(caplog, "Render failed with error: 'dict object' has no attribute 'e'")
 
 
-@pytest.mark.parametrize("partial", [False, True])
-def test_render_partial(caplog, capsys, partial):
-    log.setLevel(logging.INFO)
-    template = StringIO(initial_value="{{ greeting }} {{ recipient }}")
-    with patch.object(jinja2, "readable") as readable:
-        readable.return_value.__enter__.return_value = template
-        jinja2.render(values_src={"greeting": "Hello"}, partial=partial)
-    if partial:
-        assert "Hello {{ recipient }}" in capsys.readouterr().out
-    else:
-        assert logged(caplog, "Required value(s) not provided:")
-        assert logged(caplog, "  recipient")
-
-
 def test_render_values_missing(caplog, template_file, values_file):
     log.setLevel(logging.INFO)
     # Read in the config, remove the "roses" key, then re-write it.

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -598,8 +598,7 @@ def test__dispatch_template_render_fail(valsneeded):
         STR.env: 5,
         STR.searchpath: 6,
         STR.valsneeded: valsneeded,
-        STR.partial: 7,
-        STR.dryrun: 8,
+        STR.dryrun: 7,
     }
     with patch.object(uwtools.api.template, "render", side_effect=UWTemplateRenderError):
         assert cli._dispatch_template_render(args) is valsneeded
@@ -615,7 +614,6 @@ def test__dispatch_template_render_no_optional():
         STR.env: False,
         STR.searchpath: None,
         STR.valsneeded: False,
-        STR.partial: False,
         STR.dryrun: False,
     }
     with patch.object(uwtools.api.template, "render") as render:
@@ -629,7 +627,6 @@ def test__dispatch_template_render_no_optional():
         env=False,
         searchpath=None,
         values_needed=False,
-        partial=False,
         dry_run=False,
     )
 
@@ -644,8 +641,7 @@ def test__dispatch_template_render_yaml():
         STR.env: 5,
         STR.searchpath: 6,
         STR.valsneeded: 7,
-        STR.partial: 8,
-        STR.dryrun: 9,
+        STR.dryrun: 8,
     }
     with patch.object(uwtools.api.template, "render") as render:
         cli._dispatch_template_render(args)
@@ -658,8 +654,7 @@ def test__dispatch_template_render_yaml():
         env=5,
         searchpath=6,
         values_needed=7,
-        partial=8,
-        dry_run=9,
+        dry_run=8,
     )
 
 


### PR DESCRIPTION
**Synopsis**

As outlined in [UW-549](https://jira.epic.oarcloud.noaa.gov/browse/UW-549), Jinja2 does not support partial rendering for any but the simplest values, and it appears infeasible to detect more complicated failures with dangerous failure modes and prevent them from affecting users. So, unless/until a solution can be found (e.g. the Jinja2 maintainers [have a plan](https://github.com/pallets/jinja/issues/1194) to rewrite their lexer/parser code, which could provide a path to a solution), remove this functionality.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Documentation

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
