### PR TITLE
UW-633 Expose drivers via API

### DIFF
--- a/docs/sections/user_guide/api/chgres_cube.rst
+++ b/docs/sections/user_guide/api/chgres_cube.rst
@@ -2,4 +2,5 @@
 ===========================
 
 .. automodule:: uwtools.api.chgres_cube
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/config.rst
+++ b/docs/sections/user_guide/api/config.rst
@@ -2,4 +2,4 @@
 ======================
 
 .. automodule:: uwtools.api.config
-    :members:
+   :members:

--- a/docs/sections/user_guide/api/esg_grid.rst
+++ b/docs/sections/user_guide/api/esg_grid.rst
@@ -2,4 +2,5 @@
 ========================
 
 .. automodule:: uwtools.api.esg_grid
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/file.rst
+++ b/docs/sections/user_guide/api/file.rst
@@ -2,4 +2,4 @@
 ====================
 
 .. automodule:: uwtools.api.file
-    :members:
+   :members:

--- a/docs/sections/user_guide/api/filter_topo.rst
+++ b/docs/sections/user_guide/api/filter_topo.rst
@@ -2,4 +2,5 @@
 ===========================
 
 .. automodule:: uwtools.api.filter_topo
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/fv3.rst
+++ b/docs/sections/user_guide/api/fv3.rst
@@ -2,4 +2,5 @@
 ===================
 
 .. automodule:: uwtools.api.fv3
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/global_equiv_resol.rst
+++ b/docs/sections/user_guide/api/global_equiv_resol.rst
@@ -2,4 +2,5 @@
 ==================================
 
 .. automodule:: uwtools.api.global_equiv_resol
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/index.rst
+++ b/docs/sections/user_guide/api/index.rst
@@ -18,8 +18,10 @@ API
    mpas_init
    orog_gsl
    rocoto
+   schism
    sfc_climo_gen
    shave
    template
    ungrib
    upp
+   ww3

--- a/docs/sections/user_guide/api/ioda.rst
+++ b/docs/sections/user_guide/api/ioda.rst
@@ -2,4 +2,5 @@
 ====================
 
 .. automodule:: uwtools.api.ioda
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/jedi.rst
+++ b/docs/sections/user_guide/api/jedi.rst
@@ -2,4 +2,5 @@
 ====================
 
 .. automodule:: uwtools.api.jedi
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/logging.rst
+++ b/docs/sections/user_guide/api/logging.rst
@@ -2,4 +2,4 @@
 =======================
 
 .. automodule:: uwtools.api.logging
-    :members:
+   :members:

--- a/docs/sections/user_guide/api/make_hgrid.rst
+++ b/docs/sections/user_guide/api/make_hgrid.rst
@@ -2,4 +2,5 @@
 ==========================
 
 .. automodule:: uwtools.api.make_hgrid
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/make_solo_mosaic.rst
+++ b/docs/sections/user_guide/api/make_solo_mosaic.rst
@@ -2,4 +2,5 @@
 ================================
 
 .. automodule:: uwtools.api.make_solo_mosaic
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/mpas.rst
+++ b/docs/sections/user_guide/api/mpas.rst
@@ -2,4 +2,5 @@
 ====================
 
 .. automodule:: uwtools.api.mpas
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/mpas_init.rst
+++ b/docs/sections/user_guide/api/mpas_init.rst
@@ -2,4 +2,5 @@
 =========================
 
 .. automodule:: uwtools.api.mpas_init
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/orog_gsl.rst
+++ b/docs/sections/user_guide/api/orog_gsl.rst
@@ -2,4 +2,5 @@
 ========================
 
 .. automodule:: uwtools.api.orog_gsl
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/rocoto.rst
+++ b/docs/sections/user_guide/api/rocoto.rst
@@ -2,4 +2,4 @@
 ======================
 
 .. automodule:: uwtools.api.rocoto
-    :members:
+   :members:

--- a/docs/sections/user_guide/api/schism.rst
+++ b/docs/sections/user_guide/api/schism.rst
@@ -1,0 +1,6 @@
+``uwtools.api.schism``
+======================
+
+.. automodule:: uwtools.api.schism
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/sfc_climo_gen.rst
+++ b/docs/sections/user_guide/api/sfc_climo_gen.rst
@@ -2,4 +2,5 @@
 =============================
 
 .. automodule:: uwtools.api.sfc_climo_gen
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/shave.rst
+++ b/docs/sections/user_guide/api/shave.rst
@@ -2,4 +2,5 @@
 =====================
 
 .. automodule:: uwtools.api.shave
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/template.rst
+++ b/docs/sections/user_guide/api/template.rst
@@ -2,4 +2,4 @@
 ========================
 
 .. automodule:: uwtools.api.template
