### PR TITLE
omnibus-2024-06-24

### DIFF
--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -4,7 +4,7 @@ API access to ``uwtools`` configuration management tools.
 
 import os
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from uwtools.config.formats.fieldtable import FieldTableConfig as _FieldTableConfig
 from uwtools.config.formats.ini import INIConfig as _INIConfig
@@ -119,7 +119,7 @@ def realize(
     update_format: Optional[str] = None,
     output_file: Optional[Union[Path, str]] = None,
     output_format: Optional[str] = None,
-    key_path: Optional[List[Union[str, int]]] = None,
+    key_path: Optional[list[Union[str, int]]] = None,
     values_needed: bool = False,
     total: bool = False,
     dry_run: bool = False,

--- a/src/uwtools/api/file.py
+++ b/src/uwtools/api/file.py
@@ -4,7 +4,7 @@ API access to ``uwtools`` file-management tools.
 
 import datetime as dt
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from uwtools.file import FileCopier as _FileCopier
 from uwtools.file import FileLinker as _FileLinker
@@ -16,7 +16,7 @@ def copy(
     config: Optional[Union[dict, Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    keys: Optional[List[str]] = None,
+    keys: Optional[list[str]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:
@@ -48,7 +48,7 @@ def link(
     config: Optional[Union[dict, Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    keys: Optional[List[str]] = None,
+    keys: Optional[list[str]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -4,7 +4,7 @@ API access to ``uwtools`` templating logic.
 
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from uwtools.config.atparse_to_jinja2 import convert as _convert_atparse_to_jinja2
 from uwtools.config.jinja2 import render as _render
@@ -18,9 +18,9 @@ def render(
     values_format: Optional[str] = None,
     input_file: Optional[Union[Path, str]] = None,
     output_file: Optional[Union[Path, str]] = None,
-    overrides: Optional[Dict[str, str]] = None,
+    overrides: Optional[dict[str, str]] = None,
     env: bool = False,
-    searchpath: Optional[List[str]] = None,
+    searchpath: Optional[list[str]] = None,
     values_needed: bool = False,
     dry_run: bool = False,
     stdin_ok: bool = False,
@@ -69,9 +69,9 @@ def render_to_str(  # pylint: disable=unused-argument
     values_src: Optional[Union[dict, Path, str]] = None,
     values_format: Optional[str] = None,
     input_file: Optional[Union[Path, str]] = None,
-    overrides: Optional[Dict[str, str]] = None,
+    overrides: Optional[dict[str, str]] = None,
     env: bool = False,
-    searchpath: Optional[List[str]] = None,
+    searchpath: Optional[list[str]] = None,
     values_needed: bool = False,
     dry_run: bool = False,
 ) -> str:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -13,7 +13,7 @@ from argparse import _SubParsersAction as Subparsers
 from functools import partial
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple
+from typing import Any, Callable, NoReturn, Optional, Tuple
 
 import uwtools.api
 import uwtools.api.config
@@ -31,10 +31,10 @@ FORMATS = FORMAT.extensions()
 LEADTIME_DESC = "hours[:minutes[:seconds]]"
 TITLE_REQ_ARG = "Required arguments"
 
-Args = Dict[str, Any]
-ActionChecks = List[Callable[[Args], Args]]
-ModeChecks = Dict[str, ActionChecks]
-Checks = Dict[str, ModeChecks]
+Args = dict[str, Any]
+ActionChecks = list[Callable[[Args], Args]]
+ModeChecks = dict[str, ActionChecks]
+Checks = dict[str, ModeChecks]
 
 
 def main() -> None:
@@ -56,13 +56,13 @@ def main() -> None:
         _abort(str(e))
     try:
         log.debug("Command: %s %s", Path(sys.argv[0]).name, " ".join(sys.argv[1:]))
-        tools: Dict[str, Callable[..., bool]] = {
+        tools: dict[str, Callable[..., bool]] = {
             STR.config: _dispatch_config,
             STR.file: _dispatch_file,
             STR.rocoto: _dispatch_rocoto,
             STR.template: _dispatch_template,
         }
-        drivers: Dict[str, Callable[..., bool]] = {
+        drivers: dict[str, Callable[..., bool]] = {
             x: partial(_dispatch_to_driver, x)
             for x in [
                 STR.chgrescube,
@@ -591,7 +591,7 @@ def _add_arg_env(group: Group) -> None:
 
 
 def _add_arg_file_format(
-    group: Group, switch: str, helpmsg: str, choices: List[str], required: bool = False
+    group: Group, switch: str, helpmsg: str, choices: list[str], required: bool = False
 ) -> None:
     group.add_argument(
         switch,
@@ -632,7 +632,7 @@ def _add_arg_input_file(group: Group, required: bool = False) -> None:
     )
 
 
-def _add_arg_input_format(group: Group, choices: List[str], required: bool = False) -> None:
+def _add_arg_input_format(group: Group, choices: list[str], required: bool = False) -> None:
     group.add_argument(
         _switch(STR.infmt),
         choices=choices,
@@ -690,7 +690,7 @@ def _add_arg_output_file(group: Group, required: bool = False) -> None:
     )
 
 
-def _add_arg_output_format(group: Group, choices: List[str], required: bool = False) -> None:
+def _add_arg_output_format(group: Group, choices: list[str], required: bool = False) -> None:
     group.add_argument(
         _switch(STR.outfmt),
         choices=choices,
@@ -758,7 +758,7 @@ def _add_arg_update_file(group: Group, required: bool = False) -> None:
     )
 
 
-def _add_arg_update_format(group: Group, choices: List[str], required: bool = False) -> None:
+def _add_arg_update_format(group: Group, choices: list[str], required: bool = False) -> None:
     group.add_argument(
         _switch(STR.updatefmt),
         choices=choices,
@@ -778,7 +778,7 @@ def _add_arg_values_file(group: Group, required: bool = False) -> None:
     )
 
 
-def _add_arg_values_format(group: Group, choices: List[str]) -> None:
+def _add_arg_values_format(group: Group, choices: list[str]) -> None:
     group.add_argument(
         _switch(STR.valsfmt),
         choices=choices,
@@ -970,7 +970,7 @@ def _check_verbosity(args: Args) -> Args:
     return args
 
 
-def _dict_from_key_eq_val_strings(config_items: List[str]) -> Dict[str, str]:
+def _dict_from_key_eq_val_strings(config_items: list[str]) -> dict[str, str]:
     """
     Given a list of key=value strings, return a dictionary of key/value pairs.
 
@@ -1012,7 +1012,7 @@ def _formatter(prog: str) -> HelpFormatter:
     return HelpFormatter(prog, max_help_position=6)
 
 
-def _parse_args(raw_args: List[str]) -> Tuple[Args, Checks]:
+def _parse_args(raw_args: list[str]) -> Tuple[Args, Checks]:
     """
     Parse command-line arguments.
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -13,7 +13,7 @@ from argparse import _SubParsersAction as Subparsers
 from functools import partial
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Callable, NoReturn, Optional, Tuple
+from typing import Any, Callable, NoReturn, Optional
 
 import uwtools.api
 import uwtools.api.config
@@ -1012,7 +1012,7 @@ def _formatter(prog: str) -> HelpFormatter:
     return HelpFormatter(prog, max_help_position=6)
 
 
-def _parse_args(raw_args: list[str]) -> Tuple[Args, Checks]:
+def _parse_args(raw_args: list[str]) -> tuple[Args, Checks]:
     """
     Parse command-line arguments.
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -7,7 +7,7 @@ from collections import UserDict
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import yaml
 
@@ -83,7 +83,7 @@ class Config(ABC, UserDict):
 
     # Public methods
 
-    def characterize_values(self, values: dict, parent: str) -> Tuple[list, list]:
+    def characterize_values(self, values: dict, parent: str) -> tuple[list, list]:
         """
         Characterize values as complete or as template placeholders.
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -7,7 +7,7 @@ from collections import UserDict
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import yaml
 
@@ -63,7 +63,7 @@ class Config(ABC, UserDict):
         :param config_file: Path to config file to load.
         """
 
-    def _load_paths(self, config_files: List[Path]) -> dict:
+    def _load_paths(self, config_files: list[Path]) -> dict:
         """
         Merge and return the contents of a collection of config files.
 
@@ -91,8 +91,8 @@ class Config(ABC, UserDict):
         :param parent: Parent key.
         :return: Lists of of complete and template-placeholder values.
         """
-        complete: List[str] = []
-        template: List[str] = []
+        complete: list[str] = []
+        template: list[str] = []
         for key, val in values.items():
             if isinstance(val, dict):
                 complete.append(f"{INDENT}{parent}{key}")

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -5,7 +5,7 @@ Support for rendering Jinja2 templates.
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Union
+from typing import Optional, Set, Union
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, Undefined, meta
 from jinja2.exceptions import UndefinedError
@@ -26,7 +26,7 @@ class J2Template:
         self,
         values: dict,
         template_source: Optional[Union[str, Path]] = None,
-        searchpath: Optional[List[str]] = None,
+        searchpath: Optional[list[str]] = None,
     ) -> None:
         """
         :param values: Values needed to render the provided template.
@@ -102,7 +102,7 @@ class J2Template:
 
 
 def dereference(
-    val: _ConfigVal, context: dict, local: Optional[dict] = None, keys: Optional[List[str]] = None
+    val: _ConfigVal, context: dict, local: Optional[dict] = None, keys: Optional[list[str]] = None
 ) -> _ConfigVal:
     """
     Render Jinja2 syntax, wherever possible.
@@ -152,9 +152,9 @@ def render(
     values_format: Optional[str] = None,
     input_file: Optional[Path] = None,
     output_file: Optional[Path] = None,
-    overrides: Optional[Dict[str, str]] = None,
+    overrides: Optional[dict[str, str]] = None,
     env: bool = False,
-    searchpath: Optional[List[str]] = None,
+    searchpath: Optional[list[str]] = None,
     values_needed: bool = False,
     dry_run: bool = False,
 ) -> Optional[str]:
@@ -286,7 +286,7 @@ def _dry_run_template(rendered_template: str) -> str:
     return rendered_template
 
 
-def _log_missing_values(missing: List[str]) -> None:
+def _log_missing_values(missing: list[str]) -> None:
     """
     Log values missing from template and raise an exception.
 
@@ -305,7 +305,7 @@ def _register_filters(env: Environment) -> Environment:
     :return: The input Environment, with filters added.
     """
 
-    def path_join(path_components: List[str]) -> str:
+    def path_join(path_components: list[str]) -> str:
         if any(isinstance(x, Undefined) for x in path_components):
             raise UndefinedError()
         return os.path.join(*path_components)
@@ -332,7 +332,7 @@ def _report(args: dict) -> None:
 def _supplement_values(
     values_src: Optional[Union[dict, Path]] = None,
     values_format: Optional[str] = None,
-    overrides: Optional[Dict[str, str]] = None,
+    overrides: Optional[dict[str, str]] = None,
     env: bool = False,
 ) -> dict:
     """

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -5,7 +5,7 @@ Support for rendering Jinja2 templates.
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Set, Union
+from typing import Optional, Union
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, Undefined, meta
 from jinja2.exceptions import UndefinedError
@@ -88,7 +88,7 @@ class J2Template:
         return self._template.render(self._values)
 
     @property
-    def undeclared_variables(self) -> Set[str]:
+    def undeclared_variables(self) -> set[str]:
         """
         Returns the names of variables needed to render the template.
 
@@ -361,7 +361,7 @@ def _supplement_values(
     return values
 
 
-def _values_needed(undeclared_variables: Set[str]) -> None:
+def _values_needed(undeclared_variables: set[str]) -> None:
     """
     Log variables needed to render the template.
 

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from importlib import import_module
-from typing import Dict, Type, Union
+from typing import Type, Union
 
 import yaml
 
@@ -46,7 +46,7 @@ def format_to_config(fmt: str) -> Type:
     return cfgclass
 
 
-def from_od(d: Union[OrderedDict, Dict]) -> dict:
+def from_od(d: Union[OrderedDict, dict]) -> dict:
     """
     Returns a (nested) dict with content equivalent to the given (nested) OrderedDict.
 
@@ -105,7 +105,7 @@ class UWYAMLConvert(UWYAMLTag):
 
         Will raise an exception if the value cannot be represented as the specified type.
         """
-        converters: Dict[str, Union[Type[float], Type[int]]] = dict(zip(self.TAGS, [float, int]))
+        converters: dict[str, Union[Type[float], Type[int]]] = dict(zip(self.TAGS, [float, int]))
         return converters[self.tag](self.value)
 
 

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -3,7 +3,7 @@ Tools for working with configs.
 """
 
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 from uwtools.config.formats.base import Config
 from uwtools.config.jinja2 import unrendered
@@ -82,7 +82,7 @@ def realize_config(
     update_format: Optional[str] = None,
     output_file: Optional[Path] = None,
     output_format: Optional[str] = None,
-    key_path: Optional[List[Union[str, int]]] = None,
+    key_path: Optional[list[Union[str, int]]] = None,
     values_needed: bool = False,
     total: bool = False,
     dry_run: bool = False,
@@ -135,7 +135,7 @@ def _ensure_format(
     return fmt
 
 
-def _print_config_section(config: dict, key_path: List[str]) -> None:
+def _print_config_section(config: dict, key_path: list[str]) -> None:
     """
     Descends into the config via the given keys, then prints the contents of the located subtree as
     key=value pairs, one per line.
@@ -185,7 +185,7 @@ def _realize_config_output_setup(
     input_obj: Config,
     output_file: Optional[Path] = None,
     output_format: Optional[str] = None,
-    key_path: Optional[List[Union[str, int]]] = None,
+    key_path: Optional[list[Union[str, int]]] = None,
 ) -> Tuple[dict, str]:
     """
     Set up config-realize output.

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -3,7 +3,7 @@ Tools for working with configs.
 """
 
 from pathlib import Path
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 from uwtools.config.formats.base import Config
 from uwtools.config.jinja2 import unrendered
@@ -162,7 +162,7 @@ def _print_config_section(config: dict, key_path: list[str]) -> None:
 
 def _realize_config_input_setup(
     input_config: Union[Config, Optional[Path]] = None, input_format: Optional[str] = None
-) -> Tuple[Config, str]:
+) -> tuple[Config, str]:
     """
     Set up config-realize input.
 
@@ -186,7 +186,7 @@ def _realize_config_output_setup(
     output_file: Optional[Path] = None,
     output_format: Optional[str] = None,
     key_path: Optional[list[Union[str, int]]] = None,
-) -> Tuple[dict, str]:
+) -> tuple[dict, str]:
     """
     Set up config-realize output.
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -4,7 +4,7 @@ Support for validating a config using JSON Schema.
 
 import json
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
@@ -95,7 +95,7 @@ def _prep_config(config: Union[dict, YAMLConfig, Optional[Path]]) -> YAMLConfig:
     return cfgobj
 
 
-def _validation_errors(config: Union[dict, list], schema: dict) -> List[ValidationError]:
+def _validation_errors(config: Union[dict, list], schema: dict) -> list[ValidationError]:
     """
     Identify schema-validation errors.
 

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -4,7 +4,7 @@ A driver for chgres_cube.
 
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -25,7 +25,7 @@ class ChgresCube(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Optional, Type, Union
 
 from iotaa import asset, dryrun, external, task, tasks
 
@@ -36,7 +36,7 @@ class Assets(ABC):
         batch: bool = False,
         cycle: Optional[datetime] = None,
         leadtime: Optional[timedelta] = None,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ) -> None:
         """
         A component driver.
@@ -115,13 +115,13 @@ class Assets(ABC):
             log.debug(f"Failed to validate {path}")
 
     @property
-    def _driver_config(self) -> Dict[str, Any]:
+    def _driver_config(self) -> dict[str, Any]:
         """
         Returns the config block specific to this driver.
         """
         name = self._driver_name
         try:
-            driver_config: Dict[str, Any] = self._config[name]
+            driver_config: dict[str, Any] = self._config[name]
             return driver_config
         except KeyError as e:
             raise UWConfigError("Required '%s' block missing in config" % name) from e
@@ -134,7 +134,7 @@ class Assets(ABC):
         """
 
     def _namelist_schema(
-        self, config_keys: Optional[List[str]] = None, schema_keys: Optional[List[str]] = None
+        self, config_keys: Optional[list[str]] = None, schema_keys: Optional[list[str]] = None
     ) -> dict:
         """
         Returns the (sub)schema for validating the driver's namelist content.
@@ -258,7 +258,7 @@ class Driver(Assets):
     # Private helper methods
 
     @property
-    def _resources(self) -> Dict[str, Any]:
+    def _resources(self) -> dict[str, Any]:
         """
         Returns platform configuration data.
         """
@@ -290,9 +290,9 @@ class Driver(Assets):
 
     def _runscript(
         self,
-        execution: List[str],
-        envcmds: Optional[List[str]] = None,
-        envvars: Optional[Dict[str, str]] = None,
+        execution: list[str],
+        envcmds: Optional[list[str]] = None,
+        envvars: Optional[dict[str, str]] = None,
         scheduler: Optional[JobScheduler] = None,
     ) -> str:
         """
@@ -352,7 +352,7 @@ class Driver(Assets):
         for schema_name in (self._driver_name.replace("_", "-"), "platform"):
             validate_internal(schema_name=schema_name, config=self._config)
 
-    def _write_runscript(self, path: Path, envvars: Optional[Dict[str, str]] = None) -> None:
+    def _write_runscript(self, path: Path, envvars: Optional[dict[str, str]] = None) -> None:
         """
         Write the runscript.
         """

--- a/src/uwtools/drivers/esg_grid.py
+++ b/src/uwtools/drivers/esg_grid.py
@@ -3,7 +3,7 @@ A driver for esg_grid.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -23,7 +23,7 @@ class ESGGrid(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -3,7 +3,7 @@ A driver for filter_topo.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -23,7 +23,7 @@ class FilterTopo(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -5,7 +5,7 @@ A driver for the FV3 model.
 from datetime import datetime
 from pathlib import Path
 from shutil import copy
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -28,7 +28,7 @@ class FV3(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/global_equiv_resol.py
+++ b/src/uwtools/drivers/global_equiv_resol.py
@@ -3,7 +3,7 @@ A driver for the global_equiv_resol component.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, external, tasks
 
@@ -21,7 +21,7 @@ class GlobalEquivResol(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -5,7 +5,7 @@ A base class for jedi-based drivers.
 from abc import abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -25,7 +25,7 @@ class JEDIBase(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/make_hgrid.py
+++ b/src/uwtools/drivers/make_hgrid.py
@@ -3,7 +3,7 @@ A driver for make_hgrid.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import tasks
 
@@ -21,7 +21,7 @@ class MakeHgrid(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -3,7 +3,7 @@ A driver for make_solo_mosaic.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import tasks
 
@@ -21,7 +21,7 @@ class MakeSoloMosaic(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -5,7 +5,7 @@ A base class for MPAS drivers.
 from abc import abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 from lxml import etree
@@ -26,7 +26,7 @@ class MPASBase(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -3,7 +3,7 @@ A driver for orog_gsl.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -22,7 +22,7 @@ class OrogGSL(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -4,7 +4,7 @@ An assets driver for SCHISM.
 
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -25,7 +25,7 @@ class SCHISM(Assets):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -3,7 +3,7 @@ A driver for sfc_climo_gen.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -23,7 +23,7 @@ class SfcClimoGen(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -3,7 +3,7 @@ A driver for shave.
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import tasks
 
@@ -21,7 +21,7 @@ class Shave(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/support.py
+++ b/src/uwtools/drivers/support.py
@@ -2,8 +2,6 @@
 Driver support.
 """
 
-from typing import Dict
-
 import iotaa as _iotaa
 
 from uwtools.drivers.driver import Driver
@@ -16,7 +14,7 @@ def graph() -> str:
     return _iotaa.graph()
 
 
-def tasks(driver_class: type[Driver]) -> Dict[str, str]:
+def tasks(driver_class: type[Driver]) -> dict[str, str]:
     """
     Returns a mapping from task names to their one-line descriptions.
 

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -4,7 +4,7 @@ A driver for the ungrib component.
 
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -25,7 +25,7 @@ class Ungrib(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -4,7 +4,7 @@ A driver for UPP.
 
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -26,7 +26,7 @@ class UPP(Driver):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -4,7 +4,7 @@ An assets driver for ww3.
 
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -25,7 +25,7 @@ class WaveWatchIII(Assets):
         config: Optional[Path] = None,
         dry_run: bool = False,
         batch: bool = False,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
     ):
         """
         The driver.

--- a/src/uwtools/file.py
+++ b/src/uwtools/file.py
@@ -5,7 +5,7 @@ File handling.
 import datetime as dt
 from functools import cached_property
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from iotaa import dryrun, tasks
 
@@ -27,7 +27,7 @@ class FileStager:
         config: Optional[Union[dict, Path]] = None,
         cycle: Optional[dt.datetime] = None,
         leadtime: Optional[dt.timedelta] = None,
-        keys: Optional[List[str]] = None,
+        keys: Optional[list[str]] = None,
         dry_run: bool = False,
     ) -> None:
         """

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from math import log10
 from pathlib import Path
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from lxml import etree
 from lxml.etree import Element, SubElement, _Element
@@ -399,7 +399,7 @@ class _RocotoXML:
         for attr, val in config.get(STR.attrs, {}).items():
             e.set(attr, str(val))
 
-    def _tag_name(self, key: str) -> Tuple[str, str]:
+    def _tag_name(self, key: str) -> tuple[str, str]:
         """
         Return the tag and metadata extracted from a metadata-bearing key.
 

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from math import log10
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 from lxml import etree
 from lxml.etree import Element, SubElement, _Element
@@ -307,7 +307,7 @@ class _RocotoXML:
         self._add_workflow_tasks(e, config[STR.tasks])
         self._root: _Element = e
 
-    def _add_workflow_cycledef(self, e: _Element, config: List[dict]) -> None:
+    def _add_workflow_cycledef(self, e: _Element, config: list[dict]) -> None:
         """
         Add <cycledef> element(s) to the <workflow>.
 

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, fields
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
@@ -21,14 +21,14 @@ class JobScheduler(ABC):
     An abstract class for interacting with HPC schedulers.
     """
 
-    def __init__(self, props: Dict[str, Any]):
+    def __init__(self, props: dict[str, Any]):
         self._props = {k: v for k, v in props.items() if k != "scheduler"}
         self._validate_props()
 
     # Public methods
 
     @property
-    def directives(self) -> List[str]:
+    def directives(self) -> list[str]:
         """
         Returns resource-request scheduler directives.
         """
@@ -90,7 +90,7 @@ class JobScheduler(ABC):
 
     @property
     @abstractmethod
-    def _managed_directives(self) -> Dict[str, Any]:
+    def _managed_directives(self) -> dict[str, Any]:
         """
         Returns a mapping from canonical names to scheduler-specific CLI switches.
         """
@@ -103,7 +103,7 @@ class JobScheduler(ABC):
         """
 
     @property
-    def _processed_props(self) -> Dict[str, Any]:
+    def _processed_props(self) -> dict[str, Any]:
         """
         Pre-process directives before converting to runscript.
         """
@@ -143,7 +143,7 @@ class LSF(JobScheduler):
         return " "
 
     @property
-    def _managed_directives(self) -> Dict[str, Any]:
+    def _managed_directives(self) -> dict[str, Any]:
         """
         Returns a mapping from canonical names to scheduler-specific CLI switches.
         """
@@ -168,7 +168,7 @@ class LSF(JobScheduler):
         return "#BSUB"
 
     @property
-    def _processed_props(self) -> Dict[str, Any]:
+    def _processed_props(self) -> dict[str, Any]:
         props = deepcopy(self._props)
         props[_DirectivesOptional.THREADS] = props.get(_DirectivesOptional.THREADS, 1)
         return props
@@ -194,7 +194,7 @@ class PBS(JobScheduler):
         return " "
 
     @property
-    def _managed_directives(self) -> Dict[str, Any]:
+    def _managed_directives(self) -> dict[str, Any]:
         """
         Returns a mapping from canonical names to scheduler-specific CLI switches.
         """
@@ -213,7 +213,7 @@ class PBS(JobScheduler):
         }
 
     @staticmethod
-    def _placement(items: Dict[str, Any]) -> Dict[str, Any]:
+    def _placement(items: dict[str, Any]) -> dict[str, Any]:
         """
         Placement logic.
         """
@@ -238,7 +238,7 @@ class PBS(JobScheduler):
         return "#PBS"
 
     @property
-    def _processed_props(self) -> Dict[str, Any]:
+    def _processed_props(self) -> dict[str, Any]:
         props = self._props
         props.update(self._select(props))
         props.update(self._placement(props))
@@ -251,7 +251,7 @@ class PBS(JobScheduler):
         props.pop("select", None)
         return dict(props)
 
-    def _select(self, items: Dict[str, Any]) -> Dict[str, Any]:
+    def _select(self, items: dict[str, Any]) -> dict[str, Any]:
         """
         Select logic.
         """
@@ -285,7 +285,7 @@ class Slurm(JobScheduler):
     """
 
     @property
-    def _managed_directives(self) -> Dict[str, Any]:
+    def _managed_directives(self) -> dict[str, Any]:
         """
         Returns a mapping from canonical names to scheduler-specific CLI switches.
         """

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -3,7 +3,6 @@ Canonical strings used throughout uwtools.
 """
 
 from dataclasses import dataclass, fields
-from typing import Dict, List
 
 
 @dataclass(frozen=True)
@@ -37,14 +36,14 @@ class FORMAT:
     yml: str = _yaml
 
     @staticmethod
-    def extensions() -> List[str]:
+    def extensions() -> list[str]:
         """
         Returns recognized filename extensions.
         """
         return [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml]
 
     @staticmethod
-    def formats() -> Dict[str, str]:
+    def formats() -> dict[str, str]:
         """
         Returns the recognized format names.
         """

--- a/src/uwtools/tests/api/test_config.py
+++ b/src/uwtools/tests/api/test_config.py
@@ -4,8 +4,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 import yaml
+from pytest import mark
 
 from uwtools.api import config
 from uwtools.config.formats.yaml import YAMLConfig
@@ -29,7 +29,7 @@ def test_compare():
     )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "classname,f",
     [
         ("_FieldTableConfig", config.get_fieldtable_config),
@@ -88,7 +88,7 @@ def test_realize_to_dict():
     )
 
 
-@pytest.mark.parametrize("cfg", [{"foo": "bar"}, YAMLConfig(config={})])
+@mark.parametrize("cfg", [{"foo": "bar"}, YAMLConfig(config={})])
 def test_validate(cfg):
     kwargs: dict = {"schema_file": "schema-file", "config": cfg}
     with patch.object(config, "_validate_yaml", return_value=True) as _validate_yaml:

--- a/src/uwtools/tests/api/test_drivers.py
+++ b/src/uwtools/tests/api/test_drivers.py
@@ -4,7 +4,7 @@ import datetime as dt
 from unittest.mock import patch
 
 import iotaa
-import pytest
+from pytest import mark
 
 from uwtools.api import (
     chgres_cube,
@@ -45,7 +45,7 @@ with_cycle = [chgres_cube, fv3, jedi, mpas, mpas_init, ungrib, upp]
 with_leadtime = [upp]
 
 
-@pytest.mark.parametrize("module", modules)
+@mark.parametrize("module", modules)
 def test_api_execute(module):
     kwbase = {
         "batch": True,
@@ -71,12 +71,12 @@ def test_api_execute(module):
         )
 
 
-@pytest.mark.parametrize("module", modules)
+@mark.parametrize("module", modules)
 def test_api_graph(module):
     assert module.graph is support.graph
 
 
-@pytest.mark.parametrize("module", modules)
+@mark.parametrize("module", modules)
 def test_api_tasks(module):
     with patch.object(iotaa, "tasknames") as tasknames:
         module.tasks()

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -7,9 +7,8 @@ import logging
 import os
 from unittest.mock import patch
 
-import pytest
 import yaml
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.config import tools
 from uwtools.config.formats.base import Config
@@ -85,7 +84,7 @@ def test_characterize_values(config):
     assert template == ["  p3: {{ n }}"]
 
 
-@pytest.mark.parametrize("fmt", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
+@mark.parametrize("fmt", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
 def test_compare_config(caplog, fmt, salad_base):
     """
     Compare two config objects.
@@ -165,7 +164,7 @@ def test_derefernce_context_override(tmp_path):
     assert config["file"] == "gfs.t06z.atmanl.nc"
 
 
-@pytest.mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.sh])
+@mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.sh])
 def test_invalid_config(fmt2, tmp_path):
     """
     Test that invalid config files will error when attempting to dump.

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -3,7 +3,7 @@
 Tests for uwtools.config.formats.sh module.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 from pytest import raises
 
@@ -46,7 +46,7 @@ def test_sh(salad_base):
     """
     infile = fixture_path("simple.sh")
     cfgobj = SHConfig(infile)
-    expected: Dict[str, Any] = {
+    expected: dict[str, Any] = {
         **salad_base["salad"],
         "how_many": "12",
     }

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -10,10 +10,9 @@ from textwrap import dedent
 from types import SimpleNamespace as ns
 from unittest.mock import patch
 
-import pytest
 import yaml
 from jinja2 import DebugUndefined, Environment, TemplateNotFound, UndefinedError
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.config import jinja2
 from uwtools.config.jinja2 import J2Template
@@ -109,13 +108,13 @@ def test_dereference_local_values():
     }
 
 
-@pytest.mark.parametrize("val", (True, 3.14, 88, None))
+@mark.parametrize("val", (True, 3.14, 88, None))
 def test_dereference_no_op(val):
     # These types of values pass through dereferencing unmodified:
     assert jinja2.dereference(val=val, context={}) == val
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "logmsg,val",
     [
         ("can only concatenate", "{{ 'str' + 11 }}"),
@@ -174,7 +173,7 @@ def test_register_filters_env():
         assert template.render() == "hello world"
 
 
-@pytest.mark.parametrize("key", ["foo", "bar"])
+@mark.parametrize("key", ["foo", "bar"])
 def test_register_filters_path_join(key):
     s = "{{ ['dir', %s] | path_join }}" % key
     template = jinja2._register_filters(Environment(undefined=DebugUndefined)).from_string(s)
@@ -276,12 +275,12 @@ def test_render_values_needed(caplog, template_file, values_file):
         assert logged(caplog, f"  {var}")
 
 
-@pytest.mark.parametrize("s,status", [("foo: bar", False), ("foo: '{{ bar }} {{ baz }}'", True)])
+@mark.parametrize("s,status", [("foo: bar", False), ("foo: '{{ bar }} {{ baz }}'", True)])
 def test_unrendered(s, status):
     assert jinja2.unrendered(s) is status
 
 
-@pytest.mark.parametrize("tag", ["!float", "!int"])
+@mark.parametrize("tag", ["!float", "!int"])
 def test__deref_convert_no(caplog, tag):
     log.setLevel(logging.DEBUG)
     loader = yaml.SafeLoader(os.devnull)
@@ -291,7 +290,7 @@ def test__deref_convert_no(caplog, tag):
     assert regex_logged(caplog, "Conversion failed")
 
 
-@pytest.mark.parametrize("converted,tag,value", [(3.14, "!float", "3.14"), (88, "!int", "88")])
+@mark.parametrize("converted,tag,value", [(3.14, "!float", "3.14"), (88, "!int", "88")])
 def test__deref_convert_ok(caplog, converted, tag, value):
     log.setLevel(logging.DEBUG)
     loader = yaml.SafeLoader(os.devnull)

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -6,9 +6,8 @@ Tests for uwtools.config.jinja2 module.
 import logging
 from collections import OrderedDict
 
-import pytest
 import yaml
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.config import support
 from uwtools.config.formats.fieldtable import FieldTableConfig
@@ -22,14 +21,12 @@ from uwtools.tests.support import logged
 from uwtools.utils.file import FORMAT
 
 
-@pytest.mark.parametrize(
-    "d,n", [({1: 88}, 1), ({1: {2: 88}}, 2), ({1: {2: {3: 88}}}, 3), ({1: {}}, 2)]
-)
+@mark.parametrize("d,n", [({1: 88}, 1), ({1: {2: 88}}, 2), ({1: {2: {3: 88}}}, 3), ({1: {}}, 2)])
 def test_depth(d, n):
     assert support.depth(d) == n
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfgtype,fmt",
     [
         (FieldTableConfig, FORMAT.fieldtable),

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -11,9 +11,8 @@ from textwrap import dedent
 from unittest.mock import patch
 
 import f90nml  # type: ignore
-import pytest
 import yaml
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.config import tools
 from uwtools.config.formats.ini import INIConfig
@@ -826,8 +825,8 @@ def test__realize_config_values_needed_negative_results(caplog, tmp_path):
     assert "No keys have unrendered Jinja2 variables/expressions." in msgs
 
 
-@pytest.mark.parametrize("input_fmt", FORMAT.extensions())
-@pytest.mark.parametrize("other_fmt", FORMAT.extensions())
+@mark.parametrize("input_fmt", FORMAT.extensions())
+@mark.parametrize("other_fmt", FORMAT.extensions())
 def test__validate_format(input_fmt, other_fmt):
     call = lambda: tools._validate_format(
         other_fmt_desc="other", other_fmt=other_fmt, input_fmt=input_fmt

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -5,7 +5,7 @@ Tests for uwtools.config.validator module.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 from unittest.mock import patch
 
 import yaml
@@ -31,7 +31,7 @@ def assets(config, schema, tmp_path) -> Tuple[Path, Path, YAMLConfig]:
 
 
 @fixture
-def config(tmp_path) -> Dict[str, Any]:
+def config(tmp_path) -> dict[str, Any]:
     return {
         "color": "blue",
         "dir": str(tmp_path),
@@ -78,7 +78,7 @@ def rocoto_assets():
 
 
 @fixture
-def schema() -> Dict[str, Any]:
+def schema() -> dict[str, Any]:
     return {
         "properties": {
             "color": {
@@ -115,7 +115,7 @@ def schema_file(schema, tmp_path) -> Path:
 # Helpers
 
 
-def write_as_json(data: Dict[str, Any], path: Path) -> Path:
+def write_as_json(data: dict[str, Any], path: Path) -> Path:
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
     return path

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -5,7 +5,7 @@ Tests for uwtools.config.validator module.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 from unittest.mock import patch
 
 import yaml
@@ -22,7 +22,7 @@ from uwtools.utils.file import resource_path
 
 
 @fixture
-def assets(config, schema, tmp_path) -> Tuple[Path, Path, YAMLConfig]:
+def assets(config, schema, tmp_path) -> tuple[Path, Path, YAMLConfig]:
     config_file = tmp_path / "config.yaml"
     schema_file = tmp_path / "schema.yaml"
     write_as_json(config, config_file)

--- a/src/uwtools/tests/drivers/test_chgres_cube.py
+++ b/src/uwtools/tests/drivers/test_chgres_cube.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import f90nml  # type: ignore
 from iotaa import refs
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.chgres_cube import ChgresCube
 from uwtools.drivers.driver import Driver
@@ -83,8 +83,9 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_ChgresCube():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -97,8 +98,10 @@ def test_ChgresCube():
         "_validate",
         "_write_runscript",
         "run",
-    ]:
-        assert getattr(ChgresCube, method) is getattr(Driver, method)
+    ],
+)
+def test_ChgresCube(method):
+    assert getattr(ChgresCube, method) is getattr(Driver, method)
 
 
 def test_ChgresCube_namelist_file(caplog, driverobj):

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -259,10 +259,9 @@ def test_Driver_run(batch, driverobj):
 
 
 @mark.parametrize(
-    "arg_type", [("envcmds", list), ("envvars", dict), ("execution", list), ("scheduler", Slurm)]
+    "arg,type_", [("envcmds", list), ("envvars", dict), ("execution", list), ("scheduler", Slurm)]
 )
-def test_Driver_runscript(arg_type, driverobj):
-    arg, type_ = arg_type
+def test_Driver_runscript(arg, driverobj, type_):
     with patch.object(driverobj, "_runscript") as runscript:
         driverobj.runscript()
         runscript.assert_called_once()

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -258,13 +258,15 @@ def test_Driver_run(batch, driverobj):
             rvle.assert_called_once_with()
 
 
-def test_Driver_runscript(driverobj):
+@mark.parametrize(
+    "arg_type", [("envcmds", list), ("envvars", dict), ("execution", list), ("scheduler", Slurm)]
+)
+def test_Driver_runscript(arg_type, driverobj):
+    arg, type_ = arg_type
     with patch.object(driverobj, "_runscript") as runscript:
         driverobj.runscript()
         runscript.assert_called_once()
-        args = ("envcmds", "envvars", "execution", "scheduler")
-        types = [list, dict, list, Slurm]
-        assert [type(runscript.call_args.kwargs[x]) for x in args] == types
+        assert isinstance(runscript.call_args.kwargs[arg], type_)
 
 
 def test_Driver__run_via_batch_submission(driverobj):

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -9,10 +9,9 @@ from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock, PropertyMock, patch
 
-import pytest
 import yaml
 from iotaa import asset, task
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.drivers import driver
@@ -138,14 +137,14 @@ def test_Assets(assetobj):
     assert assetobj._batch is True
 
 
-@pytest.mark.parametrize("hours", [0, 24, 168])
+@mark.parametrize("hours", [0, 24, 168])
 def test_Assets_cycle_leadtime_error(config, hours):
     with raises(UWError) as e:
         ConcreteAssets(config=config, leadtime=dt.timedelta(hours=hours))
     assert "When leadtime is specified, cycle is required" in str(e)
 
 
-@pytest.mark.parametrize("val", (True, False))
+@mark.parametrize("val", (True, False))
 def test_Assets_dry_run(config, val):
     with patch.object(driver, "dryrun") as dryrun:
         ConcreteAssets(config=config, dry_run=val)
@@ -178,7 +177,7 @@ def test_Assets_validate(assetobj, caplog):
 # Tests for private helper methods
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "base_file,update_values,expected",
     [
         (False, False, {}),
@@ -243,7 +242,7 @@ def test_Driver(driverobj):
 # Tests for workflow methods
 
 
-@pytest.mark.parametrize("batch", [True, False])
+@mark.parametrize("batch", [True, False])
 def test_Driver_run(batch, driverobj):
     driverobj._batch = batch
     executable = Path(driverobj._driver_config["execution"]["executable"])
@@ -298,7 +297,7 @@ def test_Driver__run_via_local_execution(driverobj):
 # Tests for private helper methods
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "base_file,update_values,expected",
     [
         (False, False, {}),

--- a/src/uwtools/tests/drivers/test_esg_grid.py
+++ b/src/uwtools/tests/drivers/test_esg_grid.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import f90nml  # type: ignore
 from iotaa import refs
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.esg_grid import ESGGrid
@@ -62,8 +62,9 @@ def driverobj(config):
 # Tests
 
 
-def test_ESGGrid():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -78,8 +79,10 @@ def test_ESGGrid():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(ESGGrid, method) is getattr(Driver, method)
+    ],
+)
+def test_ESGGrid(method):
+    assert getattr(ESGGrid, method) is getattr(Driver, method)
 
 
 def test_ESGGrid_namelist_file(caplog, driverobj):

--- a/src/uwtools/tests/drivers/test_filter_topo.py
+++ b/src/uwtools/tests/drivers/test_filter_topo.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import f90nml  # type: ignore
 from iotaa import refs
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.config.support import from_od
 from uwtools.drivers.driver import Driver
@@ -57,8 +57,9 @@ def driverobj(config):
 # Tests
 
 
-def test_FilterTopo():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -73,8 +74,10 @@ def test_FilterTopo():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(FilterTopo, method) is getattr(Driver, method)
+    ],
+)
+def test_FilterTopo(method):
+    assert getattr(FilterTopo, method) is getattr(Driver, method)
 
 
 def test_FilterTopo_input_grid_file(driverobj):

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -8,10 +8,9 @@ from pathlib import Path
 from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
-import pytest
 import yaml
 from iotaa import asset, external, refs
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.fv3 import FV3
@@ -135,7 +134,7 @@ def test_FV3_field_table(driverobj):
     assert dst.is_file()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "key,task,test",
     [("files_to_copy", "files_copied", "is_file"), ("files_to_link", "files_linked", "is_symlink")],
 )
@@ -157,7 +156,7 @@ def test_FV3_files_copied_and_linked(config, cycle, key, task, test, tmp_path):
     assert all(getattr(dst, test)() for dst in [atm_dst, sfc_dst])
 
 
-@pytest.mark.parametrize("base_file_exists", [True, False])
+@mark.parametrize("base_file_exists", [True, False])
 def test_FV3_model_configure(base_file_exists, caplog, driverobj):
     log.setLevel(logging.DEBUG)
     src = driverobj._rundir / "model_configure.in"
@@ -206,7 +205,7 @@ def test_FV3_namelist_file_missing_base_file(caplog, driverobj):
     assert regex_logged(caplog, "missing.nml: State: Not Ready (external asset)")
 
 
-@pytest.mark.parametrize("domain", ("global", "regional"))
+@mark.parametrize("domain", ("global", "regional"))
 def test_FV3_provisioned_run_directory(domain, driverobj):
     driverobj._driver_config["domain"] = domain
     with patch.multiple(

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -81,8 +81,9 @@ def truetask():
 # Tests
 
 
-def test_FV3():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -95,8 +96,10 @@ def test_FV3():
         "_validate",
         "_write_runscript",
         "run",
-    ]:
-        assert getattr(FV3, method) is getattr(Driver, method)
+    ],
+)
+def test_FV3(method):
+    assert getattr(FV3, method) is getattr(Driver, method)
 
 
 def test_FV3_boundary_files(driverobj):

--- a/src/uwtools/tests/drivers/test_global_equiv_resol.py
+++ b/src/uwtools/tests/drivers/test_global_equiv_resol.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.global_equiv_resol import GlobalEquivResol
@@ -43,8 +43,9 @@ def driverobj(config):
 # Tests
 
 
-def test_GlobalEquivResol():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -58,8 +59,10 @@ def test_GlobalEquivResol():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(GlobalEquivResol, method) is getattr(Driver, method)
+    ],
+)
+def test_GlobalEquivResol(method):
+    assert getattr(GlobalEquivResol, method) is getattr(Driver, method)
 
 
 def test_GlobalEquivResol_input_file(driverobj):

--- a/src/uwtools/tests/drivers/test_ioda.py
+++ b/src/uwtools/tests/drivers/test_ioda.py
@@ -6,7 +6,7 @@ import datetime as dt
 from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.ioda import IODA
 from uwtools.drivers.jedi_base import JEDIBase
@@ -67,8 +67,9 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_IODA():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -81,8 +82,10 @@ def test_IODA():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(IODA, method) is getattr(JEDIBase, method)
+    ],
+)
+def test_IODA(method):
+    assert getattr(IODA, method) is getattr(JEDIBase, method)
 
 
 def test_IODA_provisioned_run_directory(driverobj):

--- a/src/uwtools/tests/drivers/test_jedi.py
+++ b/src/uwtools/tests/drivers/test_jedi.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, call, patch
 
 import yaml
 from iotaa import asset, external
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.drivers import jedi, jedi_base
@@ -77,8 +77,9 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_JEDI():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -91,8 +92,10 @@ def test_JEDI():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(JEDI, method) is getattr(JEDIBase, method)
+    ],
+)
+def test_JEDI(method):
+    assert getattr(JEDI, method) is getattr(JEDIBase, method)
 
 
 def test_JEDI_configuration_file(driverobj):

--- a/src/uwtools/tests/drivers/test_make_hgrid.py
+++ b/src/uwtools/tests/drivers/test_make_hgrid.py
@@ -5,7 +5,7 @@ make_hgrid driver tests.
 from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.make_hgrid import MakeHgrid
@@ -48,8 +48,9 @@ def driverobj(config):
 # Tests
 
 
-def test_MakeHgrid():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -63,8 +64,10 @@ def test_MakeHgrid():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(MakeHgrid, method) is getattr(Driver, method)
+    ],
+)
+def test_MakeHgrid(method):
+    assert getattr(MakeHgrid, method) is getattr(Driver, method)
 
 
 def test_MakeHgrid_provisioned_run_directory(driverobj):

