### PR TITLE
CLI updates

### DIFF
--- a/docs/sections/user_guide/cli/tools/config.rst
+++ b/docs/sections/user_guide/cli/tools/config.rst
@@ -191,7 +191,6 @@ In ``uw`` terminology, to realize a configuration file is to transform it from i
      PATH
          Additional files to supplement primary input
 
-
 Examples
 ^^^^^^^^
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -110,7 +110,7 @@ def _add_subparser_chgres_cube_task(
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_cycle(required)
     optional = _basic_setup(parser)
-    _add_arg_config_file(group=optional, required=False)
+    _add_arg_config_file(group=optional)
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
@@ -317,7 +317,7 @@ def _add_subparser_file_common(parser: Parser) -> ActionChecks:
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_target_dir(required, required=True)
     optional = _basic_setup(parser)
-    _add_arg_config_file(group=optional, required=False)
+    _add_arg_config_file(group=optional)
     _add_arg_dry_run(optional)
     checks = _add_args_verbosity(optional)
     _add_arg_keys(optional)
@@ -417,7 +417,7 @@ def _add_subparser_fv3_task(subparsers: Subparsers, task: str, helpmsg: str) -> 
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_cycle(required)
     optional = _basic_setup(parser)
-    _add_arg_config_file(group=optional, required=False)
+    _add_arg_config_file(group=optional)
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
@@ -469,9 +469,9 @@ def _add_subparser_jedi_task(subparsers: Subparsers, task: str, helpmsg: str) ->
     """
     parser = _add_subparser(subparsers, task, helpmsg.rstrip("."))
     required = parser.add_argument_group(TITLE_REQ_ARG)
-    _add_arg_config_file(group=required, required=True)
     _add_arg_cycle(required)
     optional = _basic_setup(parser)
+    _add_arg_config_file(group=optional)
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
@@ -527,7 +527,7 @@ def _add_subparser_mpas_task(subparsers: Subparsers, task: str, helpmsg: str) ->
 
     _add_arg_cycle(required)
     optional = _basic_setup(parser)
-    _add_arg_config_file(group=optional, required=False)
+    _add_arg_config_file(group=optional)
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
@@ -582,7 +582,7 @@ def _add_subparser_mpas_init_task(subparsers: Subparsers, task: str, helpmsg: st
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_cycle(required)
     optional = _basic_setup(parser)
-    _add_arg_config_file(group=optional, required=False)
+    _add_arg_config_file(group=optional)
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
@@ -717,7 +717,7 @@ def _add_subparser_sfc_climo_gen_task(
     """
     parser = _add_subparser(subparsers, task, helpmsg.rstrip("."))
     optional = _basic_setup(parser)
-    _add_arg_config_file(group=optional, required=False)
+    _add_arg_config_file(group=optional)
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
@@ -878,7 +878,7 @@ def _add_subparser_ungrib_task(subparsers: Subparsers, task: str, helpmsg: str) 
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_cycle(required)
     optional = _basic_setup(parser)
-    _add_arg_config_file(group=optional, required=False)
+    _add_arg_config_file(group=optional)
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
@@ -916,7 +916,7 @@ def _add_arg_batch(group: Group) -> None:
     )
 
 
-def _add_arg_config_file(group: Group, required: bool) -> None:
+def _add_arg_config_file(group: Group, required: bool = False) -> None:
     msg = "Path to config file" + ("" if required else " (default: read from stdin)")
     group.add_argument(
         _switch(STR.cfgfile),


### PR DESCRIPTION
**Synopsis**

- Make the `--config-file` option to `uw jedi` optional, as it is for the other drivers. If not specified, `stdin` will be read.
- Make the `required` argument to `_add_arg_config_file()` in `uwtools.cli` optional, with a `False` default value, and eliminate some now-unnecessary arguments.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
