### PR TITLE
run_dir -> rundir

### DIFF
--- a/docs/sections/user_guide/cli/drivers/chgres_cube.rst
+++ b/docs/sections/user_guide/cli/drivers/chgres_cube.rst
@@ -33,7 +33,7 @@ Its contents are described in depth in section :ref:`chgres_cube_yaml`. Each of 
 
      $ uw chgres_cube run --config-file config.yaml --cycle 2023-12-15T18
 
-  The driver creates a ``runscript.chgres_cube`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``chgres_cube``.
+  The driver creates a ``runscript.chgres_cube`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``chgres_cube``.
 
 * Run ``chgres_cube`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in depth in section :ref:`chgres_cube_yaml`. Each of 
 
      $ uw chgres_cube run --config-file config.yaml --cycle 2023-12-15T18 --batch
 
-  The driver creates a ``runscript.chgres_cube`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``chgres_cube:``.
+  The driver creates a ``runscript.chgres_cube`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``chgres_cube:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/esg_grid.rst
+++ b/docs/sections/user_guide/cli/drivers/esg_grid.rst
@@ -33,7 +33,7 @@ Its contents are described in depth in section :ref:`esg_grid_yaml`.
 
      $ uw esg_grid run --config-file config.yaml
 
-  The driver creates a ``runscript.esg_grid`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``esg_grid``.
+  The driver creates a ``runscript.esg_grid`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``esg_grid``.
 
 * Run ``esg_grid`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in depth in section :ref:`esg_grid_yaml`.
 
      $ uw esg_grid run --config-file config.yaml --batch
 
-The driver creates a ``runscript.esg_grid`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``esg_grid:``.
+The driver creates a ``runscript.esg_grid`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``esg_grid:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/filter_topo.rst
+++ b/docs/sections/user_guide/cli/drivers/filter_topo.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`filter_topo_yaml`.
 
      $ uw filter_topo run --config-file config.yaml
 
-  The driver creates a ``runscript.filter_topo`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``filter_topo``.
+  The driver creates a ``runscript.filter_topo`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``filter_topo``.
 
 * Run ``filter_topo`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in section :ref:`filter_topo_yaml`.
 
      $ uw filter_topo run --config-file config.yaml --batch
 
-  The driver creates a ``runscript.filter_topo`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``filter_topo:``.
+  The driver creates a ``runscript.filter_topo`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``filter_topo:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/fv3.rst
+++ b/docs/sections/user_guide/cli/drivers/fv3.rst
@@ -28,7 +28,7 @@ The examples use a configuration file named ``config.yaml``. Its contents are de
 
      $ uw fv3 run --config-file config.yaml --cycle 2024-02-11T12
 
-  The driver creates a ``runscript.fv3`` file in the directory specified by ``run_dir:`` in the config and runs it, executing FV3.
+  The driver creates a ``runscript.fv3`` file in the directory specified by ``rundir:`` in the config and runs it, executing FV3.
 
 * Run FV3 via a batch job
 
@@ -36,7 +36,7 @@ The examples use a configuration file named ``config.yaml``. Its contents are de
 
      $ uw fv3 run --config-file config.yaml --cycle 2024-02-11T12 --batch
 
-  The driver creates a ``runscript.fv3`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``fv3:``.
+  The driver creates a ``runscript.fv3`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``fv3:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/global_equiv_resol.rst
+++ b/docs/sections/user_guide/cli/drivers/global_equiv_resol.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`global_equiv_resol_yaml`.
 
      $ uw global_equiv_resol run --config-file config.yaml
 
-  The driver creates a ``runscript.global_equiv_resol`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``global_equiv_resol``.
+  The driver creates a ``runscript.global_equiv_resol`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``global_equiv_resol``.
 
 * Run ``global_equiv_resol`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in section :ref:`global_equiv_resol_yaml`.
 
      $ uw global_equiv_resol run --config-file config.yaml --batch
 
-  The driver creates a ``runscript.global_equiv_resol`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``global_equiv_resol:``.
+  The driver creates a ``runscript.global_equiv_resol`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``global_equiv_resol:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/ioda.rst
+++ b/docs/sections/user_guide/cli/drivers/ioda.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`ioda_yaml`.
 
       $ uw ioda run --config-file config.yaml --cycle 2024-05-22T12
 
-The driver creates a ``runscript.ioda`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``ioda``.
+The driver creates a ``runscript.ioda`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``ioda``.
 
 * Run ``ioda`` via a batch job
 
@@ -41,7 +41,7 @@ The driver creates a ``runscript.ioda`` file in the directory specified by ``run
 
       $ uw ioda run --config-file config.yaml --cycle 2024-05-22T12 --batch
 
-The driver creates a ``runscript.ioda`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``ioda:``.
+The driver creates a ``runscript.ioda`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``ioda:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/jedi.rst
+++ b/docs/sections/user_guide/cli/drivers/jedi.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`jedi_yaml`.
 
       $ uw jedi run --config-file config.yaml --cycle 2024-05-22T12
 
-The driver creates a ``runscript.jedi`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``jedi``.
+The driver creates a ``runscript.jedi`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``jedi``.
 
 * Run ``jedi`` via a batch job
 
@@ -41,7 +41,7 @@ The driver creates a ``runscript.jedi`` file in the directory specified by ``run
 
       $ uw jedi run --config-file config.yaml --cycle 2024-05-22T12 --batch
 
-The driver creates a ``runscript.jedi`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``jedi:``.
+The driver creates a ``runscript.jedi`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``jedi:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/make_hgrid.rst
+++ b/docs/sections/user_guide/cli/drivers/make_hgrid.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`make_hgrid_yaml`.
 
      $ uw make_hgrid run --config-file config.yaml
 
-  The driver creates a ``runscript.make_hgrid`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``make_hgrid``.
+  The driver creates a ``runscript.make_hgrid`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``make_hgrid``.
 
   An example runscript:
 
@@ -49,7 +49,7 @@ Its contents are described in section :ref:`make_hgrid_yaml`.
 
      $ uw make_hgrid run --config-file config.yaml --batch
 
-  The driver creates a ``runscript.make_hgrid`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``make_hgrid:``.
+  The driver creates a ``runscript.make_hgrid`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``make_hgrid:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/make_hgrid/runscript.cmd
+++ b/docs/sections/user_guide/cli/drivers/make_hgrid/runscript.cmd
@@ -1,5 +1,5 @@
 rm -f runscript.make_hgrid
 base=../../../../../shared/make_hgrid.yaml
-echo "make_hgrid: {run_dir: $PWD}" | uw config realize --input-file $base --update-format yaml --output-file config.yaml
+echo "make_hgrid: {rundir: $PWD}" | uw config realize --input-file $base --update-format yaml --output-file config.yaml
 uw make_hgrid runscript --config-file config.yaml 2>/dev/null
 cat runscript.make_hgrid

--- a/docs/sections/user_guide/cli/drivers/make_solo_mosaic.rst
+++ b/docs/sections/user_guide/cli/drivers/make_solo_mosaic.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`make_solo_mosaic_yaml`.
 
      $ uw make_solo_mosaic run --config-file config.yaml
 
-  The driver creates a ``runscript.make_solo_mosaic`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``make_solo_mosaic``.
+  The driver creates a ``runscript.make_solo_mosaic`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``make_solo_mosaic``.
 
 ..
   An example runscript:
@@ -50,7 +50,7 @@ Its contents are described in section :ref:`make_solo_mosaic_yaml`.
 
      $ uw make_solo_mosaic run --config-file config.yaml --batch
 
