### PR TITLE
UW-565: Reduce a config to one of its subsection

### DIFF
--- a/docs/sections/contributor_guide/documentation.rst
+++ b/docs/sections/contributor_guide/documentation.rst
@@ -15,7 +15,7 @@ The ``make docs`` command will build the docs under ``docs/build/html``, after w
 
 .. code-block:: text
 
-   file://<filesystem-path-to-your-clone>/docs/build/html/index.index.html
+   file://<filesystem-path-to-your-clone>/docs/build/html/index.html
 
 Rerun ``make docs`` and refresh your browser after making and saving changes.
 

--- a/docs/sections/user_guide/cli/tools/config.rst
+++ b/docs/sections/user_guide/cli/tools/config.rst
@@ -154,10 +154,11 @@ In ``uw`` terminology, to realize a configuration file is to transform it from i
 
 .. code-block:: text
 
-   $ uw config realize --help
+   $ uw config realize -h
    usage: uw config realize [-h] [--version] [--input-file PATH] [--input-format {ini,nml,sh,yaml}]
                             [--output-file PATH] [--output-format {ini,nml,sh,yaml}]
-                            [--values-needed] [--total] [--dry-run] [--quiet] [--verbose]
+                            [--output-block KEY[:KEY:...]] [--values-needed] [--total] [--dry-run]
+                            [--quiet] [--verbose]
                             [PATH ...]
 
    Realize config
@@ -175,6 +176,8 @@ In ``uw`` terminology, to realize a configuration file is to transform it from i
          Path to output file (defaults to stdout)
      --output-format {ini,nml,sh,yaml}
          Output format
+     --output-block KEY[:KEY:...]
+         Colon-separated path of keys to the block to be output
      --values-needed
          Print report of values needed to render template
      --total
@@ -356,6 +359,18 @@ and an additional supplemental YAML file ``values2.yaml`` with the following con
        message: 'Good Night Moon Good Night Moon '
        recipient: Moon
        repeat: 2
+
+* To read the config from ``stdin`` and realize a subsection to ``stdout`` in a different format:
+
+  .. code-block:: text
+
+     $ cat config.yaml | uw config realize --input-format yaml --output-format sh --output-block values values1.yaml
+     date=20240105
+     empty=None
+     greeting='Good Night'
+     message='Good Night Moon Good Night Moon '
+     recipient=Moon
+     repeat=2
 
 * If the config file has an unrecognized (or no) extension, ``uw`` will not know how to parse its contents:
 

