### PR TITLE
uw-579-resolve-walltime-inconsistencies

### DIFF
--- a/src/uwtools/resources/jsonschema/execution-serial.jsonschema
+++ b/src/uwtools/resources/jsonschema/execution-serial.jsonschema
@@ -2,6 +2,15 @@
   "additionalProperties": false,
   "properties": {
     "batchargs": {
+      "additionalProperties": true,
+      "properties": {
+        "walltime": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "walltime"
+      ],
       "type": "object"
     },
     "envcmds": {

--- a/src/uwtools/resources/jsonschema/execution.jsonschema
+++ b/src/uwtools/resources/jsonschema/execution.jsonschema
@@ -2,6 +2,15 @@
   "additionalProperties": false,
   "properties": {
     "batchargs": {
+      "additionalProperties": true,
+      "properties": {
+        "walltime": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "walltime"
+      ],
       "type": "object"
     },
     "envcmds": {

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -234,12 +234,13 @@ def test_execution():
 
 def test_execution_batchargs():
     errors = schema_validator("execution", "properties", "batchargs")
-    # Basic correctness, empty map is ok:
-    assert not errors({})
+    # Basic correctness, only walltime is required:
+    assert "'walltime' is a required property" in errors({})
+    assert not errors({"walltime": "00:05:00"})
     # Managed properties are fine:
-    assert not errors({"queue": "string", "walltime": "string"})
+    assert not errors({"queue": "string", "walltime": "00:05:00"})
     # But so are unknown ones:
-    assert not errors({"--foo": 88})
+    assert not errors({"--foo": 88, "walltime": "00:05:00"})
     # It just has to be a map:
     assert "[] is not of type 'object'" in errors([])
 


### PR DESCRIPTION
**Synopsis**

Make `execution.batchargs.walltime` required when `execution.batchargs` is present in a driver config. See [UW-579](https://jira.epic.oarcloud.noaa.gov/browse/UW-579) for details. This is not a breaking change because the code that looks up the value of `walltime` does so with `[]` syntax (not `.get()` syntax), so that that it was implicitly required already. Existing use cases that work should continue to work.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