-  The driver creates a ``runscript.make_solo_mosaic`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``make_solo_mosaic:``.
+  The driver creates a ``runscript.make_solo_mosaic`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``make_solo_mosaic:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/make_solo_mosaic/runscript.cmd
+++ b/docs/sections/user_guide/cli/drivers/make_solo_mosaic/runscript.cmd
@@ -1,5 +1,5 @@
 rm -f runscript.make_solo_mosaic
 base=../../../../../shared/make_solo_mosaic.yaml
-echo "make_solo_mosaic: {run_dir: $PWD}" | uw config realize --input-file $base --update-format yaml --output-file config.yaml
+echo "make_solo_mosaic: {rundir: $PWD}" | uw config realize --input-file $base --update-format yaml --output-file config.yaml
 uw make_solo_mosaic runscript --config-file config.yaml 2>/dev/null
 cat runscript.make_solo_mosaic

--- a/docs/sections/user_guide/cli/drivers/mpas.rst
+++ b/docs/sections/user_guide/cli/drivers/mpas.rst
@@ -33,7 +33,7 @@ Its contents are described in depth in section :ref:`mpas_yaml`.
 
      $ uw mpas run --config-file config.yaml --cycle 2025-02-12T12
 
-  The driver creates a ``runscript.mpas`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``atmosphere_model``.
+  The driver creates a ``runscript.mpas`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``atmosphere_model``.
 
 * Run ``mpas`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in depth in section :ref:`mpas_yaml`.
 
      $ uw mpas run --config-file config.yaml --cycle 2025-02-12T12 --batch
 
-  The driver creates a ``runscript.mpas`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``mpas:``.
+  The driver creates a ``runscript.mpas`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``mpas:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/mpas_init.rst
+++ b/docs/sections/user_guide/cli/drivers/mpas_init.rst
@@ -33,7 +33,7 @@ Its contents are described in depth in section :ref:`mpas_init_yaml`.
 
      $ uw mpas_init run --config-file config.yaml --cycle 2023-12-18T00
 
-  The driver creates a ``runscript.mpas_init`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``init_atmosphere``.
+  The driver creates a ``runscript.mpas_init`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``init_atmosphere``.
 
 * Run ``init_atmosphere`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in depth in section :ref:`mpas_init_yaml`.
 
      $ uw mpas_init run --config-file config.yaml --cycle 2023-12-18T00 --batch
 
-  The driver creates a ``runscript.mpas_init`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``mpas_init:``.
+  The driver creates a ``runscript.mpas_init`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``mpas_init:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/orog_gsl.rst
+++ b/docs/sections/user_guide/cli/drivers/orog_gsl.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`orog_gsl_yaml`.
 
      $ uw orog_gsl run --config-file config.yaml
 
-  The driver creates a ``runscript.orog_gsl`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``orog_gsl``.
+  The driver creates a ``runscript.orog_gsl`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``orog_gsl``.
 
 * Run ``orog_gsl`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in section :ref:`orog_gsl_yaml`.
 
      $ uw orog_gsl run --config-file config.yaml --batch
 
-  The driver creates a ``runscript.orog_gsl`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``orog_gsl:``.
+  The driver creates a ``runscript.orog_gsl`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``orog_gsl:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/sfc_climo_gen.rst
+++ b/docs/sections/user_guide/cli/drivers/sfc_climo_gen.rst
@@ -33,7 +33,7 @@ Its contents are described in depth in section :ref:`sfc_climo_gen_yaml`.
 
      $ uw sfc_climo_gen run --config-file config.yaml
 
-  The driver creates a ``runscript.sfc_climo_gen`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``sfc_climo_gen``.
+  The driver creates a ``runscript.sfc_climo_gen`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``sfc_climo_gen``.
 
 * Run ``sfc_climo_gen`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in depth in section :ref:`sfc_climo_gen_yaml`.
 
      $ uw sfc_climo_gen run --config-file config.yaml --batch
 
-  The driver creates a ``runscript.sfc_climo_gen`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``sfc_climo_gen:``.
+  The driver creates a ``runscript.sfc_climo_gen`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``sfc_climo_gen:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/shave.rst
+++ b/docs/sections/user_guide/cli/drivers/shave.rst
@@ -33,7 +33,7 @@ Its contents are described in section :ref:`shave_yaml`.
 
      $ uw shave run --config-file config.yaml
 
-  The driver creates a ``runscript.shave`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``shave``.
+  The driver creates a ``runscript.shave`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``shave``.
 
 * Run ``shave`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in section :ref:`shave_yaml`.
 
      $ uw shave run --config-file config.yaml --batch
 
-  The driver creates a ``runscript.shave`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``shave:``.
+  The driver creates a ``runscript.shave`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``shave:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/ungrib.rst
+++ b/docs/sections/user_guide/cli/drivers/ungrib.rst
@@ -33,7 +33,7 @@ Its contents are described in depth in section :ref:`ungrib_yaml`.
 
      $ uw ungrib run --config-file config.yaml --cycle 2021-04-01T12
 
-  The driver creates a ``runscript.ungrib`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``ungrib``.
+  The driver creates a ``runscript.ungrib`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``ungrib``.
 
 * Run ``ungrib`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in depth in section :ref:`ungrib_yaml`.
 
      $ uw ungrib run --config-file config.yaml --cycle 2021-04-01T12 --batch
 
-  The driver creates a ``runscript.ungrib`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``ungrib:``.
+  The driver creates a ``runscript.ungrib`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``ungrib:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/cli/drivers/upp.rst
+++ b/docs/sections/user_guide/cli/drivers/upp.rst
@@ -33,7 +33,7 @@ Its contents are described in depth in section :ref:`upp_yaml`.
 
      $ uw upp run --config-file config.yaml --cycle 2024-05-06T12 --leadtime 6
 
-  The driver creates a ``runscript.upp`` file in the directory specified by ``run_dir:`` in the config and runs it, executing ``upp``.
+  The driver creates a ``runscript.upp`` file in the directory specified by ``rundir:`` in the config and runs it, executing ``upp``.
 
 * Run ``upp`` via a batch job
 
@@ -41,7 +41,7 @@ Its contents are described in depth in section :ref:`upp_yaml`.
 
      $ uw upp run --config-file config.yaml --cycle 2024-05-06T12 --leadtime 6 --batch
 
-  The driver creates a ``runscript.upp`` file in the directory specified by ``run_dir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``upp:``.
+  The driver creates a ``runscript.upp`` file in the directory specified by ``rundir:`` in the config and submits it to the batch system. Running with ``--batch`` requires a correctly configured ``platform:`` block in ``config.yaml``, as well as appropriate settings in the ``execution:`` block under ``upp:``.
 
 * Specifying the ``--dry-run`` flag results in the driver logging messages about actions it would have taken, without actually taking any.
 