--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -94,6 +94,7 @@ def get_yaml_config(config: Union[dict, Optional[Path]] = None) -> _YAMLConfig:
 def realize(
     input_config: Union[dict, _Config, Optional[Path]] = None,
     input_format: Optional[str] = None,
+    output_block: Optional[List[Union[str, int]]] = None,
     output_file: Optional[Path] = None,
     output_format: Optional[str] = None,
     supplemental_configs: Optional[List[Union[dict, _Config, Path]]] = None,
@@ -107,6 +108,7 @@ def realize(
     _realize(
         input_config=_ensure_config_arg_type(input_config),
         input_format=input_format,
+        output_block=output_block,
         output_file=output_file,
         output_format=output_format,
         supplemental_configs=supplemental_configs,

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -193,6 +193,7 @@ def _add_subparser_config_realize(subparsers: Subparsers) -> ActionChecks:
     _add_arg_input_format(optional, choices=FORMATS)
     _add_arg_output_file(optional)
     _add_arg_output_format(optional, choices=FORMATS)
+    _add_arg_output_block(optional)
     _add_arg_values_needed(optional)
     _add_arg_total(optional)
     _add_arg_dry_run(optional)
@@ -256,6 +257,7 @@ def _dispatch_config_realize(args: Args) -> bool:
         uwtools.api.config.realize(
             input_config=args[STR.infile],
             input_format=args[STR.infmt],
+            output_block=args[STR.outblock],
             output_file=args[STR.outfile],
             output_format=args[STR.outfmt],
             supplemental_configs=args[STR.suppfiles],
@@ -942,6 +944,16 @@ def _add_arg_keys(group: Group) -> None:
         help="YAML key leading to file dst/src block",
         metavar="KEY",
         nargs="*",
+    )
+
+
+def _add_arg_output_block(group: Group):
+    group.add_argument(
+        _switch(STR.outblock),
+        help="Colon-separated path of keys to the block to be output",
+        metavar="KEY[:KEY:...]",
+        required=False,
+        type=lambda s: s.split(":"),
     )
 
 

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -79,6 +79,7 @@ def config_check_depths_update(config_obj: Union[Config, dict], target_format: s
 def realize_config(
     input_config: Union[Config, Optional[Path]] = None,
     input_format: Optional[str] = None,
+    output_block: Optional[List[Union[str, int]]] = None,
     output_file: Optional[Path] = None,
     output_format: Optional[str] = None,
     supplemental_configs: Optional[List[Union[dict, Config, Path]]] = None,
@@ -100,7 +101,11 @@ def realize_config(
     if supplemental_configs:
         input_obj = _realize_config_update(input_obj, input_format, supplemental_configs)
     input_obj.dereference()
-    config_check_depths_realize(input_obj, output_format)
+    output_data = input_obj.data
+    if output_block is not None:
+        for key in output_block:
+            output_data = output_data.get(key, {})
+    config_check_depths_realize(output_data, output_format)
     if dry_run:
         for line in str(input_obj).strip().split("\n"):
             log.info(line)
@@ -111,7 +116,7 @@ def realize_config(
     if total and unrendered(str(input_obj)):
         raise UWConfigRealizeError("Config could not be totally realized")
     output_class = format_to_config(output_format)
-    output_class.dump_dict(cfg=input_obj.data, path=output_file)
+    output_class.dump_dict(cfg=output_data, path=output_file)
     return input_obj.data
 
 

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -88,6 +88,7 @@ class STR:
     model: str = "model"
     mpas: str = "mpas"
     mpasinit: str = "mpas_init"
+    outblock: str = "output_block"
     outfile: str = "output_file"
     outfmt: str = "output_format"
     quiet: str = "quiet"

--- a/src/uwtools/tests/api/test_config.py
+++ b/src/uwtools/tests/api/test_config.py
@@ -44,6 +44,7 @@ def test_realize():
     kwargs: dict = {
         "input_config": "path1",
         "input_format": "fmt1",
+        "output_block": None,
         "output_file": "path2",
         "output_format": "fmt2",
         "supplemental_configs": ["path3"],

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -278,6 +278,46 @@ def test_realize_config_incompatible_file_type():
         )
 
 
+def test_realize_config_output_block(tmp_path, realize_config_testobj):
+    """
+    Test that --output-block subsets the input as expected.
+    """
+    outfile = tmp_path / "test_output.yaml"
+    tools.realize_config(
+        input_config=realize_config_testobj,
+        output_block=[1],
+        output_file=outfile,
+    )
+    expected = """
+    2:
+      3: 88"""
+    expected_file = tmp_path / "expected.yaml"
+    with open(expected_file, "w", encoding="utf-8") as f:
+        f.write(dedent(expected).strip())
+    assert compare_files(expected_file, outfile)
+
+
+def test_realize_config_output_block_format_conversion(tmp_path):
+    """
+    Test that --output-block subsets the input as expected for output format.
+    """
+    outfile = tmp_path / "test_output.nml"
+    d = {"a": {"b": {"c": 88}}}
+    tools.realize_config(
+        input_config=YAMLConfig(d),
+        output_block=["a"],
+        output_file=outfile,
+    )
+    expected = """
+    &b
+        c = 88
+    /"""
+    expected_file = tmp_path / "expected.nml"
+    with open(expected_file, "w", encoding="utf-8") as f:
+        f.write(dedent(expected).strip())
+    assert compare_files(expected_file, outfile)
+
+
 def test_realize_config_output_file_conversion(tmp_path):
     """
     Test that --output-input-type converts config object to desired object type.

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -355,24 +355,26 @@ def test__dispatch_config_realize():
     args = {
         STR.infile: 1,
         STR.infmt: 2,
-        STR.outfile: 3,
-        STR.outfmt: 4,
-        STR.suppfiles: 5,
-        STR.valsneeded: 6,
-        STR.total: 7,
-        STR.dryrun: 8,
+        STR.outblock: 3,
+        STR.outfile: 4,
+        STR.outfmt: 5,
+        STR.suppfiles: 6,
+        STR.valsneeded: 7,
+        STR.total: 8,
+        STR.dryrun: 9,
     }
     with patch.object(cli.uwtools.api.config, "realize") as realize:
         cli._dispatch_config_realize(args)
     realize.assert_called_once_with(
         input_config=1,
         input_format=2,
-        output_file=3,
-        output_format=4,
-        supplemental_configs=5,
-        values_needed=6,
-        total=7,
-        dry_run=8,
+        output_block=3,
+        output_file=4,
+        output_format=5,
+        supplemental_configs=6,
+        values_needed=7,
+        total=8,
+        dry_run=9,
     )
 
 
@@ -383,6 +385,7 @@ def test__dispatch_config_realize_fail(caplog):
         for x in (
             STR.infile,
             STR.infmt,
+            STR.outblock,
             STR.outfile,
             STR.outfmt,
             STR.suppfiles,
@@ -400,6 +403,7 @@ def test__dispatch_config_realize_no_optional():
     args = {
         STR.infile: None,
         STR.infmt: None,
+        STR.outblock: None,
         STR.outfile: None,
         STR.outfmt: None,
         STR.suppfiles: ["/foo.vals"],
@@ -412,6 +416,7 @@ def test__dispatch_config_realize_no_optional():
     realize.assert_called_once_with(
         input_config=None,
         input_format=None,
+        output_block=None,
         output_file=None,
         output_format=None,
         supplemental_configs=["/foo.vals"],


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

The ``--output-block`` flag was added to config realize to indicate that only a particular subsection of an input config file should be used to prepare output.

**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation
- [x] Enhancement (adds a new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
