### PR TITLE
Concise schema-validation error messages

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -14,7 +14,7 @@ import yaml
 from uwtools.config import jinja2
 from uwtools.config.support import INCLUDE_TAG, depth, log_and_error
 from uwtools.exceptions import UWConfigError
-from uwtools.logging import log
+from uwtools.logging import INDENT, log
 
 
 class Config(ABC, UserDict):
@@ -96,7 +96,7 @@ class Config(ABC, UserDict):
         template: List[str] = []
         for key, val in values.items():
             if isinstance(val, dict):
-                complete.append(f"    {parent}{key}")
+                complete.append(f"{INDENT}{parent}{key}")
                 c, e, t = self.characterize_values(val, f"{parent}{key}.")
                 complete, empty, template = complete + c, empty + e, template + t
             elif isinstance(val, list):
@@ -104,16 +104,16 @@ class Config(ABC, UserDict):
                     if isinstance(item, dict):
                         c, e, t = self.characterize_values(item, parent)
                         complete, empty, template = complete + c, empty + e, template + t
-                        complete.append(f"    {parent}{key}")
+                        complete.append(f"{INDENT}{parent}{key}")
                     elif "{{" in str(val) or "{%" in str(val):
-                        template.append(f"    {parent}{key}: {val}")
+                        template.append(f"{INDENT}{parent}{key}: {val}")
                         break
             elif "{{" in str(val) or "{%" in str(val):
-                template.append(f"    {parent}{key}: {val}")
+                template.append(f"{INDENT}{parent}{key}: {val}")
             elif val == "" or val is None:
-                empty.append(f"    {parent}{key}")
+                empty.append(f"{INDENT}{parent}{key}")
             else:
-                complete.append(f"    {parent}{key}")
+                complete.append(f"{INDENT}{parent}{key}")
         return complete, empty, template
 
     def compare_config(self, dict1: dict, dict2: Optional[dict] = None) -> bool:
@@ -169,7 +169,7 @@ class Config(ABC, UserDict):
         def logstate(state: str) -> None:
             log.debug("Dereferencing, %s value:", state)
             for line in str(self).split("\n"):
-                log.debug("  %s", line)
+                log.debug("%s%s", INDENT, line)
 
         while True:
             logstate("current")

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -11,7 +11,7 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined, Undefined, me
 from jinja2.exceptions import UndefinedError
 
 from uwtools.config.support import UWYAMLConvert, UWYAMLRemove, format_to_config
-from uwtools.logging import MSGWIDTH, log
+from uwtools.logging import INDENT, MSGWIDTH, log
 from uwtools.utils.file import get_file_format, readable, writable
 
 _ConfigVal = Union[bool, dict, float, int, list, str, UWYAMLConvert, UWYAMLRemove]
@@ -294,7 +294,7 @@ def _log_missing_values(missing: List[str]) -> None:
     """
     log.error("Required value(s) not provided:")
     for key in missing:
-        log.error(f"  {key}")
+        log.error(f"{INDENT}{key}")
 
 
 def _register_filters(env: Environment) -> Environment:
@@ -369,7 +369,7 @@ def _values_needed(undeclared_variables: Set[str]) -> None:
     """
     log.info("Value(s) needed to render this template are:")
     for var in sorted(undeclared_variables):
-        log.info(f"  {var}")
+        log.info(f"{INDENT}{var}")
 
 
 def _write_template(output_file: Optional[Path], rendered_template: str) -> str:

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -12,7 +12,7 @@ from referencing.jsonschema import DRAFT202012
 
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.exceptions import UWConfigError
-from uwtools.logging import log
+from uwtools.logging import INDENT, log
 from uwtools.utils.file import resource_path
 
 # Public functions

--- a/src/uwtools/logging.py
+++ b/src/uwtools/logging.py
@@ -16,6 +16,7 @@ import iotaa
 #
 # is 31 characters, leaving 69 for messages (e.g. separators) on a 100-character line.
 
