### PR TITLE
Better support for realizing scalar YAML values

### DIFF
--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -116,15 +116,15 @@ class YAMLConfig(Config):
         """
         self.dump_dict(self.data, path)
 
-    @staticmethod
-    def dump_dict(cfg: dict, path: Optional[Path] = None) -> None:
+    @classmethod
+    def dump_dict(cls, cfg: dict, path: Optional[Path] = None) -> None:
         """
         Dumps a provided config dictionary in YAML format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to.
         """
-        YAMLConfig._add_yaml_representers()
+        cls._add_yaml_representers()
         with writable(path) as f:
             yaml.dump(cfg, f, sort_keys=False)
 
@@ -144,17 +144,17 @@ class YAMLConfig(Config):
 
     # Private methods
 
-    @staticmethod
-    def _add_yaml_representers() -> None:
+    @classmethod
+    def _add_yaml_representers(cls) -> None:
         """
         Add representers to the YAML dumper for custom types.
         """
         yaml.add_representer(UWYAMLConvert, UWYAMLConvert.represent)
-        yaml.add_representer(Namelist, YAMLConfig._represent_namelist)
-        yaml.add_representer(OrderedDict, YAMLConfig._represent_ordereddict)
+        yaml.add_representer(Namelist, cls._represent_namelist)
+        yaml.add_representer(OrderedDict, cls._represent_ordereddict)
 
-    @staticmethod
-    def _represent_namelist(dumper: yaml.Dumper, data: Namelist) -> yaml.nodes.MappingNode:
+    @classmethod
+    def _represent_namelist(cls, dumper: yaml.Dumper, data: Namelist) -> yaml.nodes.MappingNode:
         """
         Convert an f90nml Namelist to an OrderedDict, then represent as a YAML mapping.
 
@@ -164,8 +164,10 @@ class YAMLConfig(Config):
         namelist_dict = data.todict()
         return dumper.represent_mapping("tag:yaml.org,2002:map", namelist_dict)
 
-    @staticmethod
-    def _represent_ordereddict(dumper: yaml.Dumper, data: OrderedDict) -> yaml.nodes.MappingNode:
+    @classmethod
+    def _represent_ordereddict(
+        cls, dumper: yaml.Dumper, data: OrderedDict
+    ) -> yaml.nodes.MappingNode:
         """
         Recursrively convert an OrderedDict to a dict, then represent as a YAML mapping.
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -176,3 +176,17 @@ class YAMLConfig(Config):
         """
 
         return dumper.represent_mapping("tag:yaml.org,2002:map", from_od(data))
+
+
+def _write_plain_open_ended(self, *args, **kwargs) -> None:
+    """
+    Write YAML without ...
+
+    end-of-stream marker.
+    """
+    self.write_plain_base(*args, **kwargs)
+    self.open_ended = False
+
+
+setattr(yaml.emitter.Emitter, "write_plain_base", yaml.emitter.Emitter.write_plain)
+setattr(yaml.emitter.Emitter, "write_plain", _write_plain_open_ended)

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -5,7 +5,6 @@ from importlib import import_module
 from typing import Dict, Type, Union
 
 import yaml
-from f90nml import Namelist  # type: ignore
 
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
@@ -15,15 +14,6 @@ INCLUDE_TAG = "!INCLUDE"
 
 
 # Public functions
-
-
-def add_yaml_representers() -> None:
-    """
-    Add representers to the YAML dumper for custom types.
-    """
-    yaml.add_representer(UWYAMLConvert, UWYAMLConvert.represent)
-    yaml.add_representer(Namelist, _represent_namelist)
-    yaml.add_representer(OrderedDict, _represent_ordereddict)
 
 
 def depth(d: dict) -> int:
