### PR TITLE
Treat 'cycle' conditionally when calling API execute() functions

### DIFF
--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -924,15 +924,17 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
     :param args: Parsed command-line args.
     """
     execute: Callable[..., bool] = import_module("uwtools.api.%s" % name).execute
-    return execute(
-        task=args[STR.action],
-        config=args[STR.cfgfile],
-        cycle=args[STR.cycle],
-        batch=args[STR.batch],
-        dry_run=args[STR.dryrun],
-        graph_file=args[STR.graphfile],
-        stdin_ok=True,
-    )
+    kwargs = {
+        "task": args[STR.action],
+        "config": args[STR.cfgfile],
+        "batch": args[STR.batch],
+        "dry_run": args[STR.dryrun],
+        "graph_file": args[STR.graphfile],
+        "stdin_ok": True,
+    }
+    if cycle := args.get(STR.cycle):
+        kwargs[STR.cycle] = cycle
+    return execute(**kwargs)
 
 
 def _formatter(prog: str) -> HelpFormatter:


### PR DESCRIPTION
**Synopsis**

Bug fix: Only pass the `cycle` parameter to a driver's `execute()` API function when that argument is expected.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
