### PR TITLE
UW-598 JEDI driver fix to provide a JEDI config in the run command. 

### DIFF
--- a/src/uwtools/drivers/jedi.py
+++ b/src/uwtools/drivers/jedi.py
@@ -49,7 +49,7 @@ class JEDI(Driver):
         """
         The JEDI YAML configuration file.
         """
-        fn = "jedi.yaml"
+        fn = self._config_fn
         yield self._taskname(fn)
         path = self._rundir / fn
         yield asset(path, path.is_file)
@@ -130,11 +130,34 @@ class JEDI(Driver):
     # Private helper methods
 
     @property
+    def _config_fn(self) -> str:
+        """
+        Returns the name of the config file used in execution.
+        """
+        return "jedi.yaml"
+
+    @property
     def _driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.jedi
+
+    @property
+    def _runcmd(self) -> str:
+        """
+        Returns the full command-line component invocation.
+        """
+        execution = self._driver_config.get("execution", {})
+        jedi_config = self._rundir / self._config_fn
+        mpiargs = execution.get("mpiargs", [])
+        components = [
+            execution.get("mpicmd"),  # MPI run program
+            *[str(x) for x in mpiargs],  # MPI arguments
+            execution["executable"],  # component executable name
+            str(jedi_config),  # JEDI config file
+        ]
+        return " ".join(filter(None, components))
 
     def _taskname(self, suffix: str) -> str:
         """

--- a/src/uwtools/tests/drivers/test_jedi.py
+++ b/src/uwtools/tests/drivers/test_jedi.py
@@ -187,6 +187,18 @@ def test_JEDI_configuration_file(driverobj):
     assert newcfg == {**basecfg, "baz": "qux"}
 
 
+def test_JEDI__config_fn(driverobj):
+    assert driverobj._config_fn == "jedi.yaml"
+
+
+def test_JEDI__runcmd(driverobj):
+    executable = driverobj._driver_config["execution"]["executable"]
+    config = driverobj._rundir / driverobj._config_fn
+    assert (
+        driverobj._runcmd == f"srun --export=ALL --ntasks $SLURM_CPUS_ON_NODE {executable} {config}"
+    )
+
+
 def test_JEDI__runscript_path(driverobj):
     assert driverobj._runscript_path == driverobj._rundir / "runscript.jedi"
 


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

Fixes a bug in the JEDI driver where the jedi.yaml was not provided to the specified JEDI executable.

**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