+INDENT = "  "
 MSGWIDTH = 69
 
 

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -81,9 +81,9 @@ def test__load_paths(config, tmp_path):
 def test_characterize_values(config):
     values = {1: "", 2: None, 3: "{{ n }}", 4: {"a": 88}, 5: [{"b": 99}], 6: "string"}
     complete, empty, template = config.characterize_values(values=values, parent="p")
-    assert complete == ["    p4", "    p4.a", "    pb", "    p5", "    p6"]
-    assert empty == ["    p1", "    p2"]
-    assert template == ["    p3: {{ n }}"]
+    assert complete == ["  p4", "  p4.a", "  pb", "  p5", "  p6"]
+    assert empty == ["  p1", "  p2"]
+    assert template == ["  p3: {{ n }}"]
 
 
 @pytest.mark.parametrize("fmt", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -529,23 +529,23 @@ def test_realize_config_values_needed_ini(caplog):
     )
     expected = """
 Keys that are complete:
-    salad
-    salad.base
-    salad.fruit
-    salad.vegetable
-    salad.dressing
-    dessert
-    dessert.type
-    dessert.side
-    dessert.servings
+  salad
+  salad.base
+  salad.fruit
+  salad.vegetable
+  salad.dressing
+  dessert
+  dessert.type
+  dessert.side
+  dessert.servings
 
 Keys with unrendered Jinja2 variables/expressions:
-    salad.how_many: {{ amount }}
-    dessert.flavor: {{ flavor }}
+  salad.how_many: {{ amount }}
+  dessert.flavor: {{ flavor }}
 
 Keys that are set to empty:
-    salad.toppings
-    salad.meat
+  salad.toppings
+  salad.meat
 """.strip()
     actual = "\n".join(record.message for record in caplog.records)
     assert actual == expected
@@ -566,22 +566,22 @@ def test_realize_config_values_needed_yaml(caplog):
     actual = "\n".join(record.message for record in caplog.records)
     expected = """
 Keys that are complete:
-    FV3GFS
-    FV3GFS.nomads
-    FV3GFS.nomads.protocol
-    FV3GFS.nomads.file_names
-    FV3GFS.nomads.file_names.grib2
-    FV3GFS.nomads.file_names.testfalse
-    FV3GFS.nomads.file_names.testzero
+  FV3GFS
+  FV3GFS.nomads
+  FV3GFS.nomads.protocol
+  FV3GFS.nomads.file_names
+  FV3GFS.nomads.file_names.grib2
+  FV3GFS.nomads.file_names.testfalse
+  FV3GFS.nomads.file_names.testzero
 
 Keys with unrendered Jinja2 variables/expressions:
-    FV3GFS.nomads.url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos
-    FV3GFS.nomads.file_names.grib2.anl: ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio']
-    FV3GFS.nomads.file_names.grib2.fcst: ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']
+  FV3GFS.nomads.url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos
+  FV3GFS.nomads.file_names.grib2.anl: ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio']
+  FV3GFS.nomads.file_names.grib2.fcst: ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']
 
 Keys that are set to empty:
-    FV3GFS.nomads.file_names.nemsio
-    FV3GFS.nomads.testempty
+  FV3GFS.nomads.file_names.nemsio
+  FV3GFS.nomads.testempty
 """.strip()
     assert actual == expected
 
@@ -725,9 +725,9 @@ def test__realize_config_values_needed(caplog, tmp_path):
     c = YAMLConfig(config=path)
     tools._realize_config_values_needed(input_obj=c)
     msgs = "\n".join(record.message for record in caplog.records)