--- a/src/uwtools/tests/drivers/test_make_solo_mosaic.py
+++ b/src/uwtools/tests/drivers/test_make_solo_mosaic.py
@@ -4,7 +4,7 @@ make_solo_mosaic driver tests.
 """
 from unittest.mock import patch
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.make_solo_mosaic import MakeSoloMosaic
@@ -44,8 +44,9 @@ def driverobj(config):
 # Tests
 
 
-def test_MakeSoloMosaic():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -58,8 +59,10 @@ def test_MakeSoloMosaic():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(MakeSoloMosaic, method) is getattr(Driver, method)
+    ],
+)
+def test_MakeSoloMosaic(method):
+    assert getattr(MakeSoloMosaic, method) is getattr(Driver, method)
 
 
 def test_MakeSoloMosaic_provisioned_run_directory(driverobj):

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -9,11 +9,10 @@ from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
 import f90nml  # type: ignore
-import pytest
 import yaml
 from iotaa import refs
 from lxml import etree
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.mpas import MPAS
 from uwtools.drivers.mpas_base import MPASBase
@@ -156,7 +155,7 @@ def test_MPAS_boundary_files(driverobj, cycle):
     assert all(link.is_symlink() for link in links)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "key,task,test",
     [("files_to_copy", "files_copied", "is_file"), ("files_to_link", "files_linked", "is_symlink")],
 )

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -117,8 +117,9 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_MPAS():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -134,8 +135,10 @@ def test_MPAS():
         "run",
         "runscript",
         "streams_file",
-    ]:
-        assert getattr(MPAS, method) is getattr(MPASBase, method)
+    ],
+)
+def test_MPAS(method):
+    assert getattr(MPAS, method) is getattr(MPASBase, method)
 
 
 def test_MPAS_boundary_files(driverobj, cycle):
@@ -148,9 +151,8 @@ def test_MPAS_boundary_files(driverobj, cycle):
     infile_path = Path(driverobj._driver_config["lateral_boundary_conditions"]["path"])
     infile_path.mkdir()
     for n in ns:
-        (
-            infile_path / f"lbc.{(cycle+dt.timedelta(hours=n)).strftime('%Y-%m-%d_%H.%M.%S')}.nc"
-        ).touch()
+        path = infile_path / f"lbc.{(cycle+dt.timedelta(hours=n)).strftime('%Y-%m-%d_%H.%M.%S')}.nc"
+        path.touch()
     driverobj.boundary_files()
     assert all(link.is_symlink() for link in links)
 

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -9,9 +9,8 @@ from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
 import f90nml  # type: ignore
-import pytest
 from iotaa import refs
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.mpas_base import MPASBase
 from uwtools.drivers.mpas_init import MPASInit
@@ -136,7 +135,7 @@ def test_MPASInit_boundary_files(cycle, driverobj):
     assert all(link.is_symlink() for link in links)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "key,task,test",
     [("files_to_copy", "files_copied", "is_file"), ("files_to_link", "files_linked", "is_symlink")],
 )

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -99,8 +99,9 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_MPASInit():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -116,8 +117,10 @@ def test_MPASInit():
         "run",
         "runscript",
         "streams_file",
-    ]:
-        assert getattr(MPASInit, method) is getattr(MPASBase, method)
+    ],
+)
+def test_MPASInit(method):
+    assert getattr(MPASInit, method) is getattr(MPASBase, method)
 
 
 def test_MPASInit_boundary_files(cycle, driverobj):

--- a/src/uwtools/tests/drivers/test_orog_gsl.py
+++ b/src/uwtools/tests/drivers/test_orog_gsl.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.orog_gsl import OrogGSL
@@ -51,8 +51,9 @@ def driverobj(config):
 # Tests
 
 
-def test_OrogGSL():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -66,8 +67,10 @@ def test_OrogGSL():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(OrogGSL, method) is getattr(Driver, method)
+    ],
+)
+def test_OrogGSL(method):
+    assert getattr(OrogGSL, method) is getattr(Driver, method)
 
 
 def test_OrogGSL_input_grid_file(driverobj):

--- a/src/uwtools/tests/drivers/test_schism.py
+++ b/src/uwtools/tests/drivers/test_schism.py
@@ -7,7 +7,7 @@ from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
 import yaml
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Assets
 from uwtools.drivers.schism import SCHISM
@@ -43,13 +43,16 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_SCHISM():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_taskname",
         "_validate",
-    ]:
-        assert getattr(SCHISM, method) is getattr(Assets, method)
+    ],
+)
+def test_SCHISM(method):
+    assert getattr(SCHISM, method) is getattr(Assets, method)
 
 
 def test_SCHISM_namelist_file(driverobj):

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import f90nml  # type: ignore
 from iotaa import asset, external, refs
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers import sfc_climo_gen
 from uwtools.drivers.driver import Driver
@@ -84,8 +84,9 @@ def driverobj(config):
 # Tests
 
 
-def test_SfcClimoGen():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -100,8 +101,10 @@ def test_SfcClimoGen():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(SfcClimoGen, method) is getattr(Driver, method)
+    ],
+)
+def test_SfcClimoGen(method):
+    assert getattr(SfcClimoGen, method) is getattr(Driver, method)
 
 
 def test_SfcClimoGen_namelist_file(caplog, driverobj):

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -5,7 +5,7 @@ Shave driver tests.
 from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.shave import Shave
@@ -49,8 +49,9 @@ def driverobj(config):
 # Tests
 
 
-def test_Shave():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -64,8 +65,10 @@ def test_Shave():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(Shave, method) is getattr(Driver, method)
+    ],
+)
+def test_Shave(method):
+    assert getattr(Shave, method) is getattr(Driver, method)
 
 
 def test_Shave_provisioned_run_directory(driverobj):

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -7,7 +7,7 @@ from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
 import f90nml  # type: ignore
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers import ungrib
 from uwtools.drivers.driver import Driver
@@ -56,8 +56,9 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_Ungrib():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -71,8 +72,10 @@ def test_Ungrib():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(Ungrib, method) is getattr(Driver, method)
+    ],
+)
+def test_Ungrib(method):
+    assert getattr(Ungrib, method) is getattr(Driver, method)
 
 
 def test_Ungrib_gribfiles(driverobj, tmp_path):

--- a/src/uwtools/tests/drivers/test_upp.py
+++ b/src/uwtools/tests/drivers/test_upp.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import f90nml  # type: ignore
 from iotaa import refs
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.upp import UPP
@@ -77,8 +77,9 @@ def leadtime():
 # Tests
 
 
-def test_UPP():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_resources",
         "_run_via_batch_submission",
@@ -91,8 +92,10 @@ def test_UPP():
         "_write_runscript",
         "run",
         "runscript",
-    ]:
-        assert getattr(UPP, method) is getattr(Driver, method)
+    ],
+)
+def test_UPP(method):
+    assert getattr(UPP, method) is getattr(Driver, method)
 
 
 def test_UPP_files_copied(driverobj):

--- a/src/uwtools/tests/drivers/test_ww3.py
+++ b/src/uwtools/tests/drivers/test_ww3.py
@@ -7,7 +7,7 @@ from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
 import yaml
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Assets
 from uwtools.drivers.ww3 import WaveWatchIII
@@ -43,13 +43,16 @@ def driverobj(config, cycle):
 # Tests
 
 
-def test_WaveWatchIII():
-    for method in [
+@mark.parametrize(
+    "method",
+    [
         "_driver_config",
         "_taskname",
         "_validate",
-    ]:
-        assert getattr(WaveWatchIII, method) is getattr(Assets, method)
+    ],
+)
+def test_WaveWatchIII(method):
+    assert getattr(WaveWatchIII, method) is getattr(Assets, method)
 
 
 def test_WaveWatchIII_namelist_file(driverobj):

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -7,7 +7,6 @@ import sys
 from argparse import ArgumentParser as Parser
 from argparse import _SubParsersAction
 from pathlib import Path
-from typing import List
 from unittest.mock import Mock, patch
 
 from pytest import fixture, mark, raises
@@ -26,7 +25,7 @@ from uwtools.utils.file import FORMAT
 # Helpers
 
 
-def actions(parser: Parser) -> List[str]:
+def actions(parser: Parser) -> list[str]:
     # Return actions (named subparsers) belonging to the given parser.
     if actions := [x for x in parser._actions if isinstance(x, _SubParsersAction)]:
         return list(actions[0].choices.keys())

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -10,8 +10,7 @@ from pathlib import Path
 from typing import List
 from unittest.mock import Mock, patch
 
-import pytest
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 import uwtools.api
 import uwtools.api.config
@@ -163,7 +162,7 @@ def test__add_subparser_template_translate(subparsers):
     assert subparsers.choices[STR.translate]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "vals",
     [
         (STR.file1path, STR.file1fmt),
@@ -198,7 +197,7 @@ def test__check_file_vs_format_pass_explicit():
     assert args[STR.infmt] == fmt
 
 
-@pytest.mark.parametrize("fmt", FORMAT.formats())
+@mark.parametrize("fmt", FORMAT.formats())
 def test__check_file_vs_format_pass_implicit(fmt):
     # The format is correctly deduced for a file with a known extension.
     args = {STR.infile: f"/path/to/input.{fmt}", STR.infmt: None}
@@ -237,7 +236,7 @@ def test__check_template_render_vals_args_noop_explicit_valsfmt():
     assert cli._check_template_render_vals_args(args) == args
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "fmt,fn,ok",
     [
         (None, "update.txt", False),
@@ -265,7 +264,7 @@ def test__check_verbosity_fail(capsys):
     assert "--quiet may not be used with --verbose" in capsys.readouterr().err
 
 
-@pytest.mark.parametrize("flags", ([STR.quiet], [STR.verbose]))
+@mark.parametrize("flags", ([STR.quiet], [STR.verbose]))
 def test__check_verbosity_ok(flags):
     args = {flag: True for flag in flags}
     assert cli._check_verbosity(args) == args
@@ -276,7 +275,7 @@ def test__dict_from_key_eq_val_strings():
     assert cli._dict_from_key_eq_val_strings(["a=1", "b=2"]) == {"a": "1", "b": "2"}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "params",
     [
         (STR.compare, "_dispatch_config_compare"),
@@ -343,7 +342,7 @@ def test__dispatch_config_validate_config_obj():
     _validate_yaml.assert_called_once_with(**_validate_yaml_args)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "action, funcname", [(STR.copy, "_dispatch_file_copy"), (STR.link, "_dispatch_file_link")]
 )
 def test__dispatch_file(action, funcname):
@@ -383,7 +382,7 @@ def test__dispatch_file_link(args_dispatch_file):
     )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "params",
     [
         (STR.realize, "_dispatch_rocoto_realize"),
@@ -432,7 +431,7 @@ def test__dispatch_rocoto_validate_xml_no_optional():
     validate.assert_called_once_with(xml_file=None)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "params",
     [(STR.render, "_dispatch_template_render"), (STR.translate, "_dispatch_template_translate")],
 )
@@ -444,7 +443,7 @@ def test__dispatch_template(params):
     func.assert_called_once_with(args)
 
 
-@pytest.mark.parametrize("valsneeded", [False, True])
+@mark.parametrize("valsneeded", [False, True])
 def test__dispatch_template_render_fail(valsneeded):
     args = {
         STR.infile: 1,
@@ -545,7 +544,7 @@ def test__dispatch_template_translate_no_optional():
     )
 
 
-@pytest.mark.parametrize("hours", [0, 24, 168])
+@mark.parametrize("hours", [0, 24, 168])
 def test__dispatch_to_driver(hours):
     name = "adriver"
     cycle = dt.datetime.now()
@@ -577,8 +576,8 @@ def test__dispatch_to_driver(hours):
         )
 
 
-@pytest.mark.parametrize("quiet", [False, True])
-@pytest.mark.parametrize("verbose", [False, True])
+@mark.parametrize("quiet", [False, True])
+@mark.parametrize("verbose", [False, True])
 def test_main_fail_checks(capsys, quiet, verbose):
     # Using mode 'template render' for testing.
     raw_args = ["testing", STR.template, STR.render]
@@ -597,7 +596,7 @@ def test_main_fail_checks(capsys, quiet, verbose):
                 assert e.value.code == 0
 
 
-@pytest.mark.parametrize("vals", [(True, 0), (False, 1)])
+@mark.parametrize("vals", [(True, 0), (False, 1)])
 def test_main_fail_dispatch(vals):
     # Using mode 'template render' for testing.
     dispatch_retval, exit_status = vals

--- a/src/uwtools/tests/test_file.py
+++ b/src/uwtools/tests/test_file.py
@@ -1,9 +1,8 @@
 # pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
 
 import iotaa
-import pytest
 import yaml
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools import file
 from uwtools.exceptions import UWConfigError
@@ -26,7 +25,7 @@ def assets(tmp_path):
     return dstdir, cfgdict, cfgfile
 
 
-@pytest.mark.parametrize("source", ("dict", "file"))
+@mark.parametrize("source", ("dict", "file"))
 def test_FileCopier(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
@@ -49,7 +48,7 @@ def test_FileCopier_config_file_dry_run(assets):
     iotaa.dryrun(False)
 
 
-@pytest.mark.parametrize("source", ("dict", "file"))
+@mark.parametrize("source", ("dict", "file"))
 def test_FileLinker(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
@@ -61,7 +60,7 @@ def test_FileLinker(assets, source):
     assert (dstdir / "subdir" / "bar").is_symlink()
 
 
-@pytest.mark.parametrize("source", ("dict", "file"))
+@mark.parametrize("source", ("dict", "file"))
 def test_FileStager(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
@@ -70,7 +69,7 @@ def test_FileStager(assets, source):
     assert stager._validate() is True
 
 
-@pytest.mark.parametrize("source", ("dict", "file"))
+@mark.parametrize("source", ("dict", "file"))
 def test_FileStager_bad_key(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
@@ -79,7 +78,7 @@ def test_FileStager_bad_key(assets, source):
     assert str(e.value) == "Failed following YAML key(s): a -> x"
 
 
-@pytest.mark.parametrize("val", [None, True, False, "str", 88, 3.14, [], tuple()])
+@mark.parametrize("val", [None, True, False, "str", 88, 3.14, [], tuple()])
 def test_FileStager_empty_val(assets, val):
     dstdir, cfgdict, _ = assets
     cfgdict["a"]["b"] = val

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -3,7 +3,6 @@
 Tests for uwtools.rocoto module.
 """
 
