### PR TITLE
Use iotaa v0.8.x

### DIFF
--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -8,7 +8,7 @@
       "coverage =7.4.*",
       "docformatter =1.7.*",
       "f90nml =1.4.*",
-      "iotaa =0.7.*",
+      "iotaa =0.8.*",
       "isort =5.13.*",
       "jinja2 =3.1.*",
       "jq =1.7.*",
@@ -24,7 +24,7 @@
     ],
     "run": [
       "f90nml =1.4.*",
-      "iotaa =0.7.*",
+      "iotaa =0.8.*",
       "jinja2 =3.1.*",
       "jsonschema =4.21.*",
       "lxml =5.1.*",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - pip
   run:
     - f90nml 1.4.*
-    - iotaa 0.7.*
+    - iotaa 0.8.*
     - jinja2 3.1.*
     - jsonschema 4.21.*
     - lxml 5.1.*


### PR DESCRIPTION
**Synopsis**

Use `iotaa` v0.8.x. The primary benefit to `uwtools` is improved log messages, i.e. tasks described as `Not Ready` instead of `Pending`, and external assets described as `(external asset)` instead of just `(EXTERNAL)`. There are no functional changes currently of interest to `uwtools`.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