-    assert "Keys that are complete:\n    1" in msgs
-    assert "Keys with unrendered Jinja2 variables/expressions:\n    2" in msgs
-    assert "Keys that are set to empty:\n    3" in msgs
+    assert "Keys that are complete:\n  1" in msgs
+    assert "Keys with unrendered Jinja2 variables/expressions:\n  2" in msgs
+    assert "Keys that are set to empty:\n  3" in msgs
 
 
 def test__realize_config_values_needed_negative_results(caplog, tmp_path):

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -128,7 +128,8 @@ def test_validate_internal_no(caplog, schema_file):
     with patch.object(validator, "resource_path", return_value=schema_file.parent):
         with raises(UWConfigError) as e:
             validator.validate_internal(schema_name="a", config={"color": "orange"})
-    assert logged(caplog, "'orange' is not one of ['blue', 'red']")
+    assert logged(caplog, "Error at color:")
+    assert logged(caplog, "  'orange' is not one of ['blue', 'red']")
     assert str(e.value) == "YAML validation errors"
 
 

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from subprocess import STDOUT, CalledProcessError, check_output
 from typing import Dict, Optional, Tuple, Union
 
-from uwtools.logging import log
+from uwtools.logging import INDENT, log
 
 
 def execute(
@@ -25,14 +25,13 @@ def execute(
     :return: A result object providing combined stder/stdout output and success values.
     """
 
-    indent = "  "
     log.info("Executing: %s", cmd)
     if cwd:
-        log.info("%sin %s", indent, cwd)
+        log.info("%sin %s", INDENT, cwd)
     if env:
-        log.info("%swith environment variables:", indent)
+        log.info("%swith environment variables:", INDENT)
         for key, val in env.items():
-            log.info("%s%s=%s", indent * 2, key, val)
+            log.info("%s%s=%s", INDENT * 2, key, val)
     try:
         output = check_output(
             cmd, cwd=cwd, encoding="utf=8", env=env, shell=True, stderr=STDOUT, text=True
@@ -41,11 +40,11 @@ def execute(
         success = True
     except CalledProcessError as e:
         output = e.output
-        log.error("%sFailed with status: %s", indent, e.returncode)
+        log.error("%sFailed with status: %s", INDENT, e.returncode)
         logfunc = log.error
         success = False
     if output and (log_output or not success):
-        logfunc("%sOutput:", indent)
+        logfunc("%sOutput:", INDENT)
         for line in output.split("\n"):
-            logfunc("%s%s", indent * 2, line)
+            logfunc("%s%s", INDENT * 2, line)
     return success, output


### PR DESCRIPTION
**Synopsis**

1. Instead of printing the entire `str` representation of a JSON Schema validation error, select, format, and log the most pertinent information to avoid information overwhelm.
2. Standardize indentation in error messages.

Using the `fv3` driver config as an example, and making two breaking changes -- setting the lateral boundary conditions `interval_hours` to `-1` and removing the forecast `length` key entirely -- we get

Old behavior:

```
% uw fv3 validate --config-file fv3.yaml --cycle 2024-04-19T12
[2024-04-20T16:03:29]     INFO Validating config against internal schema fv3
[2024-04-20T16:03:29]    ERROR 2 UW schema-validation errors found
[2024-04-20T16:03:29]    ERROR -1 is less than the minimum of 1
[2024-04-20T16:03:29]    ERROR 
[2024-04-20T16:03:29]    ERROR Failed validating 'minimum' in schema['properties']['fv3']['properties']['lateral_boundary_conditions']['properties']['interval_hours']:
[2024-04-20T16:03:29]    ERROR     {'minimum': 1, 'type': 'integer'}
[2024-04-20T16:03:29]    ERROR 
[2024-04-20T16:03:29]    ERROR On instance['fv3']['lateral_boundary_conditions']['interval_hours']:
[2024-04-20T16:03:29]    ERROR     -1
[2024-04-20T16:03:29]    ERROR 'length' is a required property
[2024-04-20T16:03:29]    ERROR 
[2024-04-20T16:03:29]    ERROR Failed validating 'required' in schema['properties']['fv3']:
[2024-04-20T16:03:29]    ERROR     {'additionalProperties': False,
[2024-04-20T16:03:29]    ERROR      'allOf': [{'if': {'properties': {'domain': {'const': 'regional'}}},
[2024-04-20T16:03:29]    ERROR                 'then': {'required': ['lateral_boundary_conditions']}}],
[2024-04-20T16:03:29]    ERROR      'properties': {'diag_table': {'type': 'string'},
[2024-04-20T16:03:29]    ERROR                     'domain': {'enum': ['global', 'regional'],
[2024-04-20T16:03:29]    ERROR                                'type': 'string'},
[2024-04-20T16:03:29]    ERROR                     'execution': {'$ref': 'urn:uwtools:execution'},
[2024-04-20T16:03:29]    ERROR                     'field_table': {'additionalProperties': False,
[2024-04-20T16:03:29]    ERROR                                     'properties': {'base_file': {'type': 'string'}},
[2024-04-20T16:03:29]    ERROR                                     'required': ['base_file'],
[2024-04-20T16:03:29]    ERROR                                     'type': 'object'},
[2024-04-20T16:03:29]    ERROR                     'files_to_copy': {'$ref': 'urn:uwtools:files-to-stage'},
[2024-04-20T16:03:29]    ERROR                     'files_to_link': {'$ref': 'urn:uwtools:files-to-stage'},
[2024-04-20T16:03:29]    ERROR                     'lateral_boundary_conditions': {'additionalProperties': False,
[2024-04-20T16:03:29]    ERROR                                                     'properties': {'interval_hours': {'minimum': 1,
[2024-04-20T16:03:29]    ERROR                                                                                       'type': 'integer'},
[2024-04-20T16:03:29]    ERROR                                                                    'offset': {'minimum': 0,
[2024-04-20T16:03:29]    ERROR                                                                               'type': 'integer'},
[2024-04-20T16:03:29]    ERROR                                                                    'path': {'type': 'string'}},
[2024-04-20T16:03:29]    ERROR                                                     'required': ['interval_hours',
[2024-04-20T16:03:29]    ERROR                                                                  'offset',
[2024-04-20T16:03:29]    ERROR                                                                  'path'],
[2024-04-20T16:03:29]    ERROR                                                     'type': 'object'},
[2024-04-20T16:03:29]    ERROR                     'length': {'minimum': 1, 'type': 'integer'},
[2024-04-20T16:03:29]    ERROR                     'model_configure': {'additionalProperties': False,
[2024-04-20T16:03:29]    ERROR                                         'anyOf': [{'required': ['base_file']},
[2024-04-20T16:03:29]    ERROR                                                   {'required': ['update_values']}],
[2024-04-20T16:03:29]    ERROR                                         'properties': {'base_file': {'type': 'string'},
[2024-04-20T16:03:29]    ERROR                                                        'update_values': {'minProperties': 1,
[2024-04-20T16:03:29]    ERROR                                                                          'patternProperties': {'^.*$': {'type': ['boolean',
[2024-04-20T16:03:29]    ERROR                                                                                                                  'number',
[2024-04-20T16:03:29]    ERROR                                                                                                                  'string']}},
[2024-04-20T16:03:29]    ERROR                                                                          'type': 'object'}},
[2024-04-20T16:03:29]    ERROR                                         'type': 'object'},
[2024-04-20T16:03:29]    ERROR                     'namelist': {'additionalProperties': False,
[2024-04-20T16:03:29]    ERROR                                  'anyOf': [{'required': ['base_file']},
[2024-04-20T16:03:29]    ERROR                                            {'required': ['update_values']}],
[2024-04-20T16:03:29]    ERROR                                  'properties': {'base_file': {'type': 'string'},
[2024-04-20T16:03:29]    ERROR                                                 'update_values': {'$ref': 'urn:uwtools:namelist'}},
[2024-04-20T16:03:29]    ERROR                                  'type': 'object'},
[2024-04-20T16:03:29]    ERROR                     'run_dir': {'type': 'string'}},
[2024-04-20T16:03:29]    ERROR      'required': ['domain',
[2024-04-20T16:03:29]    ERROR                   'execution',
[2024-04-20T16:03:29]    ERROR                   'field_table',
[2024-04-20T16:03:29]    ERROR                   'length',
[2024-04-20T16:03:29]    ERROR                   'run_dir'],
[2024-04-20T16:03:29]    ERROR      'type': 'object'}
[2024-04-20T16:03:29]    ERROR 
[2024-04-20T16:03:29]    ERROR On instance['fv3']:
[2024-04-20T16:03:29]    ERROR     {'diag_table': '/path/to/diag_table_to_use',
[2024-04-20T16:03:29]    ERROR      'domain': 'regional',
[2024-04-20T16:03:29]    ERROR      'execution': {'batchargs': {'walltime': '00:10:00'},
[2024-04-20T16:03:29]    ERROR                    'executable': 'ufs_model',
[2024-04-20T16:03:29]    ERROR                    'mpiargs': ['--export=NONE'],
[2024-04-20T16:03:29]    ERROR                    'mpicmd': 'srun',
[2024-04-20T16:03:29]    ERROR                    'threads': 1},
[2024-04-20T16:03:29]    ERROR      'field_table': {'base_file': '/path/to/field_table_to_use'},
[2024-04-20T16:03:29]    ERROR      'files_to_copy': {'INPUT/gfs_ctrl.nc': '/path/to/gfs_ctrl.nc',
[2024-04-20T16:03:29]    ERROR                        'INPUT/gfs_data.nc': '/path/to/gfs_data.nc',
[2024-04-20T16:03:29]    ERROR                        'INPUT/sfc_data.nc': '/path/to/sfc_data.nc'},
[2024-04-20T16:03:29]    ERROR      'files_to_link': {'co2historicaldata_2010.txt': 'src/uwtools/drivers/global_co2historicaldata_2010.txt',
[2024-04-20T16:03:29]    ERROR                        'co2historicaldata_2011.txt': 'src/uwtools/drivers/global_co2historicaldata_2011.txt'},
[2024-04-20T16:03:29]    ERROR      'lateral_boundary_conditions': {'interval_hours': -1,
[2024-04-20T16:03:29]    ERROR                                      'offset': 0,
[2024-04-20T16:03:29]    ERROR                                      'path': 'gfs_bndy.tile{tile}.f{forecast_hour}.nc'},
[2024-04-20T16:03:29]    ERROR      'model_configure': {'base_file': '/path/to/model_configure_to_use',
[2024-04-20T16:03:29]    ERROR                          'update_values': {'write_dopost': '.false.'}},
[2024-04-20T16:03:29]    ERROR      'namelist': {'base_file': '/path/to/base/input.nml',
[2024-04-20T16:03:29]    ERROR                   'update_values': {'fv_core_nml': {'k_split': 2,
[2024-04-20T16:03:29]    ERROR                                                     'n_split': 6}}},
[2024-04-20T16:03:29]    ERROR      'run_dir': '/path/to/runs/2024041912'}
[2024-04-20T16:03:29]    ERROR YAML validation errors
```

New behavior:

```
% uw fv3 validate --config-file fv3.yaml --cycle 2024-04-19T12
[2024-04-20T16:03:03]     INFO Validating config against internal schema fv3
[2024-04-20T16:03:03]    ERROR 2 UW schema-validation errors found
[2024-04-20T16:03:03]    ERROR Error at fv3 -> lateral_boundary_conditions -> interval_hours:
[2024-04-20T16:03:03]    ERROR   -1 is less than the minimum of 1
[2024-04-20T16:03:03]    ERROR Error at fv3:
[2024-04-20T16:03:03]    ERROR   'length' is a required property
[2024-04-20T16:03:03]    ERROR YAML validation errors
```

**Type**

- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