@@ -74,31 +64,6 @@ def log_and_error(msg: str) -> Exception:
     """
     log.error(msg)
     return UWConfigError(msg)
-
-
-# Private functions
-
-
-def _represent_namelist(dumper: yaml.Dumper, data: Namelist) -> yaml.nodes.MappingNode:
-    """
-    Convert an f90nml Namelist to an OrderedDict, then represent as a YAML mapping.
-
-    :param dumper: The YAML dumper.
-    :param data: The f90nml Namelist to serialize.
-    """
-    namelist_dict = data.todict()
-    return dumper.represent_mapping("tag:yaml.org,2002:map", namelist_dict)
-
-
-def _represent_ordereddict(dumper: yaml.Dumper, data: OrderedDict) -> yaml.nodes.MappingNode:
-    """
-    Recursrively convert an OrderedDict to a dict, then represent as a YAML mapping.
-
-    :param dumper: The YAML dumper.
-    :param data: The OrderedDict to serialize.
-    """
-
-    return dumper.represent_mapping("tag:yaml.org,2002:map", from_od(data))
 
 
 class UWYAMLTag:

--- a/src/uwtools/tests/config/formats/test_yaml.py
+++ b/src/uwtools/tests/config/formats/test_yaml.py
@@ -180,8 +180,7 @@ def test_unexpected_error(tmp_path):
 
 
 def test__add_yaml_representers():
-    cfgobj = YAMLConfig({})
-    cfgobj._add_yaml_representers()
+    YAMLConfig._add_yaml_representers()
     representers = yaml.Dumper.yaml_representers
     assert support.UWYAMLConvert in representers
     assert OrderedDict in representers
@@ -189,16 +188,14 @@ def test__add_yaml_representers():
 
 
 def test__represent_namelist():
-    cfgobj = YAMLConfig({})
-    cfgobj._add_yaml_representers()
+    YAMLConfig._add_yaml_representers()
     namelist = f90nml.reads("&namelist\n key = value\n/\n")
     expected = "{namelist: {key: value}}"
     assert yaml.dump(namelist, default_flow_style=True).strip() == expected
 
 
 def test__represent_ordereddict():
-    cfgobj = YAMLConfig({})
-    cfgobj._add_yaml_representers()
+    YAMLConfig._add_yaml_representers()
     ordereddict_values = OrderedDict([("example", OrderedDict([("key", "value")]))])
     expected = "{example: {key: value}}"
     assert yaml.dump(ordereddict_values, default_flow_style=True).strip() == expected

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -6,10 +6,8 @@ Tests for uwtools.config.jinja2 module.
 import logging
 from collections import OrderedDict
 
-import f90nml  # type: ignore
 import pytest
 import yaml
-from f90nml import Namelist
 from pytest import fixture, raises
 
 from uwtools.config import support
@@ -22,14 +20,6 @@ from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.tests.support import logged
 from uwtools.utils.file import FORMAT
-
-
-def test_add_yaml_representers():
-    support.add_yaml_representers()
-    representers = yaml.Dumper.yaml_representers
-    assert support.UWYAMLConvert in representers
-    assert OrderedDict in representers
-    assert Namelist in representers
 
 
 @pytest.mark.parametrize(
@@ -71,20 +61,6 @@ def test_log_and_error(caplog):
         raise support.log_and_error(msg)
     assert msg in str(e.value)
     assert logged(caplog, msg)
-
-
-def test_represent_namelist():
-    support.add_yaml_representers()
-    namelist = f90nml.reads("&namelist\n key = value\n/\n")
-    assert yaml.dump(namelist, default_flow_style=True).strip() == "{namelist: {key: value}}"
-
-
-def test_represent_ordereddict():
-    support.add_yaml_representers()
-    ordereddict_values = OrderedDict([("example", OrderedDict([("key", "value")]))])
-    assert (
-        yaml.dump(ordereddict_values, default_flow_style=True).strip() == "{example: {key: value}}"
-    )
 
 
 class Test_UWYAMLConvert:

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -347,6 +347,16 @@ def test_realize_config_remove_yaml_to_yaml_subtree(tmp_path):
     )
 
 
+def test_realize_config_scalar_value(capsys):
+    stdinproxy.cache_clear()
+    tools.realize_config(
+        input_config=YAMLConfig(config={"foo": {"bar": "baz"}}),
+        output_format="yaml",
+        key_path=["foo", "bar"],
+    )
+    assert capsys.readouterr().out.strip() == "baz"
+
+
 def test_realize_config_simple_ini(tmp_path):
     """
     Test that providing an INI file with necessary settings will create an INI config file.


### PR DESCRIPTION
**Synopsis**

Add YAML configuration to omit `...` end-of-stream marker when dumping scalar values. For example:

Old behavior:
```
(DEV-uwtools) ~/git/uwtools ∴ echo "{foo: {bar: baz}}" | uw config realize --input-format yaml --output-format yaml --key-path foo.bar
baz
...
```

New behavior:
```
(DEV-uwtools) ~/git/uwtools ∴ echo "{foo: {bar: baz}}" | uw config realize --input-format yaml --output-format yaml --key-path foo.bar
baz
```

This supports easier lookups of single values from input configs.

Works for e.g. namelist inputs, too:
```
(DEV-uwtools) ~/git/uwtools ∴ echo "&nl res = 768 /" | uw config realize --input-format nml --output-format yaml --key-path nl.res
768
```

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