--- a/docs/sections/user_guide/yaml/components/chgres_cube.rst
+++ b/docs/sections/user_guide/yaml/components/chgres_cube.rst
@@ -27,7 +27,7 @@ Supports ``base_file:`` and ``update_values:`` blocks (see :ref:`updating_values
 
 .. include:: /shared/validate_namelist.rst
 
-run_dir
-^^^^^^^
+rundir
+^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/esg_grid.rst
+++ b/docs/sections/user_guide/yaml/components/esg_grid.rst
@@ -25,7 +25,7 @@ Supports ``base_file:`` and ``update_values:`` blocks (see :ref:`updating_values
 
 .. include:: /shared/validate_namelist.rst
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/filter_topo.rst
+++ b/docs/sections/user_guide/yaml/components/filter_topo.rst
@@ -36,7 +36,7 @@ execution:
 
 See :ref:`here <execution_yaml>` for details.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/fv3.rst
+++ b/docs/sections/user_guide/yaml/components/fv3.rst
@@ -79,7 +79,7 @@ Supports ``base_file:`` and ``update_values:`` blocks (see :ref:`updating_values
 
 .. include:: /shared/validate_namelist.rst
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/global_equiv_resol.rst
+++ b/docs/sections/user_guide/yaml/components/global_equiv_resol.rst
@@ -25,7 +25,7 @@ input_grid_file:
 
 The path to the input grid file required by the program.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/ioda.rst
+++ b/docs/sections/user_guide/yaml/components/ioda.rst
@@ -35,7 +35,7 @@ files_to_link:
 
 Identical to ``files_to_copy:`` except that symbolic links will be created in the run directory instead of copies.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/jedi.rst
+++ b/docs/sections/user_guide/yaml/components/jedi.rst
@@ -35,7 +35,7 @@ files_to_link:
 
 Identical to ``files_to_copy:`` except that symbolic links will be created in the run directory instead of copies.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/make_hgrid.rst
+++ b/docs/sections/user_guide/yaml/components/make_hgrid.rst
@@ -195,7 +195,7 @@ Describes the required parameters to run a ``make_hgrid`` configuration.
 
   Specify boundaries for defining meridional regions of varying resolution.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/make_solo_mosaic.rst
+++ b/docs/sections/user_guide/yaml/components/make_solo_mosaic.rst
@@ -49,7 +49,7 @@ execution:
 
 See :ref:`here <execution_yaml>` for details.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/mpas.rst
+++ b/docs/sections/user_guide/yaml/components/mpas.rst
@@ -77,8 +77,8 @@ Supports ``base_file:`` and ``update_values:`` blocks (see :ref:`updating_values
 
 .. include:: /shared/validate_namelist.rst
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.
 

--- a/docs/sections/user_guide/yaml/components/mpas_init.rst
+++ b/docs/sections/user_guide/yaml/components/mpas_init.rst
@@ -76,8 +76,8 @@ Supports ``base_file:`` and ``update_values:`` blocks (see :ref:`updating_values
 
 .. include:: /shared/validate_namelist.rst
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.
 

--- a/docs/sections/user_guide/yaml/components/orog_gsl.rst
+++ b/docs/sections/user_guide/yaml/components/orog_gsl.rst
@@ -49,7 +49,7 @@ execution:
 
 See :ref:`here <execution_yaml>` for details.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/schism.rst
+++ b/docs/sections/user_guide/yaml/components/schism.rst
@@ -26,7 +26,7 @@ namelist:
 
   Key-value pairs necessary to render all Jinja2 expressions in the input template file named by ``template_file:``.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/sfc_climo_gen.rst
+++ b/docs/sections/user_guide/yaml/components/sfc_climo_gen.rst
@@ -25,7 +25,7 @@ Supports ``base_file:`` and ``update_values:`` blocks (see :ref:`updating_values
 
 .. include:: /shared/validate_namelist.rst
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/shave.rst
+++ b/docs/sections/user_guide/yaml/components/shave.rst
@@ -39,7 +39,7 @@ Describes the required parameters to run a ``shave`` configuration.
 
   The j/y dimensions of the compute domain (not including halo)
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/ungrib.rst
+++ b/docs/sections/user_guide/yaml/components/ungrib.rst
@@ -41,8 +41,8 @@ Describes the GRIB-formatted files to be processed by ``ungrib``.
 
   An absolute-path template to the GRIB-formatted files to be processed by ``ungrib``. The Python ``int`` variables ``cycle_hour`` and ``forecast_hour`` will be interpolated into, e.g., ``/path/to/gfs.t{cycle_hour:02d}z.pgrb2.0p25.f{forecast_hour:03d}``. Note that this is a Python string template rather than a Jinja2 template.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.
 

--- a/docs/sections/user_guide/yaml/components/upp.rst
+++ b/docs/sections/user_guide/yaml/components/upp.rst
@@ -53,7 +53,7 @@ Read more on the UPP namelists, including variable meanings and appropriate valu
 
 .. include:: /shared/validate_namelist.rst
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/sections/user_guide/yaml/components/ww3.rst
+++ b/docs/sections/user_guide/yaml/components/ww3.rst
@@ -26,7 +26,7 @@ namelist:
 
   Key-value pairs necessary to render all Jinja2 expressions in the input template file named by ``template_file:``.
 
-run_dir:
-^^^^^^^^
+rundir:
+^^^^^^^
 
 The path to the run directory.

--- a/docs/shared/chgres_cube.yaml
+++ b/docs/shared/chgres_cube.yaml
@@ -24,7 +24,7 @@ chgres_cube:
         varmap_file: /path/to/varmap_table
         vcoord_file_target_grid: /path/to/global_hyblev.l65.txt
     validate: true
-  run_dir: /path/to/dir
+  rundir: /path/to/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/esg_grid.yaml
+++ b/docs/shared/esg_grid.yaml
@@ -17,7 +17,7 @@ esg_grid:
         plat: 38.5
         plon: -97.5
     validate: true
-  run_dir: /path/to/esg_grid
+  rundir: /path/to/esg_grid
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/filter_topo.yaml
+++ b/docs/shared/filter_topo.yaml
@@ -21,7 +21,7 @@ filter_topo:
         topo_field: orog_filt
         topo_file: /path/to/C403_filtered_orog # filter_topo adds a .tile{n}.nc extension
         zero_ocean: true
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/fv3.yaml
+++ b/docs/shared/fv3.yaml
@@ -34,7 +34,7 @@ fv3:
         k_split: 2
         n_split: 6
     validate: true
-  run_dir: /path/to/runs/{{ cycle.strftime('%Y%m%d%H') }}
+  rundir: /path/to/runs/{{ cycle.strftime('%Y%m%d%H') }}
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/global_equiv_resol.yaml
+++ b/docs/shared/global_equiv_resol.yaml
@@ -5,7 +5,7 @@ global_equiv_resol:
       walltime: "00:01:00"
     executable: /path/to/global_equiv_resol.exe
   input_grid_file: /path/to/input/grid/file
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/ioda.yaml
+++ b/docs/shared/ioda.yaml
@@ -19,7 +19,7 @@ ioda:
   files_to_link:
     f3: /path/to/f3
     f4: d/f4
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/jedi.yaml
+++ b/docs/shared/jedi.yaml
@@ -22,7 +22,7 @@ jedi:
   files_to_link:
     f3: /path/to/f3
     f4: d/f4
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/make_hgrid.yaml
+++ b/docs/shared/make_hgrid.yaml
@@ -29,4 +29,4 @@ make_hgrid:
       stdout: /path/to/runscript.out
       walltime: "08:00:00"
     executable: /path/to/make_hgrid
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir

--- a/docs/shared/make_solo_mosaic.yaml
+++ b/docs/shared/make_solo_mosaic.yaml
@@ -11,7 +11,7 @@ make_solo_mosaic:
       cores: 1
       walltime: "00:01:00"
     executable: /path/to/make_solo_mosaic.exe
-  run_dir: /path/to/rundir
+  rundir: /path/to/rundir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/mpas.yaml
+++ b/docs/shared/mpas.yaml
@@ -42,7 +42,7 @@ mpas:
       nhyd_model:
         config_dt: 60
     validate: true
-  run_dir: /path/to/run/directory
+  rundir: /path/to/run/directory
   streams:
     input:
       filename_template: conus.init.nc

--- a/docs/shared/mpas_init.yaml
+++ b/docs/shared/mpas_init.yaml
@@ -48,7 +48,7 @@ mpas_init:
       vertical_grid:
         config_blend_bdy_terrain: true
     validate: true
-  run_dir: /path/to/rundir
+  rundir: /path/to/rundir
   streams:
     input:
       filename_template: conus.static.nc

--- a/docs/shared/orog_gsl.yaml
+++ b/docs/shared/orog_gsl.yaml
@@ -14,7 +14,7 @@ orog_gsl:
       - module use /path/to/modules
       - module load module_name
     executable: /path/to/orog_gsl
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/schism.yaml
+++ b/docs/shared/schism.yaml
@@ -3,7 +3,7 @@ schism:
     template_file: /path/to/schism/param.nml.IN
     template_values:
       dt: 100
-  run_dir: /path/to/run/directory
+  rundir: /path/to/run/directory
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/sfc_climo_gen.yaml
+++ b/docs/shared/sfc_climo_gen.yaml
@@ -33,7 +33,7 @@ sfc_climo_gen:
         snowfree_albedo_method: bilinear
         vegetation_greenness_method: bilinear
     validate: true
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/shave.yaml
+++ b/docs/shared/shave.yaml
@@ -9,7 +9,7 @@ shave:
       cores: 1
       walltime: "00:01:00"
     executable: /path/to/shave
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/ungrib.yaml
+++ b/docs/shared/ungrib.yaml
@@ -9,7 +9,7 @@ ungrib:
     interval_hours: 6
     offset: 0
     path: /path/to/dir/gfs.t{cycle_hour:02d}z.pgrb2.0p25.f{forecast_hour:03d}
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
   vtable: /path/to/Vtable.GFS
 platform:
   account: me

--- a/docs/shared/upp.yaml
+++ b/docs/shared/upp.yaml
@@ -35,7 +35,7 @@ upp:
           - 100
           - 1
     validate: true
-  run_dir: /path/to/run/dir
+  rundir: /path/to/run/dir
 platform:
   account: me
   scheduler: slurm

--- a/docs/shared/ww3.yaml
+++ b/docs/shared/ww3.yaml
@@ -3,7 +3,7 @@ ww3:
     template_file: /path/to/ww3/ww3_shel.nml.IN
     template_values:
       input_forcing_winds: "C"
-  run_dir: /path/to/run/directory
+  rundir: /path/to/run/directory
 platform:
   account: me
   scheduler: slurm

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -166,7 +166,7 @@ class Assets(ABC):
         """
         The path to the component's run directory.
         """
-        return Path(self._driver_config["run_dir"])
+        return Path(self._driver_config["rundir"])
 
     def _taskname(self, suffix: str) -> str:
         """

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -43,7 +43,7 @@ class FilterTopo(Driver):
         The input grid file.
         """
         src = Path(self._driver_config["config"]["input_grid_file"])
-        dst = Path(self._driver_config["run_dir"]) / src.name
+        dst = Path(self._driver_config["rundir"]) / src.name
         yield self._taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -45,7 +45,7 @@ class OrogGSL(Driver):
             self._driver_config["config"][k] for k in ["resolution", "tile", "halo"]
         )
         src = Path(self._driver_config["config"]["input_grid_file"])
-        dst = Path(self._driver_config["run_dir"]) / fn
+        dst = Path(self._driver_config["rundir"]) / fn
         yield self._taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)
@@ -70,7 +70,7 @@ class OrogGSL(Driver):
         """
         fn = "geo_em.d01.lat-lon.2.5m.HGT_M.nc"
         src = Path(self._driver_config["config"]["topo_data_2p5m"])
-        dst = Path(self._driver_config["run_dir"]) / fn
+        dst = Path(self._driver_config["rundir"]) / fn
         yield self._taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)
@@ -82,7 +82,7 @@ class OrogGSL(Driver):
         """
         fn = "HGT.Beljaars_filtered.lat-lon.30s_res.nc"
         src = Path(self._driver_config["config"]["topo_data_30s"])
-        dst = Path(self._driver_config["run_dir"]) / fn
+        dst = Path(self._driver_config["rundir"]) / fn
         yield self._taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)