-    :members:
+   :members:

--- a/docs/sections/user_guide/api/ungrib.rst
+++ b/docs/sections/user_guide/api/ungrib.rst
@@ -2,4 +2,5 @@
 ======================
 
 .. automodule:: uwtools.api.ungrib
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/upp.rst
+++ b/docs/sections/user_guide/api/upp.rst
@@ -2,4 +2,5 @@
 ===================
 
 .. automodule:: uwtools.api.upp
-    :members:
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/ww3.rst
+++ b/docs/sections/user_guide/api/ww3.rst
@@ -1,0 +1,6 @@
+``uwtools.api.ww3``
+===================
+
+.. automodule:: uwtools.api.ww3
+   :inherited-members:
+   :members:

--- a/src/uwtools/api/chgres_cube.py
+++ b/src/uwtools/api/chgres_cube.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``chgres_cube`` driver.
 """
 
-from uwtools.drivers.chgres_cube import ChgresCube as _Driver
+from uwtools.drivers.chgres_cube import ChgresCube
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = ChgresCube
+execute = _make_execute(_driver, with_cycle=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/esg_grid.py
+++ b/src/uwtools/api/esg_grid.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``esg_grid`` driver.
 """
 
-from uwtools.drivers.esg_grid import ESGGrid as _Driver
+from uwtools.drivers.esg_grid import ESGGrid
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = ESGGrid
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/filter_topo.py
+++ b/src/uwtools/api/filter_topo.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``filter_topo`` driver.
 """
 
-from uwtools.drivers.filter_topo import FilterTopo as _Driver
+from uwtools.drivers.filter_topo import FilterTopo
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = FilterTopo
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/fv3.py
+++ b/src/uwtools/api/fv3.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``fv3`` driver.
 """
 
