### PR TITLE
UW-494: Add page about supported tags to UW YAML docs

### DIFF
--- a/docs/sections/user_guide/yaml/index.rst
+++ b/docs/sections/user_guide/yaml/index.rst
@@ -11,3 +11,4 @@ UW YAML
    updating_values
    field_table
    rocoto
+   tags

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -1,0 +1,76 @@
+.. _defining_YAML_tags:
+
+Defining YAML ``tags``
+==========================
+
+Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined at http://yaml.org/type/index.html.
+
+Tags may be implicit:
+
+.. code-block:: text
+
+   boolean: true
+   integer: 3
+   float: 3.14
+
+Or explicit:
+
+.. code-block:: text
+
+   boolean: !!bool "true"
+   integer: !!int "3"
+   float: !!float "3.14"
+
+Additionally, UW extends the following tags and constructors to support other formats:
+
+UW YAML Tags
+------------
+
+``!float``
+^^^^^^^^^^
+
+Converts the tagged node to a Python ``float`` type.
+
+.. code-block:: yaml
+
+   f2: !float '3.14'
+
+
+``!int``
+^^^^^^^^
+
+Converts the tagged node to a Python ``integer`` type.
+
+.. code-block:: yaml
+
+   cycle_day: !int "{{ cycle.strftime('%d') }}"
+
+
+``!include``
+^^^^^^^^^^^^
+
+Parse the tagged file and include its tags.
+
+.. code-block:: yaml
+
+   salad: !INCLUDE [./fruit_config.yaml]
+
+
+``!list``
+^^^^^^^^^
+
+Converts the tagged node to a Python ``list`` type.
+
+.. code-block:: yaml
+
+   file_names: !list [&gfs_file_names]
+
+
+``!remove``
+^^^^^^^^^^^
+
+Removes the tagged YAML key/value pair.
+
+.. code-block:: yaml
+
+   update_values: !remove

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -23,9 +23,6 @@ Or explicit:
 
 Additionally, UW defines the following tags to support use cases not covered by standard tags:
 
-UW YAML Tags
-------------
-
 ``!float``
 ^^^^^^^^^^
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -21,7 +21,7 @@ Or explicit:
    integer: !!int "3"
    float: !!float "3.14"
 
-Additionally, UW extends the following tags and constructors to support other formats:
+Additionally, UW defines the following tags to support use cases not covered by standard tags:
 
 UW YAML Tags
 ------------

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -26,9 +26,7 @@ Additionally, UW defines the following tags to support use cases not covered by 
 ``!float``
 ^^^^^^^^^^
 
-Converts the tagged node to a Python ``float`` value. For example:
-
-Given ``input.yaml``:
+Converts the tagged node to a Python ``float`` value. For example, given ``input.yaml``:
 
 .. code-block:: yaml
 
@@ -43,9 +41,7 @@ Given ``input.yaml``:
 ``!int``
 ^^^^^^^^
 
-Converts the tagged node to a Python ``int`` value. For example:
-
-Given ``input.yaml``:
+Converts the tagged node to a Python ``int`` value. For example, given ``input.yaml``:
 
 .. code-block:: yaml
 
@@ -64,9 +60,7 @@ Given ``input.yaml``:
 ``!include``
 ^^^^^^^^^^^^
 
-Parse the tagged file and include its tags. For example:
-
-Given ``input.yaml``:
+Parse the tagged file and include its tags. For example, given ``input.yaml``:
 
 .. code-block:: yaml
 
@@ -90,9 +84,7 @@ and ``supplemental.yaml``:
 ``!remove``
 ^^^^^^^^^^^
 
-Removes the tagged YAML key/value pair. For example:
-
-Given ``input.yaml``:
+Removes the tagged YAML key/value pair. For example, given ``input.yaml``:
 
 .. code-block:: yaml
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -3,7 +3,7 @@
 UW YAML tags
 ============
 
-Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined `here<http://yaml.org/type/index.html>`.
+Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined `here <http://yaml.org/type/index.html>`_.
 
 Tags may be implicit:
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -3,7 +3,7 @@
 UW YAML tags
 ============
 
-Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined [here](http://yaml.org/type/index.html).
+Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined `here<http://yaml.org/type/index.html>`.
 
 Tags may be implicit:
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -28,9 +28,14 @@ Additionally, UW defines the following tags to support use cases not covered by 
 
 Converts the tagged node to a Python ``float`` value.
 
-.. code-block:: yaml
+* Given input.yaml
+  .. code-block:: yaml
 
-   f2: !float '3.14'
+    f2: !float "{{ 3.141 + 2.718 }}"
+
+  .. code-block:: text
+     % uw config realize --input-file input.yaml --output-format yaml
+     f2: 5.859
 
 
 ``!int``
@@ -38,9 +43,20 @@ Converts the tagged node to a Python ``float`` value.
 
 Converts the tagged node to a Python ``int`` value.
 
-.. code-block:: yaml
 
-   cycle_day: !int "{{ cycle.strftime('%d') }}"
+* Given input.yaml
+  .. code-block:: yaml
+
+   values:
+    f1: 3
+    f2: 11
+    f3: !int "{{ (f1 + f2) * 10 }}"
+
+  .. code-block:: text
+     % uw config realize --input-file input.yaml --output-format yaml
+     f1: 3
+     f2: 11
+     f2: 140
 
 
 ``!include``
@@ -48,26 +64,40 @@ Converts the tagged node to a Python ``int`` value.
 
 Parse the tagged file and include its tags.
 
-.. code-block:: yaml
+* Given input.yaml
+  .. code-block:: yaml
 
-   salad: !INCLUDE [./fruit_config.yaml]
+     values: !INCLUDE [./supplemental.yaml]
 
+  and supplemental.yaml
+  .. code-block:: yaml
 
-``!list``
-^^^^^^^^^
+     e: 2.718
+     pi: 3.141
 
-Converts the tagged node to a Python ``list`` type.
-
-.. code-block:: yaml
-
-   file_names: !list [&gfs_file_names]
+  .. code-block:: text
+     % uw config realize --input-file input.yaml --output-format yaml
+     values:
+       e: 2.718
+       pi: 3.141
 
 
 ``!remove``
 ^^^^^^^^^^^
 
-Removes the tagged YAML key/value pair.
+Removes the tagged YAML key/value pair. For example:
 
-.. code-block:: yaml
+* Given input.yaml
+  .. code-block:: yaml
 
-   update_values: !remove
+     e: 2.718
+     pi: 3.141
+
+  and supplemental.yaml
+  .. code-block:: yaml
+
+     e: !remove
+
+  .. code-block:: text
+     % uw config realize --input-file input.yaml supplemental.yaml --output-format yaml
+     pi: 3.141

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -7,7 +7,7 @@ Tags are used to denote the type of a YAML node when converting to a Python obje
 
 Tags may be implicit:
 
-.. code-block:: text
+.. code-block:: yaml
 
    boolean: true
    integer: 3
@@ -15,7 +15,7 @@ Tags may be implicit:
 
 Or explicit:
 
-.. code-block:: text
+.. code-block:: yaml
 
    boolean: !!bool "true"
    integer: !!int "3"

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -26,60 +26,65 @@ Additionally, UW defines the following tags to support use cases not covered by 
 ``!float``
 ^^^^^^^^^^
 
-Converts the tagged node to a Python ``float`` value.
+Converts the tagged node to a Python ``float`` value. For example:
 
-* Given input.yaml
-  .. code-block:: yaml
+Given input.yaml:
 
-    f2: !float "{{ 3.141 + 2.718 }}"
+.. code-block:: yaml
 
-  .. code-block:: text
-     % uw config realize --input-file input.yaml --output-format yaml
-     f2: 5.859
+   f2: !float "{{ 3.141 + 2.718 }}"
+
+.. code-block:: text
+
+   % uw config realize --input-file input.yaml --output-format yaml
+   f2: 5.859
 
 
 ``!int``
 ^^^^^^^^
 
-Converts the tagged node to a Python ``int`` value.
+Converts the tagged node to a Python ``int`` value. For example:
 
+Given input.yaml:
 
-* Given input.yaml
-  .. code-block:: yaml
+.. code-block:: yaml
 
-   values:
-    f1: 3
-    f2: 11
-    f3: !int "{{ (f1 + f2) * 10 }}"
+   f1: 3
+   f2: 11
+   f3: !int "{{ (f1 + f2) * 10 }}"
 
-  .. code-block:: text
-     % uw config realize --input-file input.yaml --output-format yaml
-     f1: 3
-     f2: 11
-     f2: 140
+.. code-block:: text
+
+   % uw config realize --input-file input.yaml --output-format yaml
+   f1: 3
+   f2: 11
+   f2: 140
 
 
 ``!include``
 ^^^^^^^^^^^^
 
-Parse the tagged file and include its tags.
+Parse the tagged file and include its tags. For example:
 
-* Given input.yaml
-  .. code-block:: yaml
+Given input.yaml:
 
-     values: !INCLUDE [./supplemental.yaml]
+.. code-block:: yaml
 
-  and supplemental.yaml
-  .. code-block:: yaml
+   values: !INCLUDE [./supplemental.yaml]
 
-     e: 2.718
-     pi: 3.141
+and supplemental.yaml:
 
-  .. code-block:: text
-     % uw config realize --input-file input.yaml --output-format yaml
-     values:
-       e: 2.718
-       pi: 3.141
+.. code-block:: yaml
+
+   e: 2.718
+   pi: 3.141
+
+.. code-block:: text
+
+   % uw config realize --input-file input.yaml --output-format yaml
+   values:
+      e: 2.718
+      pi: 3.141
 
 
 ``!remove``
@@ -87,17 +92,20 @@ Parse the tagged file and include its tags.
 
 Removes the tagged YAML key/value pair. For example:
 
-* Given input.yaml
-  .. code-block:: yaml
+Given input.yaml:
 
-     e: 2.718
-     pi: 3.141
+.. code-block:: yaml
 
-  and supplemental.yaml
-  .. code-block:: yaml
+   e: 2.718
+   pi: 3.141
 
-     e: !remove
+and supplemental.yaml:
 
-  .. code-block:: text
-     % uw config realize --input-file input.yaml supplemental.yaml --output-format yaml
-     pi: 3.141
+.. code-block:: yaml
+
+   e: !remove
+
+.. code-block:: text
+
+   % uw config realize --input-file input.yaml supplemental.yaml --output-format yaml
+   pi: 3.141

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -3,7 +3,7 @@
 UW YAML tags
 ============
 
-Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined at http://yaml.org/type/index.html.
+Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined [here](http://yaml.org/type/index.html).
 
 Tags may be implicit:
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -28,7 +28,7 @@ Additionally, UW defines the following tags to support use cases not covered by 
 
 Converts the tagged node to a Python ``float`` value. For example:
 
-Given input.yaml:
+Given ``input.yaml``:
 
 .. code-block:: yaml
 
@@ -45,7 +45,7 @@ Given input.yaml:
 
 Converts the tagged node to a Python ``int`` value. For example:
 
-Given input.yaml:
+Given ``input.yaml``:
 
 .. code-block:: yaml
 
@@ -66,13 +66,13 @@ Given input.yaml:
 
 Parse the tagged file and include its tags. For example:
 
-Given input.yaml:
+Given ``input.yaml``:
 
 .. code-block:: yaml
 
    values: !INCLUDE [./supplemental.yaml]
 
-and supplemental.yaml:
+and ``supplemental.yaml``:
 
 .. code-block:: yaml
 
@@ -92,14 +92,14 @@ and supplemental.yaml:
 
 Removes the tagged YAML key/value pair. For example:
 
-Given input.yaml:
+Given ``input.yaml``:
 
 .. code-block:: yaml
 
    e: 2.718
    pi: 3.141
 
-and supplemental.yaml:
+and ``supplemental.yaml``:
 
 .. code-block:: yaml
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -1,7 +1,7 @@
 .. _defining_YAML_tags:
 
-Defining YAML ``tags``
-==========================
+UW YAML tags
+============
 
 Tags are used to denote the type of a YAML node when converting to a Python object. Standard YAML tags are defined at http://yaml.org/type/index.html.
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -29,7 +29,7 @@ UW YAML Tags
 ``!float``
 ^^^^^^^^^^
 
-Converts the tagged node to a Python ``float`` type.
+Converts the tagged node to a Python ``float`` value.
 
 .. code-block:: yaml
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -39,7 +39,7 @@ Converts the tagged node to a Python ``float`` type.
 ``!int``
 ^^^^^^^^
 
-Converts the tagged node to a Python ``integer`` type.
+Converts the tagged node to a Python ``int`` value.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
**Synopsis**

Describe the behavior for how this syntax works. it is modeled from pyYAML syntax for YAML tags and constructors, but the behavior is extended in UW to support the other formats. May also include the remove and list tags.

Acceptance Criteria:
add a YAML page to the documentation
include the the int, float and include tags

Docs for this PR are [here](https://uwtools--463.org.readthedocs.build/en/463/sections/user_guide/yaml/tags.html)

**Type**

- [ ] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation
- [ ] Enhancement (adds a new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