-from typing import List
 from unittest.mock import DEFAULT as D
 from unittest.mock import PropertyMock, patch
 
@@ -379,7 +378,7 @@ class Test__RocotoXML:
         mocks["_add_workflow_tasks"].assert_called_once_with(workflow, "5")
 
     def test__add_workflow_cycledef(self, instance, root):
-        config: List[dict] = [
+        config: list[dict] = [
             {"attrs": {"group": "g1"}, "spec": "t1"},
             {"attrs": {"group": "g2"}, "spec": "t2"},
         ]

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -7,8 +7,7 @@ from typing import List
 from unittest.mock import DEFAULT as D
 from unittest.mock import PropertyMock, patch
 
-import pytest
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools import rocoto
 from uwtools.config.formats.yaml import YAMLConfig
@@ -166,7 +165,7 @@ class Test__RocotoXML:
         mocks["_add_task_dependency"].assert_called_once_with(task, "qux")
         mocks["_add_task_envar"].assert_called_once_with(task, "A", "apple")
 
-    @pytest.mark.parametrize("cores", [1, "1"])
+    @mark.parametrize("cores", [1, "1"])
     def test__add_task_cores_int_or_str(self, cores, instance, root):
         # Ensure that either int or str "cores" values are accepted.
         config = {"command": "c", "cores": cores, "walltime": "00:00:01"}
@@ -181,7 +180,7 @@ class Test__RocotoXML:
         assert and_.tag == "and"
         assert and_.xpath("or[1]/taskdep")[0].get("task") == "foo"
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "value",
         ["/some/file", {"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "06:00:00"}}}],
     )
@@ -208,7 +207,7 @@ class Test__RocotoXML:
         with raises(UWConfigError):
             instance._add_task_dependency(e=root, config=config)
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "tag_config",
         [("and", {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}})],
     )