-from uwtools.drivers.fv3 import FV3 as _Driver
+from uwtools.drivers.fv3 import FV3
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = FV3
+execute = _make_execute(_driver, with_cycle=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/global_equiv_resol.py
+++ b/src/uwtools/api/global_equiv_resol.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``global_equiv_resol`` driver.
 """
 
-from uwtools.drivers.global_equiv_resol import GlobalEquivResol as _Driver
+from uwtools.drivers.global_equiv_resol import GlobalEquivResol
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = GlobalEquivResol
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/ioda.py
+++ b/src/uwtools/api/ioda.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``ioda`` driver.
 """
 
-from uwtools.drivers.ioda import IODA as _Driver
+from uwtools.drivers.ioda import IODA
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = IODA
+execute = _make_execute(_driver, with_cycle=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/jedi.py
+++ b/src/uwtools/api/jedi.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``jedi`` driver.
 """
 
-from uwtools.drivers.jedi import JEDI as _Driver
+from uwtools.drivers.jedi import JEDI
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = JEDI
+execute = _make_execute(_driver, with_cycle=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/make_hgrid.py
+++ b/src/uwtools/api/make_hgrid.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``make_hgrid`` driver.
 """
 
-from uwtools.drivers.make_hgrid import MakeHgrid as _Driver
+from uwtools.drivers.make_hgrid import MakeHgrid
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = MakeHgrid
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/make_solo_mosaic.py
+++ b/src/uwtools/api/make_solo_mosaic.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``make_solo_mosaic`` driver.
 """
 
-from uwtools.drivers.make_solo_mosaic import MakeSoloMosaic as _Driver
+from uwtools.drivers.make_solo_mosaic import MakeSoloMosaic
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = MakeSoloMosaic
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/mpas.py
+++ b/src/uwtools/api/mpas.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``mpas`` driver.
 """
 
-from uwtools.drivers.mpas import MPAS as _Driver
+from uwtools.drivers.mpas import MPAS
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = MPAS
+execute = _make_execute(_driver, with_cycle=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/mpas_init.py
+++ b/src/uwtools/api/mpas_init.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``mpas_init`` driver.
 """
 
-from uwtools.drivers.mpas_init import MPASInit as _Driver
+from uwtools.drivers.mpas_init import MPASInit
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = MPASInit
+execute = _make_execute(_driver, with_cycle=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/orog_gsl.py
+++ b/src/uwtools/api/orog_gsl.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``orog_gsl`` driver.
 """
 
-from uwtools.drivers.orog_gsl import OrogGSL as _Driver
+from uwtools.drivers.orog_gsl import OrogGSL
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = OrogGSL
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/schism.py
+++ b/src/uwtools/api/schism.py
@@ -8,6 +8,6 @@ from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
 _driver = SCHISM
-execute = _make_execute(_driver)
+execute = _make_execute(_driver, with_cycle=True)
 tasks = _make_tasks(_driver)
 __all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/schism.py
+++ b/src/uwtools/api/schism.py
@@ -1,0 +1,13 @@
+"""
+API access to the ``uwtools`` ``schism`` driver.
+"""
+
+from uwtools.drivers.schism import SCHISM
+from uwtools.drivers.support import graph
+from uwtools.utils.api import make_execute as _make_execute
+from uwtools.utils.api import make_tasks as _make_tasks
+
+_driver = SCHISM
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/sfc_climo_gen.py
+++ b/src/uwtools/api/sfc_climo_gen.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``sfc_climo_gen`` driver.
 """
 
-from uwtools.drivers.sfc_climo_gen import SfcClimoGen as _Driver
+from uwtools.drivers.sfc_climo_gen import SfcClimoGen
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = SfcClimoGen
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/shave.py
+++ b/src/uwtools/api/shave.py
@@ -2,11 +2,12 @@
 API access to the ``uwtools`` ``shave`` driver.
 """
 
-from uwtools.drivers.shave import Shave as _Driver
+from uwtools.drivers.shave import Shave
 from uwtools.drivers.support import graph
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = Shave
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/ungrib.py
+++ b/src/uwtools/api/ungrib.py
@@ -3,10 +3,11 @@ API access to the ``uwtools`` ``ungrib`` driver.
 """
 
 from uwtools.drivers.support import graph
-from uwtools.drivers.ungrib import Ungrib as _Driver
+from uwtools.drivers.ungrib import Ungrib
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = Ungrib
+execute = _make_execute(_driver, with_cycle=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/upp.py
+++ b/src/uwtools/api/upp.py
@@ -3,10 +3,11 @@ API access to the ``uwtools`` ``upp`` driver.
 """
 
 from uwtools.drivers.support import graph
-from uwtools.drivers.upp import UPP as _Driver
+from uwtools.drivers.upp import UPP
 from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
-execute = _make_execute(_Driver, with_cycle=True, with_leadtime=True)
-tasks = _make_tasks(_Driver)
-__all__ = ["execute", "graph", "tasks"]
+_driver = UPP
+execute = _make_execute(_driver, with_cycle=True, with_leadtime=True)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/ww3.py
+++ b/src/uwtools/api/ww3.py
@@ -8,6 +8,6 @@ from uwtools.utils.api import make_execute as _make_execute
 from uwtools.utils.api import make_tasks as _make_tasks
 
 _driver = WaveWatchIII
-execute = _make_execute(_driver)
+execute = _make_execute(_driver, with_cycle=True)
 tasks = _make_tasks(_driver)
 __all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/api/ww3.py
+++ b/src/uwtools/api/ww3.py
@@ -1,0 +1,13 @@
+"""
+API access to the ``uwtools`` ``ww3`` driver.
+"""
+
+from uwtools.drivers.support import graph
+from uwtools.drivers.ww3 import WaveWatchIII
+from uwtools.utils.api import make_execute as _make_execute
+from uwtools.utils.api import make_tasks as _make_tasks
+
+_driver = WaveWatchIII
+execute = _make_execute(_driver)
+tasks = _make_tasks(_driver)
+__all__ = [_driver.__name__, "execute", "graph", "tasks"]

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -105,7 +105,7 @@ class UWYAMLConvert(UWYAMLTag):
 
         Will raise an exception if the value cannot be represented as the specified type.
         """
-        converters: dict[str, Union[Type[float], Type[int]]] = dict(zip(self.TAGS, [float, int]))
+        converters: dict[str, Union[type[float], type[int]]] = dict(zip(self.TAGS, [float, int]))
         return converters[self.tag](self.value)
 
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Optional, Type, Union
+from typing import Any, Optional, Union
 
 from iotaa import asset, dryrun, external, task, tasks
 
@@ -87,7 +87,7 @@ class Assets(ABC):
 
     @staticmethod
     def _create_user_updated_config(
-        config_class: Type[Config], config_values: dict, path: Path, schema: Optional[dict] = None
+        config_class: type[Config], config_values: dict, path: Path, schema: Optional[dict] = None
     ) -> None:
         """
         Create a config from a base file, user-provided values, or a combination of the two.
@@ -369,3 +369,6 @@ class Driver(Assets):
         with open(path, "w", encoding="utf-8") as f:
             print(rs, file=f)
         os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC)
+
+
+DriverT = Union[type[Assets], type[Driver]]

--- a/src/uwtools/drivers/support.py
+++ b/src/uwtools/drivers/support.py
@@ -4,7 +4,7 @@ Driver support.
 
 import iotaa as _iotaa
 
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverT
 
 
 def graph() -> str:
@@ -14,7 +14,7 @@ def graph() -> str:
     return _iotaa.graph()
 
 
-def tasks(driver_class: type[Driver]) -> dict[str, str]:
+def tasks(driver_class: DriverT) -> dict[str, str]:
     """
     Returns a mapping from task names to their one-line descriptions.
 

--- a/src/uwtools/tests/api/test_drivers.py
+++ b/src/uwtools/tests/api/test_drivers.py
@@ -64,7 +64,7 @@ def test_api_execute(module):
     with patch.object(api, "_execute") as _execute:
         module.execute(**kwargs)
         _execute.assert_called_once_with(
-            driver_class=module._Driver,
+            driver_class=module._driver,
             cycle=kwargs["cycle"] if module in with_cycle else None,
             leadtime=kwargs["leadtime"] if module in with_leadtime else None,
             **kwbase
@@ -80,4 +80,4 @@ def test_api_graph(module):
 def test_api_tasks(module):
     with patch.object(iotaa, "tasknames") as tasknames:
         module.tasks()
-        tasknames.assert_called_once_with(module._Driver)
+        tasknames.assert_called_once_with(module._driver)

--- a/src/uwtools/tests/api/test_drivers.py
+++ b/src/uwtools/tests/api/test_drivers.py
@@ -17,10 +17,12 @@ from uwtools.api import (
     mpas,
     mpas_init,
     orog_gsl,
+    schism,
     sfc_climo_gen,
     shave,
     ungrib,
     upp,
+    ww3,
 )
 from uwtools.drivers import support
 from uwtools.utils import api
@@ -36,12 +38,14 @@ modules = [
     mpas,
     mpas_init,
     orog_gsl,
+    schism,
     sfc_climo_gen,
     shave,
     ungrib,
     upp,
+    ww3,
 ]
-with_cycle = [chgres_cube, fv3, jedi, mpas, mpas_init, ungrib, upp]
+with_cycle = [chgres_cube, fv3, jedi, mpas, mpas_init, schism, ungrib, upp, ww3]
 with_leadtime = [upp]
 
 

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
 from uwtools.config.formats.base import Config
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverT
 from uwtools.drivers.support import graph
 from uwtools.drivers.support import tasks as _tasks
 from uwtools.exceptions import UWError
@@ -33,7 +33,7 @@ def ensure_data_source(
 
 
 def make_execute(
-    driver_class: type[Driver],
+    driver_class: DriverT,
     with_cycle: Optional[bool] = False,
     with_leadtime: Optional[bool] = False,
 ) -> Callable[..., bool]:
@@ -133,7 +133,7 @@ def make_execute(
     return execute
 
 
-def make_tasks(driver_class: type[Driver]) -> Callable[..., dict[str, str]]:
+def make_tasks(driver_class: DriverT) -> Callable[..., dict[str, str]]:
     """
     Returns a function that maps task names to descriptions for the given driver.
 
@@ -162,7 +162,7 @@ def str2path(val: Any) -> Any:
 
 
 def _execute(
-    driver_class: type[Driver],
+    driver_class: DriverT,
     task: str,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,


### PR DESCRIPTION
**Synopsis**

Expose driver classes via API. See docs linked to in the checks section, below, for a preview of the update API docs. This makes driver classes officially available for integration into external coupled drivers. Note that this also makes future changes to drivers potential breaking changes.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
