### PR TITLE
UW-566 Support FV3 global-domain configuration

### DIFF
--- a/docs/sections/user_guide/yaml/components/fv3.rst
+++ b/docs/sections/user_guide/yaml/components/fv3.rst
@@ -58,7 +58,7 @@ Identical to ``files_to_copy:`` except that symbolic links will be created in th
 lateral_boundary_conditions:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Describes how the lateral boundary conditions have been prepared for a limited-area configuration of the FV3 forecast.
+Describes how the lateral boundary conditions have been prepared for a limited-area configuration of the FV3 forecast. Required when ``domain`` is ``regional``.
 
 interval_hours:
 """""""""""""""

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -157,8 +157,7 @@ class FV3(Driver):
         Run directory provisioned with all required content.
         """
         yield self._taskname("provisioned run directory")
-        yield [
-            self.boundary_files(),
+        required = [
             self.diag_table(),
             self.field_table(),
             self.files_copied(),
@@ -168,6 +167,9 @@ class FV3(Driver):
             self.restart_directory(),
             self.runscript(),
         ]
+        if self._driver_config["domain"] == "regional":
+            required.append(self.boundary_files())
+        yield required
 
     @task
     def restart_directory(self):

--- a/src/uwtools/resources/jsonschema/fv3.jsonschema
+++ b/src/uwtools/resources/jsonschema/fv3.jsonschema
@@ -2,6 +2,22 @@
   "properties": {
     "fv3": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "domain": {
+                "const": "regional"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "lateral_boundary_conditions"
+            ]
+          }
+        }
+      ],
       "properties": {
         "diag_table": {
           "type": "string"
@@ -195,7 +211,6 @@
       "required": [
         "domain",
         "execution",
-        "lateral_boundary_conditions",
         "length",
         "run_dir"
       ],

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -160,7 +160,7 @@ def test_FV3_namelist_file(driverobj):
     assert dst.is_file()
 
 
-def test_FV3_provisioned_run_directory(driverobj):
+def test_FV3_provisioned_run_directory_global(driverobj):
     with patch.multiple(
         driverobj,
         boundary_files=D,
@@ -178,6 +178,25 @@ def test_FV3_provisioned_run_directory(driverobj):
         if not m == "boundary_files":
             mocks[m].assert_called_once_with()
     mocks["boundary_files"].assert_not_called()
+
+
+def test_FV3_provisioned_run_directory_regional(driverobj):
+    driverobj._driver_config["domain"] = "regional"
+    with patch.multiple(
+        driverobj,
+        boundary_files=D,
+        diag_table=D,
+        field_table=D,
+        files_copied=D,
+        files_linked=D,
+        model_configure=D,
+        namelist_file=D,
+        restart_directory=D,
+        runscript=D,
+    ) as mocks:
+        driverobj.provisioned_run_directory()
+    for m in mocks:
+        mocks[m].assert_called_once_with()
 
 
 def test_FV3_restart_directory(driverobj):

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -178,10 +178,10 @@ def test_FV3_provisioned_run_directory_global(domain, driverobj):
         driverobj.provisioned_run_directory()
     excluded = ["boundary_files"] if domain == "global" else []
     for m in mocks:
-        if not m in excluded:
+        if m in excluded:
+            mocks[m].assert_not_called()
+        else:
             mocks[m].assert_called_once_with()
-    for m in excluded:
-        mocks[m].assert_not_called()
 
 
 def test_FV3_restart_directory(driverobj):

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -175,7 +175,9 @@ def test_FV3_provisioned_run_directory(driverobj):
     ) as mocks:
         driverobj.provisioned_run_directory()
     for m in mocks:
-        mocks[m].assert_called_once_with()
+        if not m == "boundary_files":
+            mocks[m].assert_called_once_with()
+    mocks["boundary_files"].assert_not_called()
 
 
 def test_FV3_restart_directory(driverobj):

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -160,7 +160,9 @@ def test_FV3_namelist_file(driverobj):
     assert dst.is_file()
 
 
-def test_FV3_provisioned_run_directory_global(driverobj):
+@pytest.mark.parametrize("domain", ("global", "regional"))
+def test_FV3_provisioned_run_directory_global(domain, driverobj):
+    driverobj._driver_config["domain"] = domain
     with patch.multiple(
         driverobj,
         boundary_files=D,
@@ -174,29 +176,12 @@ def test_FV3_provisioned_run_directory_global(driverobj):
         runscript=D,
     ) as mocks:
         driverobj.provisioned_run_directory()
+    excluded = ["boundary_files"] if domain == "global" else []
     for m in mocks:
-        if not m == "boundary_files":
+        if not m in excluded:
             mocks[m].assert_called_once_with()
-    mocks["boundary_files"].assert_not_called()
-
-
-def test_FV3_provisioned_run_directory_regional(driverobj):
-    driverobj._driver_config["domain"] = "regional"
-    with patch.multiple(
-        driverobj,
-        boundary_files=D,
-        diag_table=D,
-        field_table=D,
-        files_copied=D,
-        files_linked=D,
-        model_configure=D,
-        namelist_file=D,
-        restart_directory=D,
-        runscript=D,
-    ) as mocks:
-        driverobj.provisioned_run_directory()
-    for m in mocks:
-        mocks[m].assert_called_once_with()
+    for m in excluded:
+        mocks[m].assert_not_called()
 
 
 def test_FV3_restart_directory(driverobj):


### PR DESCRIPTION
**Synopsis**

Make lateral boundary conditions required only when running FV3 with a regional domain.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Documentation
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