@@ -263,7 +262,7 @@ class Test__RocotoXML:
         assert streq.tag == "streq"
         assert streq.get("left") == "&RUN_GSI;"
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "config",
         [
             ("streq", {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}),
@@ -296,7 +295,7 @@ class Test__RocotoXML:
         assert taskvalid.tag == "taskvalid"
         assert taskvalid.get("task") == "foo"
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "value",
         [
             "202301031200",

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -6,7 +6,7 @@
 Tests for uwtools.scheduler module.
 """
 
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import patch
 
 from pytest import fixture, raises
@@ -54,7 +54,7 @@ class ConcreteScheduler(scheduler.JobScheduler):
         return directive_separator
 
     @property
-    def _managed_directives(self) -> Dict[str, Any]:
+    def _managed_directives(self) -> dict[str, Any]:
         return managed_directives
 
     @property

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -5,8 +5,7 @@ Granular tests of JSON Schema schemas.
 
 from functools import partial
 
-import pytest
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.tests.support import schema_validator, with_del, with_set
 
@@ -242,7 +241,7 @@ def test_schema_esg_grid_namelist(esg_grid_prop, esg_namelist):
     assert "not valid" in errors({})
 
 
-@pytest.mark.parametrize("key", ["delx", "dely", "lx", "ly", "pazi", "plat", "plon"])
+@mark.parametrize("key", ["delx", "dely", "lx", "ly", "pazi", "plat", "plon"])
 def test_schema_esg_grid_namelist_content(key):
     config: dict = {
         "regional_grid_nml": {
@@ -639,7 +638,7 @@ def test_schema_global_equiv_resol():
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
 
 
-@pytest.mark.parametrize("schema_entry", ["run_dir", "input_grid_file"])
+@mark.parametrize("schema_entry", ["run_dir", "input_grid_file"])
 def test_schema_global_equiv_resol_paths(global_equiv_resol_prop, schema_entry):
     errors = global_equiv_resol_prop(schema_entry)
     # Must be a string:

--- a/src/uwtools/tests/utils/test_api.py
+++ b/src/uwtools/tests/utils/test_api.py
@@ -4,8 +4,7 @@ import datetime as dt
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.exceptions import UWError
 from uwtools.tests.drivers import test_driver
@@ -26,7 +25,7 @@ def execute_kwargs():
     }
 
 
-@pytest.mark.parametrize("val", [Path("/some/path"), {"foo": 88}])
+@mark.parametrize("val", [Path("/some/path"), {"foo": 88}])
 def test_ensure_data_source_passthrough(val):
     assert api.ensure_data_source(data_source=val, stdin_ok=False) == val
 
@@ -106,7 +105,7 @@ def test_make_tasks():
     assert list(taskmap.keys()) == ["atask", "run", "runscript", "validate"]
 
 
-@pytest.mark.parametrize("val", [Path("/some/path"), {"foo": 88}])
+@mark.parametrize("val", [Path("/some/path"), {"foo": 88}])
 def test_str2path_passthrough(val):
     assert api.str2path(val) == val
 
@@ -118,7 +117,7 @@ def test_str2path_convert():
     assert result == Path(val)
 
 
-@pytest.mark.parametrize("hours", [0, 24, 168])
+@mark.parametrize("hours", [0, 24, 168])
 def test__execute(execute_kwargs, hours, tmp_path):
     graph_file = tmp_path / "g.dot"
     with patch.object(test_driver, "ConcreteDriver", wraps=test_driver.ConcreteDriver) as cd:

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -9,7 +9,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.exceptions import UWError
 from uwtools.utils import file
@@ -58,8 +58,9 @@ def test__stdinproxy():
         assert file._stdinproxy().read() == msg1  # <-- the NEW message
 
 
-def test_get_file_format():
-    for ext, file_type in {
+@mark.parametrize(
+    "ext,file_type",
+    {
         "atparse": "atparse",
         "bash": "sh",
         "cfg": "ini",
@@ -70,8 +71,10 @@ def test_get_file_format():
         "sh": "sh",
         "yaml": "yaml",
         "yml": "yaml",
-    }.items():
-        assert file.get_file_format(Path(f"a.{ext}")) == file_type
+    }.items(),
+)
+def test_get_file_format(ext, file_type):
+    assert file.get_file_format(Path(f"a.{ext}")) == file_type
 
 
 def test_get_file_format_unrecognized():

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -5,7 +5,7 @@ Support for API modules.
 import datetime as dt
 import re
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from uwtools.config.formats.base import Config
 from uwtools.drivers.driver import Driver
@@ -51,7 +51,7 @@ def make_execute(
         batch: bool = False,
         dry_run: bool = False,
         graph_file: Optional[Union[Path, str]] = None,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
         stdin_ok: bool = False,
     ) -> bool:
         return _execute(
@@ -74,7 +74,7 @@ def make_execute(
         batch: bool = False,
         dry_run: bool = False,
         graph_file: Optional[Union[Path, str]] = None,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
         stdin_ok: bool = False,
     ) -> bool:
         return _execute(
@@ -98,7 +98,7 @@ def make_execute(
         batch: bool = False,
         dry_run: bool = False,
         graph_file: Optional[Union[Path, str]] = None,
-        key_path: Optional[List[str]] = None,
+        key_path: Optional[list[str]] = None,
         stdin_ok: bool = False,
     ) -> bool:
         return _execute(
@@ -133,14 +133,14 @@ def make_execute(
     return execute
 
 
-def make_tasks(driver_class: type[Driver]) -> Callable[..., Dict[str, str]]:
+def make_tasks(driver_class: type[Driver]) -> Callable[..., dict[str, str]]:
     """
     Returns a function that maps task names to descriptions for the given driver.
 
     :param driver_class: The driver class whose tasks and descriptions to map.
     """
 
-    def tasks() -> Dict[str, str]:
+    def tasks() -> dict[str, str]:
         """
         Returns a mapping from task names to their one-line descriptions.
         """
@@ -170,7 +170,7 @@ def _execute(
     batch: bool = False,
     dry_run: bool = False,
     graph_file: Optional[Union[Path, str]] = None,
-    key_path: Optional[List[str]] = None,
+    key_path: Optional[list[str]] = None,
     stdin_ok: bool = False,
 ) -> bool:
     """

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -4,7 +4,7 @@ Utilities for interacting with external processes.
 
 from pathlib import Path
 from subprocess import STDOUT, CalledProcessError, check_output
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 from uwtools.logging import INDENT, log
 
@@ -12,7 +12,7 @@ from uwtools.logging import INDENT, log
 def execute(
     cmd: str,
     cwd: Optional[Union[Path, str]] = None,
-    env: Optional[Dict[str, str]] = None,
+    env: Optional[dict[str, str]] = None,
     log_output: Optional[bool] = False,
 ) -> Tuple[bool, str]:
     """

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -4,7 +4,7 @@ Utilities for interacting with external processes.
 
 from pathlib import Path
 from subprocess import STDOUT, CalledProcessError, check_output
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from uwtools.logging import INDENT, log
 
@@ -14,7 +14,7 @@ def execute(
     cwd: Optional[Union[Path, str]] = None,
     env: Optional[dict[str, str]] = None,
     log_output: Optional[bool] = False,
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     """
     Execute a command in a subshell.
 


### PR DESCRIPTION
**Synopsis**

1. Since Python 3.9, which happens to be the earliest version `uwtools` supports, type annotations can use the built-in type names instead of those provided by the `typing` module, e.g. `list` can be used instead of `List`, eliminating the need for a `from typing import List` statement. This PR simplifies our code by taking advantage of this fact for `list`, `dict`, `tuple`, and `set` types.
2. Use `from pytest import mark` and simplify `@pytest.mark.parametrize` decorations given this more explicit import.
3. In a number of tests, convert in-test `for` loops to `@mark.parametrize` decorations. Parametrization is preferable because an `assert` in a `for` loop terminates the entire test and reports a single error, while a parametrized test tests every parametrized value and reports every failure. (I will open a separate PR in the near future to update `test_schemas.py` to break up many of the tests that contains multiple `assert` statements into separate tests, some parametrized, to obtain similar benefits.)

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