--- a/src/uwtools/resources/jsonschema/chgres-cube.jsonschema
+++ b/src/uwtools/resources/jsonschema/chgres-cube.jsonschema
@@ -211,14 +211,14 @@
           },
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "execution",
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/esg-grid.jsonschema
+++ b/src/uwtools/resources/jsonschema/esg-grid.jsonschema
@@ -107,14 +107,14 @@
             }
           ]
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "execution",
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/filter-topo.jsonschema
+++ b/src/uwtools/resources/jsonschema/filter-topo.jsonschema
@@ -88,7 +88,7 @@
           },
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
@@ -96,7 +96,7 @@
         "config",
         "execution",
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/fv3.jsonschema
+++ b/src/uwtools/resources/jsonschema/fv3.jsonschema
@@ -137,7 +137,7 @@
           },
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
@@ -147,7 +147,7 @@
         "field_table",
         "length",
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/global-equiv-resol.jsonschema
+++ b/src/uwtools/resources/jsonschema/global-equiv-resol.jsonschema
@@ -9,14 +9,14 @@
         "input_grid_file": {
           "type": "string"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "execution",
         "input_grid_file",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/ioda.jsonschema
+++ b/src/uwtools/resources/jsonschema/ioda.jsonschema
@@ -37,14 +37,14 @@
         "files_to_link": {
           "$ref": "urn:uwtools:files-to-stage"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "configuration_file",
         "execution",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/jedi.jsonschema
+++ b/src/uwtools/resources/jsonschema/jedi.jsonschema
@@ -37,14 +37,14 @@
         "files_to_link": {
           "$ref": "urn:uwtools:files-to-stage"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "configuration_file",
         "execution",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/make-hgrid.jsonschema
+++ b/src/uwtools/resources/jsonschema/make-hgrid.jsonschema
@@ -306,14 +306,14 @@
         "execution": {
           "$ref": "urn:uwtools:execution-serial"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "config",
         "execution",
-        "run_dir"
+        "rundir"
       ]
     }
   },

--- a/src/uwtools/resources/jsonschema/make-solo-mosaic.jsonschema
+++ b/src/uwtools/resources/jsonschema/make-solo-mosaic.jsonschema
@@ -34,14 +34,14 @@
         "execution": {
           "$ref": "urn:uwtools:execution-serial"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "execution",
         "config",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/mpas-init.jsonschema
+++ b/src/uwtools/resources/jsonschema/mpas-init.jsonschema
@@ -66,7 +66,7 @@
           },
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         },
         "streams": {
@@ -76,7 +76,7 @@
       "required": [
         "execution",
         "namelist",
-        "run_dir",
+        "rundir",
         "streams"
       ],
       "type": "object"

--- a/src/uwtools/resources/jsonschema/mpas.jsonschema
+++ b/src/uwtools/resources/jsonschema/mpas.jsonschema
@@ -65,7 +65,7 @@
           },
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         },
         "streams": {
@@ -75,7 +75,7 @@
       "required": [
         "execution",
         "namelist",
-        "run_dir",
+        "rundir",
         "streams"
       ],
       "type": "object"

--- a/src/uwtools/resources/jsonschema/orog-gsl.jsonschema
+++ b/src/uwtools/resources/jsonschema/orog-gsl.jsonschema
@@ -39,14 +39,14 @@
         "execution": {
           "$ref": "urn:uwtools:execution-serial"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "config",
         "execution",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/schism.jsonschema
+++ b/src/uwtools/resources/jsonschema/schism.jsonschema
@@ -19,13 +19,13 @@
           ],
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/sfc-climo-gen.jsonschema
+++ b/src/uwtools/resources/jsonschema/sfc-climo-gen.jsonschema
@@ -125,14 +125,14 @@
           },
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "execution",
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/shave.jsonschema
+++ b/src/uwtools/resources/jsonschema/shave.jsonschema
@@ -32,14 +32,14 @@
         "execution": {
           "$ref": "urn:uwtools:execution-serial"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "config",
         "execution",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/ungrib.jsonschema
+++ b/src/uwtools/resources/jsonschema/ungrib.jsonschema
@@ -33,7 +33,7 @@
           ],
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         },
         "vtable": {
@@ -43,7 +43,7 @@
       "required": [
         "execution",
         "gfs_files",
-        "run_dir",
+        "rundir",
         "vtable"
       ],
       "type": "object"

--- a/src/uwtools/resources/jsonschema/upp.jsonschema
+++ b/src/uwtools/resources/jsonschema/upp.jsonschema
@@ -175,14 +175,14 @@
           },
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "execution",
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/resources/jsonschema/ww3.jsonschema
+++ b/src/uwtools/resources/jsonschema/ww3.jsonschema
@@ -19,13 +19,13 @@
           ],
           "type": "object"
         },
