### PR TITLE
Use datetime.timezone.utc instead of datetime.UTC alias function

### DIFF
--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -551,7 +551,7 @@ def _add_arg_config_file(group: Group, required: bool = False) -> None:
 
 
 def _add_arg_cycle(group: Group) -> None:
-    offset = dt.timedelta(hours=(dt.datetime.now(dt.UTC).hour // 6) * 6)
+    offset = dt.timedelta(hours=(dt.datetime.now(dt.timezone.utc).hour // 6) * 6)
     cycle = dt.datetime.combine(dt.date.today(), dt.datetime.min.time()) + offset
     group.add_argument(
         _switch(STR.cycle),


### PR DESCRIPTION

**Synopsis**

This is a one line change that replaces the call to `datetime.UTC` with a call to `datetime.timezone.utc`.  This maintains backward compatibility with versions of Python (< 3.11) before the `datetime.UTC` alias function was introduced.  Fixes #487 .

**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