-        "run_dir": {
+        "rundir": {
           "type": "string"
         }
       },
       "required": [
         "namelist",
-        "run_dir"
+        "rundir"
       ],
       "type": "object"
     }

--- a/src/uwtools/tests/drivers/test_chgres_cube.py
+++ b/src/uwtools/tests/drivers/test_chgres_cube.py
@@ -66,7 +66,7 @@ def config(tmp_path):
                 },
                 "validate": True,
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",
@@ -125,7 +125,7 @@ def test_ChgresCube_namelist_file_fails_validation(caplog, driverobj):
 
 def test_ChgresCube_namelist_file_missing_base_file(caplog, driverobj):
     log.setLevel(logging.DEBUG)
-    base_file = str(Path(driverobj._driver_config["run_dir"]) / "missing.nml")
+    base_file = str(Path(driverobj._driver_config["rundir"]) / "missing.nml")
     driverobj._driver_config["namelist"]["base_file"] = base_file
     path = Path(refs(driverobj.namelist_file()))
     assert not path.exists()

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -89,14 +89,14 @@ def config(tmp_path):
                 "batchargs": {
                     "export": "NONE",
                     "nodes": 1,
-                    "stdout": "{{ concrete.run_dir }}/out",
+                    "stdout": "{{ concrete.rundir }}/out",
                     "walltime": "00:05:00",
                 },
                 "executable": str(tmp_path / "qux"),
                 "mpiargs": ["bar", "baz"],
                 "mpicmd": "foo",
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
             "update_values": {"a": 33},
         },
         "platform": {
@@ -212,13 +212,13 @@ def test_Assets__driver_config_pass(assetobj):
     assert set(assetobj._driver_config.keys()) == {
         "base_file",
         "execution",
-        "run_dir",
+        "rundir",
         "update_values",
     }
 
 
 def test_Assets__rundir(assetobj):
-    assert assetobj._rundir == Path(assetobj._driver_config["run_dir"])
+    assert assetobj._rundir == Path(assetobj._driver_config["rundir"])
 
 
 def test_Assets__validate(assetobj):
@@ -333,7 +333,7 @@ def test_Driver__driver_config_pass(driverobj):
     assert set(driverobj._driver_config.keys()) == {
         "base_file",
         "execution",
-        "run_dir",
+        "rundir",
         "update_values",
     }
 
@@ -444,8 +444,8 @@ def test_Driver__runscript_done_file(driverobj):
 
 
 def test_Driver__runscript_path(driverobj):
-    run_dir = Path(driverobj._driver_config["run_dir"])
-    assert driverobj._runscript_path == run_dir / "runscript.concrete"
+    rundir = Path(driverobj._driver_config["rundir"])
+    assert driverobj._runscript_path == rundir / "runscript.concrete"
 
 
 def test_Driver__scheduler(driverobj):
@@ -470,18 +470,18 @@ def test_Driver__validate(assetobj):
 
 
 def test_Driver__write_runscript(driverobj):
-    run_dir = driverobj._driver_config["run_dir"]
-    path = Path(run_dir) / "runscript"
+    rundir = driverobj._driver_config["rundir"]
+    path = Path(rundir) / "runscript"
     executable = driverobj._driver_config["execution"]["executable"]
     driverobj._write_runscript(path=path, envvars={"FOO": "bar", "BAZ": "qux"})
     expected = f"""
     #!/bin/bash
 
     #SBATCH --account=me
-    #SBATCH --chdir={run_dir}
+    #SBATCH --chdir={rundir}
     #SBATCH --export=NONE
     #SBATCH --nodes=1
-    #SBATCH --output={run_dir}/out
+    #SBATCH --output={rundir}/out
     #SBATCH --time=00:05:00
 
     export FOO=bar

--- a/src/uwtools/tests/drivers/test_esg_grid.py
+++ b/src/uwtools/tests/drivers/test_esg_grid.py
@@ -45,7 +45,7 @@ def config(tmp_path):
                     }
                 }
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",
@@ -106,7 +106,7 @@ def test_ESGGrid_namelist_file_fails_validation(caplog, driverobj):
 
 def test_ESGGrid_namelist_file_missing_base_file(caplog, driverobj):
     log.setLevel(logging.DEBUG)
-    base_file = str(Path(driverobj._driver_config["run_dir"]) / "missing.nml")
+    base_file = str(Path(driverobj._driver_config["rundir"]) / "missing.nml")
     driverobj._driver_config["namelist"]["base_file"] = base_file
     path = Path(refs(driverobj.namelist_file()))
     assert not path.exists()

--- a/src/uwtools/tests/drivers/test_filter_topo.py
+++ b/src/uwtools/tests/drivers/test_filter_topo.py
@@ -44,7 +44,7 @@ def config(tmp_path):
                     }
                 }
             },
-            "run_dir": str(tmp_path / "run"),
+            "rundir": str(tmp_path / "run"),
         }
     }
 
@@ -81,7 +81,7 @@ def test_FilterTopo(method):
 
 
 def test_FilterTopo_input_grid_file(driverobj):
-    path = Path(driverobj._driver_config["run_dir"]) / "C403_grid.tile7.halo4.nc"
+    path = Path(driverobj._driver_config["rundir"]) / "C403_grid.tile7.halo4.nc"
     assert not path.is_file()
     driverobj.input_grid_file()
     assert path.is_symlink()

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -49,7 +49,7 @@ def config(tmp_path):
                     },
                 },
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",
@@ -201,7 +201,7 @@ def test_FV3_namelist_file_fails_validation(caplog, driverobj):
 
 def test_FV3_namelist_file_missing_base_file(caplog, driverobj):
     log.setLevel(logging.DEBUG)
-    base_file = str(Path(driverobj._driver_config["run_dir"]) / "missing.nml")
+    base_file = str(Path(driverobj._driver_config["rundir"]) / "missing.nml")
     driverobj._driver_config["namelist"]["base_file"] = base_file
     path = Path(refs(driverobj.namelist_file()))
     assert not path.exists()

--- a/src/uwtools/tests/drivers/test_global_equiv_resol.py
+++ b/src/uwtools/tests/drivers/test_global_equiv_resol.py
@@ -25,7 +25,7 @@ def config(tmp_path):
                 },
                 "executable": "/path/to/global_equiv_resol.exe",
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
             "input_grid_file": str(tmp_path / "input" / "input_grid_file"),
         },
         "platform": {

--- a/src/uwtools/tests/drivers/test_ioda.py
+++ b/src/uwtools/tests/drivers/test_ioda.py
@@ -45,7 +45,7 @@ def config(tmp_path):
                 "foo": "/path/to/foo",
                 "bar/baz": "/path/to/baz",
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",

--- a/src/uwtools/tests/drivers/test_jedi.py
+++ b/src/uwtools/tests/drivers/test_jedi.py
@@ -55,7 +55,7 @@ def config(tmp_path):
                 "foo": "/path/to/foo",
                 "bar/baz": "/path/to/baz",
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",
@@ -103,7 +103,7 @@ def test_JEDI_configuration_file(driverobj):
     base_file = Path(driverobj._driver_config["configuration_file"]["base_file"])
     with open(base_file, "w", encoding="utf-8") as f:
         yaml.dump(basecfg, f)
-    cfgfile = Path(driverobj._driver_config["run_dir"]) / "jedi.yaml"
+    cfgfile = Path(driverobj._driver_config["rundir"]) / "jedi.yaml"
     assert not cfgfile.is_file()
     driverobj.configuration_file()
     assert cfgfile.is_file()
@@ -113,9 +113,9 @@ def test_JEDI_configuration_file(driverobj):
 
 def test_JEDI_configuration_file_missing_base_file(caplog, driverobj):
     log.setLevel(logging.DEBUG)
-    base_file = Path(driverobj._driver_config["run_dir"]) / "missing"
+    base_file = Path(driverobj._driver_config["rundir"]) / "missing"
     driverobj._driver_config["configuration_file"]["base_file"] = base_file
-    cfgfile = Path(driverobj._driver_config["run_dir"]) / "jedi.yaml"
+    cfgfile = Path(driverobj._driver_config["rundir"]) / "jedi.yaml"
     assert not cfgfile.is_file()
     driverobj.configuration_file()
     assert not cfgfile.is_file()
@@ -124,7 +124,7 @@ def test_JEDI_configuration_file_missing_base_file(caplog, driverobj):
 
 def test_JEDI_files_copied(driverobj):
     with patch.object(jedi_base, "filecopy") as filecopy:
-        driverobj._driver_config["run_dir"] = "/path/to/run"
+        driverobj._driver_config["rundir"] = "/path/to/run"
         driverobj.files_copied()
         assert filecopy.call_count == 2
         assert (
@@ -138,7 +138,7 @@ def test_JEDI_files_copied(driverobj):
 
 def test_JEDI_files_linked(driverobj):
     with patch.object(jedi_base, "symlink") as symlink:
-        driverobj._driver_config["run_dir"] = "/path/to/run"
+        driverobj._driver_config["rundir"] = "/path/to/run"
         driverobj.files_linked()
         assert symlink.call_count == 2
         assert (
@@ -178,7 +178,7 @@ def test_JEDI_validate_only(caplog, driverobj):
             result = Mock(output="", success=True)
             run.return_value = result
             driverobj.validate_only()
-            cfgfile = Path(driverobj._driver_config["run_dir"]) / "jedi.yaml"
+            cfgfile = Path(driverobj._driver_config["rundir"]) / "jedi.yaml"
             cmds = [
                 "module load some-module",
                 "module load jedi-module",

--- a/src/uwtools/tests/drivers/test_make_hgrid.py
+++ b/src/uwtools/tests/drivers/test_make_hgrid.py
@@ -31,7 +31,7 @@ def config(tmp_path):
                 },
                 "executable": "/path/to/make_hgrid",
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "myaccount",

--- a/src/uwtools/tests/drivers/test_make_solo_mosaic.py
+++ b/src/uwtools/tests/drivers/test_make_solo_mosaic.py
@@ -27,7 +27,7 @@ def config(tmp_path):
                 },
                 "executable": "/path/to/make_solo_mosaic.exe",
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -26,7 +26,7 @@ def streams_file(config, driverobj, drivername):
     array_elements = {"file", "stream", "var", "var_array", "var_struct"}
     array_elements_tested = set()
     driverobj.streams_file()
-    path = Path(driverobj._driver_config["run_dir"]) / driverobj._streams_fn
+    path = Path(driverobj._driver_config["rundir"]) / driverobj._streams_fn
     with open(path, "r", encoding="utf-8") as f:
         xml = etree.parse(f).getroot()
     assert xml.tag == "streams"
@@ -72,7 +72,7 @@ def config(tmp_path):
                     "nhyd_model": {"config_start_time": "12", "config_stop_time": "12"},
                 },
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
             "streams": {
                 "input": {
                     "filename_template": "conus.init.nc",
@@ -200,7 +200,7 @@ def test_MPAS_namelist_file_fails_validation(caplog, driverobj):
 
 def test_MPAS_namelist_file_missing_base_file(caplog, driverobj):
     log.setLevel(logging.DEBUG)
-    base_file = str(Path(driverobj._driver_config["run_dir"]) / "missing.nml")
+    base_file = str(Path(driverobj._driver_config["rundir"]) / "missing.nml")
     driverobj._driver_config["namelist"]["base_file"] = base_file
     path = Path(refs(driverobj.namelist_file()))
     assert not path.exists()

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -58,7 +58,7 @@ def config(tmp_path):
                     "nhyd_model": {"config_start_time": "12", "config_stop_time": "12"},
                 },
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
             "streams": {
                 "input": {
                     "filename_template": "conus.static.nc",
@@ -190,7 +190,7 @@ def test_MPASInit_namelist_file_fails_validation(caplog, driverobj):
 
 def test_MPASInit_namelist_file_missing_base_file(caplog, driverobj):
     log.setLevel(logging.DEBUG)
-    base_file = str(Path(driverobj._driver_config["run_dir"]) / "missing.nml")
+    base_file = str(Path(driverobj._driver_config["rundir"]) / "missing.nml")
     driverobj._driver_config["namelist"]["base_file"] = base_file
     path = Path(refs(driverobj.namelist_file()))
     assert not path.exists()

--- a/src/uwtools/tests/drivers/test_orog_gsl.py
+++ b/src/uwtools/tests/drivers/test_orog_gsl.py
@@ -34,7 +34,7 @@ def config(tmp_path):
                 },
                 "executable": "/path/to/orog_gsl",
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",
@@ -74,7 +74,7 @@ def test_OrogGSL(method):
 
 
 def test_OrogGSL_input_grid_file(driverobj):
-    path = Path(driverobj._driver_config["run_dir"]) / "C403_grid.tile7.halo4.nc"
+    path = Path(driverobj._driver_config["rundir"]) / "C403_grid.tile7.halo4.nc"
     assert not path.is_file()
     driverobj.input_grid_file()
     assert path.is_symlink()
@@ -90,14 +90,14 @@ def test_OrogGSL_provisioned_run_directory(driverobj):
 
 
 def test_OrogGSL_topo_data_2p5m(driverobj):
-    path = Path(driverobj._driver_config["run_dir"]) / "geo_em.d01.lat-lon.2.5m.HGT_M.nc"
+    path = Path(driverobj._driver_config["rundir"]) / "geo_em.d01.lat-lon.2.5m.HGT_M.nc"
     assert not path.is_file()
     driverobj.topo_data_2p5m()
     assert path.is_symlink()
 
 
 def test_OrogGSL_topo_data_3os(driverobj):
-    path = Path(driverobj._driver_config["run_dir"]) / "HGT.Beljaars_filtered.lat-lon.30s_res.nc"
+    path = Path(driverobj._driver_config["rundir"]) / "HGT.Beljaars_filtered.lat-lon.30s_res.nc"
     assert not path.is_file()
     driverobj.topo_data_30s()
     assert path.is_symlink()

--- a/src/uwtools/tests/drivers/test_schism.py
+++ b/src/uwtools/tests/drivers/test_schism.py
@@ -25,7 +25,7 @@ def config(tmp_path):
                     "dt": 100,
                 },
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
     }
 

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -67,7 +67,7 @@ def config(tmp_path):
                 },
                 "validate": True,
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -32,7 +32,7 @@ def config(tmp_path):
                 "nx": 214,
                 "ny": 128,
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
         "platform": {
             "account": "me",

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -33,7 +33,7 @@ def config(tmp_path):
                 "offset": 6,
                 "path": str(tmp_path / "gfs.t{cycle_hour:02d}z.pgrb2.0p25.f{forecast_hour:03d}"),
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
             "vtable": str(tmp_path / "Vtable.GFS"),
         },
         "platform": {

--- a/src/uwtools/tests/drivers/test_upp.py
+++ b/src/uwtools/tests/drivers/test_upp.py
@@ -50,7 +50,7 @@ def config(tmp_path):
                     },
                 },
             },
-            "run_dir": str(tmp_path / "run"),
+            "rundir": str(tmp_path / "run"),
         },
         "platform": {
             "account": "me",
@@ -148,7 +148,7 @@ def test_UPP_namelist_file_fails_validation(caplog, driverobj):
 
 def test_UPP_namelist_file_missing_base_file(caplog, driverobj):
     log.setLevel(logging.DEBUG)
-    base_file = str(Path(driverobj._driver_config["run_dir"]) / "missing.nml")
+    base_file = str(Path(driverobj._driver_config["rundir"]) / "missing.nml")
     driverobj._driver_config["namelist"]["base_file"] = base_file
     path = Path(refs(driverobj.namelist_file()))
     assert not path.exists()

--- a/src/uwtools/tests/drivers/test_ww3.py
+++ b/src/uwtools/tests/drivers/test_ww3.py
@@ -25,7 +25,7 @@ def config(tmp_path):
                     "input_forcing_winds": "C",
                 },
             },
-            "run_dir": str(tmp_path),
+            "rundir": str(tmp_path),
         },
     }
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -151,13 +151,13 @@ def test_schema_chgres_cube():
     config = {
         "execution": {"executable": "chgres_cube"},
         "namelist": {"base_file": "/path", "validate": True},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("chgres-cube", "properties", "chgres_cube")
     # Basic correctness:
     assert not errors(config)
     # Some top-level keys are required:
-    for key in ("execution", "namelist", "run_dir"):
+    for key in ("execution", "namelist", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -191,8 +191,8 @@ def test_schema_chgres_cube_namelist_update_values(chgres_cube_prop):
     assert not errors({})
 
 
-def test_schema_chgres_cube_run_dir(chgres_cube_prop):
-    errors = chgres_cube_prop("run_dir")
+def test_schema_chgres_cube_rundir(chgres_cube_prop):
+    errors = chgres_cube_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -205,13 +205,13 @@ def test_schema_esg_grid():
     config = {
         "execution": {"executable": "esg_grid"},
         "namelist": {"base_file": "/path", "validate": True},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("esg-grid", "properties", "esg_grid")
     # Basic correctness:
     assert not errors(config)
     # Some top-level keys are required:
-    for key in ("execution", "namelist", "run_dir"):
+    for key in ("execution", "namelist", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -266,8 +266,8 @@ def test_schema_esg_grid_namelist_content(key):
     assert "is a required property" in errors(with_del(config, "regional_grid_nml", key))
 
 
-def test_schema_esg_grid_run_dir(esg_grid_prop):
-    errors = esg_grid_prop("run_dir")
+def test_schema_esg_grid_rundir(esg_grid_prop):
+    errors = esg_grid_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -404,19 +404,19 @@ def test_schema_filter_topo():
                 }
             }
         },
-        "run_dir": "/path/to/run/dir",
+        "rundir": "/path/to/run/dir",
     }
     errors = schema_validator("filter-topo", "properties", "filter_topo")
     nmlkeys = ("namelist", "update_values", "filter_topo_nml")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are requried:
-    for key in ["config", "execution", "namelist", "run_dir"]:
+    for key in ["config", "execution", "namelist", "rundir"]:
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Other top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors(with_set(config, "bar", "foo"))
-    # Top-level run_dir key requires a string value:
-    assert "is not of type 'string'" in errors(with_set(config, None, "run_dir"))
+    # Top-level rundir key requires a string value:
+    assert "is not of type 'string'" in errors(with_set(config, None, "rundir"))
     # All config keys are requried:
     for key in ["input_grid_file"]:
         assert f"'{key}' is a required property" in errors(with_del(config, "config", key))
@@ -473,7 +473,7 @@ def test_schema_fv3():
         "lateral_boundary_conditions": {"interval_hours": 1, "offset": 0, "path": "/tmp/file"},
         "length": 3,
         "namelist": {"base_file": "/path", "validate": True},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("fv3", "properties", "fv3")
     # Basic correctness:
@@ -485,7 +485,7 @@ def test_schema_fv3():
         "lateral_boundary_conditions",
         "length",
         "namelist",
-        "run_dir",
+        "rundir",
     ):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Some top-level keys are optional:
@@ -612,8 +612,8 @@ def test_schema_fv3_namelist_update_values(fv3_prop):
     assert "{} should be non-empty" in errors({"nml": {}})
 
 
-def test_schema_fv3_run_dir(fv3_prop):
-    errors = fv3_prop("run_dir")
+def test_schema_fv3_rundir(fv3_prop):
+    errors = fv3_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -626,19 +626,19 @@ def test_schema_global_equiv_resol():
     config = {
         "execution": {"executable": "/tmp/global_equiv_resol.exe"},
         "input_grid_file": "/tmp/input_grid_file",
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("global-equiv-resol", "properties", "global_equiv_resol")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("execution", "input_grid_file", "run_dir"):
+    for key in ("execution", "input_grid_file", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
 
 
-@mark.parametrize("schema_entry", ["run_dir", "input_grid_file"])
+@mark.parametrize("schema_entry", ["rundir", "input_grid_file"])
 def test_schema_global_equiv_resol_paths(global_equiv_resol_prop, schema_entry):
     errors = global_equiv_resol_prop(schema_entry)
     # Must be a string:
@@ -658,13 +658,13 @@ def test_schema_ioda():
         "execution": {"executable": "/tmp/ioda.exe"},
         "files_to_copy": {"file1": "src1", "file2": "src2"},
         "files_to_link": {"link1": "src3", "link2": "src4"},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("ioda", "properties", "ioda")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("configuration_file", "execution", "run_dir"):
+    for key in ("configuration_file", "execution", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -683,8 +683,8 @@ def test_schema_ioda_configuration_file(ioda_prop):
     assert "should be non-empty" in errors({"update_values": {}})
 
 
-def test_schema_ioda_run_dir(ioda_prop):
-    errors = ioda_prop("run_dir")
+def test_schema_ioda_rundir(ioda_prop):
+    errors = ioda_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -702,13 +702,13 @@ def test_schema_jedi():
         "execution": {"executable": "/tmp/jedi.exe"},
         "files_to_copy": {"file1": "src1", "file2": "src2"},
         "files_to_link": {"link1": "src3", "link2": "src4"},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("jedi", "properties", "jedi")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("configuration_file", "execution", "run_dir"):
+    for key in ("configuration_file", "execution", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -727,8 +727,8 @@ def test_schema_jedi_configuration_file(jedi_prop):
     assert "should be non-empty" in errors({"update_values": {}})
 
 
-def test_schema_jedi_run_dir(jedi_prop):
-    errors = jedi_prop("run_dir")
+def test_schema_jedi_rundir(jedi_prop):
+    errors = jedi_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -741,13 +741,13 @@ def test_schema_make_hgrid():
     config = {
         "config": {"grid_type": "from_file", "my_grid_file": "/path/to/my_grid_file"},
         "execution": {"executable": "make_hgrid"},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("make-hgrid", "properties", "make_hgrid")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("config", "execution", "run_dir"):
+    for key in ("config", "execution", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -789,8 +789,8 @@ def test_schema_make_hgrid_grid_type():
         )
 
 
-def test_schema_make_hgrid_run_dir(make_hgrid_prop):
-    errors = make_hgrid_prop("run_dir")
+def test_schema_make_hgrid_rundir(make_hgrid_prop):
+    errors = make_hgrid_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -803,13 +803,13 @@ def test_schema_make_solo_mosaic():
     config = {
         "config": {"dir": "path/to/dir", "num_tiles": 1},
         "execution": {"executable": "make_solo_mosaic"},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("make-solo-mosaic", "properties", "make_solo_mosaic")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("config", "execution", "run_dir"):
+    for key in ("config", "execution", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -832,8 +832,8 @@ def test_schema_make_solo_mosaic_config(make_solo_mosaic_prop):
         assert "None is not of type" in str(errors({key: None}))
 
 
-def test_schema_make_solo_mosaic_run_dir(make_solo_mosaic_prop):
-    errors = make_solo_mosaic_prop("run_dir")
+def test_schema_make_solo_mosaic_rundir(make_solo_mosaic_prop):
+    errors = make_solo_mosaic_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -846,14 +846,14 @@ def test_schema_mpas(mpas_streams):
     config = {
         "execution": {"executable": "atmosphere_model"},
         "namelist": {"base_file": "path/to/simple.nml", "validate": True},
-        "run_dir": "path/to/rundir",
+        "rundir": "path/to/rundir",
         "streams": mpas_streams,
     }
     errors = schema_validator("mpas", "properties", "mpas")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("execution", "namelist", "run_dir", "streams"):
+    for key in ("execution", "namelist", "rundir", "streams"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -926,8 +926,8 @@ def test_schema_mpas_namelist_update_values(mpas_prop):
     assert "{} should be non-empty" in errors({"nml": {}})
 
 
-def test_schema_mpas_run_dir(mpas_prop):
-    errors = mpas_prop("run_dir")
+def test_schema_mpas_rundir(mpas_prop):
+    errors = mpas_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -940,14 +940,14 @@ def test_schema_mpas_init(mpas_streams):
     config = {
         "execution": {"executable": "mpas_init"},
         "namelist": {"base_file": "path/to/simple.nml", "validate": True},
-        "run_dir": "path/to/rundir",
+        "rundir": "path/to/rundir",
         "streams": mpas_streams,
     }
     errors = schema_validator("mpas-init", "properties", "mpas_init")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("execution", "namelist", "run_dir", "streams"):
+    for key in ("execution", "namelist", "rundir", "streams"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -1014,8 +1014,8 @@ def test_schema_mpas_init_namelist_update_values(mpas_init_prop):
     assert "{} should be non-empty" in errors({"nml": {}})
 
 
-def test_schema_mpas_init_run_dir(mpas_init_prop):
-    errors = mpas_init_prop("run_dir")
+def test_schema_mpas_init_rundir(mpas_init_prop):
+    errors = mpas_init_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -1179,7 +1179,7 @@ def test_schema_orog_gsl():
         "execution": {
             "executable": "/path/to/orog_gsl",
         },
-        "run_dir": "/path/to/run/dir",
+        "rundir": "/path/to/run/dir",
     }
     errors = schema_validator("orog-gsl", "properties", "orog_gsl")
     # Basic correctness:
@@ -1198,12 +1198,12 @@ def test_schema_orog_gsl():
     for key in ["input_grid_file", "topo_data_2p5m", "topo_data_30s"]:
         assert "is not of type 'string'" in errors(with_set(config, None, "config", key))
     # Some top level keys are required:
-    for key in ["config", "execution", "run_dir"]:
+    for key in ["config", "execution", "rundir"]:
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Other top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors(with_set(config, "bar", "foo"))
-    # Top-level run_dir key requires a string value:
-    assert "is not of type 'string'" in errors(with_set(config, None, "run_dir"))
+    # Top-level rundir key requires a string value:
+    assert "is not of type 'string'" in errors(with_set(config, None, "rundir"))
 
 
 # platform
@@ -1322,13 +1322,13 @@ def test_schema_schism():
                 "dt": 100,
             },
         },
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("schism", "properties", "schism")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("namelist", "run_dir"):
+    for key in ("namelist", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -1349,8 +1349,8 @@ def test_schema_schism_namelist(schism_prop):
     )
 
 
-def test_schema_schism_run_dir(schism_prop):
-    errors = schism_prop("run_dir")
+def test_schema_schism_rundir(schism_prop):
+    errors = schism_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -1363,13 +1363,13 @@ def test_schema_sfc_climo_gen():
     config = {
         "execution": {"executable": "sfc_climo_gen"},
         "namelist": {"base_file": "/path", "validate": True},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("sfc-climo-gen", "properties", "sfc_climo_gen")
     # Basic correctness:
     assert not errors(config)
     # Some top-level keys are required:
-    for key in ("execution", "namelist", "run_dir"):
+    for key in ("execution", "namelist", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -1403,8 +1403,8 @@ def test_schema_sfc_climo_gen_namelist_update_values(sfc_climo_gen_prop):
     assert not errors({})
 
 
-def test_schema_sfc_climo_gen_run_dir(sfc_climo_gen_prop):
-    errors = sfc_climo_gen_prop("run_dir")
+def test_schema_sfc_climo_gen_rundir(sfc_climo_gen_prop):
+    errors = sfc_climo_gen_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -1422,13 +1422,13 @@ def test_schema_shave():
             "nh4": 1,
         },
         "execution": {"executable": "shave"},
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("shave", "properties", "shave")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("config", "execution", "run_dir"):
+    for key in ("config", "execution", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -1453,8 +1453,8 @@ def test_schema_shave_config_properties():
         assert "None is not of type" in str(errors({key: None}))
 
 
-def test_schema_shave_run_dir(shave_prop):
-    errors = shave_prop("run_dir")
+def test_schema_shave_rundir(shave_prop):
+    errors = shave_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -1472,21 +1472,21 @@ def test_schema_ungrib():
             "offset": 0,
             "path": "/tmp/gfs.t12z.pgrb2.0p25.f000",
         },
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
         "vtable": "/tmp/Vtable.GFS",
     }
     errors = schema_validator("ungrib", "properties", "ungrib")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("execution", "gfs_files", "run_dir", "vtable"):
+    for key in ("execution", "gfs_files", "rundir", "vtable"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
 
 
-def test_schema_ungrib_run_dir(ungrib_prop):
-    errors = ungrib_prop("run_dir")
+def test_schema_ungrib_rundir(ungrib_prop):
+    errors = ungrib_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -1516,13 +1516,13 @@ def test_schema_upp():
             },
             "validate": True,
         },
-        "run_dir": "/path/to/run",
+        "rundir": "/path/to/run",
     }
     errors = schema_validator("upp", "properties", "upp")
     # Basic correctness:
     assert not errors(config)
     # Some top-level keys are required:
-    for key in ("execution", "namelist", "run_dir"):
+    for key in ("execution", "namelist", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Other top-level keys are optional:
     assert not errors({**config, "files_to_copy": {"dst": "src"}})
@@ -1617,8 +1617,8 @@ def test_schema_upp_namelist(upp_prop):
     )
 
 
-def test_schema_upp_run_dir(upp_prop):
-    errors = upp_prop("run_dir")
+def test_schema_upp_rundir(upp_prop):
+    errors = upp_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)
@@ -1635,13 +1635,13 @@ def test_schema_ww3():
                 "input_forcing_winds": "C",
             },
         },
-        "run_dir": "/tmp",
+        "rundir": "/tmp",
     }
     errors = schema_validator("ww3", "properties", "ww3")
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("namelist", "run_dir"):
+    for key in ("namelist", "rundir"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
@@ -1662,8 +1662,8 @@ def test_schema_ww3_namelist(ww3_prop):
     )
 
 
-def test_schema_ww3_run_dir(ww3_prop):
-    errors = ww3_prop("run_dir")
+def test_schema_ww3_rundir(ww3_prop):
+    errors = ww3_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
     assert "88 is not of type 'string'" in errors(88)


### PR DESCRIPTION
**Synopsis**

Replace UW YAML key `run_dir` with the simpler (and IMO more instinctive) `rundir`. There's nothing here but a simple replacement. All tests still pass, and no documentation needed to be updated. This _will_ require existing UW YAML configs to update accordingly, but we're currently in the early days of integration and, if we want this change, should do it now.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
