### PR TITLE
Allow API users to obtain copies of driver configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,3 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Code owners:
-
 * @NaureenBharwaniNOAA @christinaholtNOAA @elcarpenterNOAA @fgabelmannjr @maddenp-noaa @weirae
-
-# Documentation owners:
-
-.readthedocs.yaml @christinaholtNOAA @jprestop @maddenp-noaa
-docs/* @christinaholtNOAA @jprestop @maddenp-noaa

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 with open("../recipe/meta.json", "r", encoding="utf-8") as f:
     _metadata = json.loads(f.read())
 
+autoclass_content = "both"
 autodoc_mock_imports = ["f90nml", "iotaa", "jsonschema", "lxml", "referencing"]
 copyright = str(dt.datetime.now().year)
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.extlinks", "sphinx.ext.intersphinx"]

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -83,11 +83,3 @@ class ChgresCube(DriverWithCycle):
         Returns the name of this driver.
         """
         return STR.chgrescube
-
-    def _taskname(self, suffix: str) -> str:
-        """
-        Returns a common tag for graph-task log messages.
-
-        :param suffix: Log-string suffix.
-        """
-        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverWithCycle
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class ChgresCube(Driver):
+class ChgresCube(DriverWithCycle):
     """
     A driver for chgres_cube.
     """

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -39,7 +39,6 @@ class ChgresCube(Driver):
         super().__init__(
             config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
         )
-        self._cycle = cycle
 
     # Workflow tasks
 
@@ -114,4 +113,4 @@ class ChgresCube(Driver):
 
         :param suffix: Log-string suffix.
         """
-        return self._taskname_with_cycle(self._cycle, suffix)
+        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import DriverWithCycle
+from uwtools.drivers.driver import DriverCycleBased
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class ChgresCube(DriverWithCycle):
+class ChgresCube(DriverCycleBased):
     """
     A driver for chgres_cube.
     """

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -2,9 +2,7 @@
 A driver for chgres_cube.
 """
 
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -18,27 +16,6 @@ class ChgresCube(Driver):
     """
     A driver for chgres_cube.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -142,11 +142,12 @@ class Assets(ABC):
         """
         Returns the config block specific to this driver.
         """
+        name = self._driver_name
         try:
-            driver_config: dict[str, Any] = self._config[self._driver_name]
+            driver_config: dict[str, Any] = self._config[name]
             return driver_config
         except KeyError as e:
-            raise UWConfigError("Required '%s' block missing in config" % self._driver_name) from e
+            raise UWConfigError("Required '%s' block missing in config" % name) from e
 
     @property
     @abstractmethod

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -32,20 +32,20 @@ class Assets(ABC):
 
     def __init__(
         self,
-        config: Optional[Union[dict, Path]],
         cycle: Optional[datetime] = None,
         leadtime: Optional[timedelta] = None,
-        key_path: Optional[list[str]] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
+        key_path: Optional[list[str]] = None,
     ) -> None:
         """
         A component driver.
 
-        :param config: Path to config file (read stdin if missing or None).
         :param cycle: The cycle.
         :param leadtime: The leadtime.
-        :param key_path: Keys leading through the config to the driver's configuration block.
+        :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
+        :param key_path: Keys leading through the config to the driver's configuration block.
         """
         self._config = YAMLConfig(config=config)
         self._config.dereference(
@@ -234,7 +234,7 @@ class AssetsCycleBased(Assets):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         """
-        super().__init__(config=config, dry_run=dry_run, cycle=cycle, key_path=key_path)
+        super().__init__(cycle=cycle, config=config, dry_run=dry_run, key_path=key_path)
         self._cycle = cycle
 
 
@@ -261,7 +261,7 @@ class AssetsCycleAndLeadtimeBased(Assets):
         :param key_path: Keys leading through the config to the driver's configuration block.
         """
         super().__init__(
-            config=config, dry_run=dry_run, cycle=cycle, key_path=key_path, leadtime=leadtime
+            cycle=cycle, leadtime=leadtime, config=config, dry_run=dry_run, key_path=key_path
         )
         self._cycle = cycle
         self._leadtime = leadtime
@@ -295,25 +295,25 @@ class Driver(Assets):
 
     def __init__(
         self,
-        config: Optional[Path] = None,
         cycle: Optional[datetime] = None,
         leadtime: Optional[timedelta] = None,
+        config: Optional[Path] = None,
         dry_run: bool = False,
-        batch: bool = False,
         key_path: Optional[list[str]] = None,
+        batch: bool = False,
     ):
         """
         The driver.
 
-        :param config: Path to config file (read stdin if missing or None).
         :param cycle: The cycle.
         :param leadtime: The leadtime.
+        :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param batch: Run component via the batch system?
         """
         super().__init__(
-            config=config, cycle=cycle, leadtime=leadtime, dry_run=dry_run, key_path=key_path
+            cycle=cycle, leadtime=leadtime, config=config, dry_run=dry_run, key_path=key_path
         )
         self._batch = batch
 
@@ -487,8 +487,8 @@ class DriverCycleBased(Driver):
         cycle: datetime,
         config: Optional[Path] = None,
         dry_run: bool = False,
-        batch: bool = False,
         key_path: Optional[list[str]] = None,
+        batch: bool = False,
     ):
         """
         The driver.
@@ -496,11 +496,11 @@ class DriverCycleBased(Driver):
         :param cycle: The cycle.
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param batch: Run component via the batch system?
         """
         super().__init__(
-            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
+            cycle=cycle, config=config, dry_run=dry_run, key_path=key_path, batch=batch
         )
         self._cycle = cycle
 
@@ -516,8 +516,8 @@ class DriverCycleAndLeadtimeBased(Driver):
         leadtime: timedelta,
         config: Optional[Path] = None,
         dry_run: bool = False,
-        batch: bool = False,
         key_path: Optional[list[str]] = None,
+        batch: bool = False,
     ):
         """
         The driver.
@@ -526,16 +526,16 @@ class DriverCycleAndLeadtimeBased(Driver):
         :param leadtime: The leadtime.
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param batch: Run component via the batch system?
         """
         super().__init__(
+            cycle=cycle,
+            leadtime=leadtime,
             config=config,
             dry_run=dry_run,
-            batch=batch,
-            cycle=cycle,
             key_path=key_path,
-            leadtime=leadtime,
+            batch=batch,
         )
         self._cycle = cycle
         self._leadtime = leadtime
@@ -550,18 +550,18 @@ class DriverTimeInvariant(Driver):
         self,
         config: Optional[Path] = None,
         dry_run: bool = False,
-        batch: bool = False,
         key_path: Optional[list[str]] = None,
+        batch: bool = False,
     ):
         """
         The driver.
 
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param batch: Run component via the batch system?
         """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
+        super().__init__(config=config, dry_run=dry_run, key_path=key_path, batch=batch)
 
 
 DriverT = Union[type[Assets], type[Driver]]

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -237,6 +237,34 @@ class Assets(ABC):
         validate_internal(schema_name=schema_name, config=self._config)
 
 
+class AssetsWithCycle(Assets):
+    """
+    An abstract class to provision cycle-based assets for component drivers.
+    """
+
+    def __init__(
+        self,
+        cycle: datetime,
+        config: Optional[Path] = None,
+        dry_run: bool = False,
+        batch: bool = False,
+        key_path: Optional[list[str]] = None,
+    ):
+        """
+        The driver.
+
+        :param cycle: The cycle.
+        :param config: Path to config file (read stdin if missing or None).
+        :param dry_run: Run in dry-run mode?
+        :param batch: Run component via the batch system?
+        :param key_path: Keys leading through the config to the driver's configuration block.
+        """
+        super().__init__(
+            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
+        )
+        self._cycle = cycle
+
+
 class Driver(Assets):
     """
     An abstract class for standalone component drivers.
@@ -400,6 +428,93 @@ class Driver(Assets):
         with open(path, "w", encoding="utf-8") as f:
             print(rs, file=f)
         os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC)
+
+
+class DriverTimeInvariant(Driver):
+    """
+    An abstract class for standalone time-invariant component drivers.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Path] = None,
+        dry_run: bool = False,
+        batch: bool = False,
+        key_path: Optional[list[str]] = None,
+    ):
+        """
+        The driver.
+
+        :param config: Path to config file (read stdin if missing or None).
+        :param dry_run: Run in dry-run mode?
+        :param batch: Run component via the batch system?
+        :param key_path: Keys leading through the config to the driver's configuration block.
+        """
+        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
+
+
+class DriverWithCycle(Driver):
+    """
+    An abstract class for standalone cycle-based component drivers.
+    """
+
+    def __init__(
+        self,
+        cycle: datetime,
+        config: Optional[Path] = None,
+        dry_run: bool = False,
+        batch: bool = False,
+        key_path: Optional[list[str]] = None,
+    ):
+        """
+        The driver.
+
+        :param cycle: The cycle.
+        :param config: Path to config file (read stdin if missing or None).
+        :param dry_run: Run in dry-run mode?
+        :param batch: Run component via the batch system?
+        :param key_path: Keys leading through the config to the driver's configuration block.
+        """
+        super().__init__(
+            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
+        )
+        self._cycle = cycle
+
+
+class DriverWithCycleAndLeadtime(Driver):
+    """
+    An abstract class for standalone cycle-and-leadtime-based component drivers.
+    """
+
+    def __init__(
+        self,
+        cycle: datetime,
+        leadtime: timedelta,
+        config: Optional[Path] = None,
+        dry_run: bool = False,
+        batch: bool = False,
+        key_path: Optional[list[str]] = None,
+    ):
+        """
+        The driver.
+
+        :param cycle: The cycle.
+        :param leadtime: The leadtime.
+        :param config: Path to config file (read stdin if missing or None).
+        :param dry_run: Run in dry-run mode?
+        :param batch: Run component via the batch system?
+        :param key_path: Keys leading through the config to the driver's configuration block.
+        """
+        super().__init__(
+            config=config,
+            dry_run=dry_run,
+            batch=batch,
+            cycle=cycle,
+            key_path=key_path,
+            leadtime=leadtime,
+        )
+        self._cycle = cycle
+        self._leadtime = leadtime
 
 
 DriverT = Union[type[Assets], type[Driver]]

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -68,7 +68,7 @@ class Assets(ABC):
             m, s = divmod(r, 60)
             leadtime = "%02d:%02d:%02d" % (h, m, s)
         return " ".join(
-            filter(None, [str(self), cycle, leadtime, "in", self._driver_config["run_dir"]])
+            filter(None, [str(self), cycle, leadtime, "in", self._driver_config["rundir"]])
         )
 
     def __str__(self) -> str:

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -222,7 +222,7 @@ class AssetsCycleBased(Assets):
     def __init__(
         self,
         cycle: datetime,
-        config: Optional[Path] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
     ):
@@ -247,7 +247,7 @@ class AssetsCycleAndLeadtimeBased(Assets):
         self,
         cycle: datetime,
         leadtime: timedelta,
-        config: Optional[Path] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
     ):
@@ -274,7 +274,7 @@ class AssetsTimeInvariant(Assets):
 
     def __init__(
         self,
-        config: Optional[Path] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
     ):
@@ -297,7 +297,7 @@ class Driver(Assets):
         self,
         cycle: Optional[datetime] = None,
         leadtime: Optional[timedelta] = None,
-        config: Optional[Path] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,
@@ -485,7 +485,7 @@ class DriverCycleBased(Driver):
     def __init__(
         self,
         cycle: datetime,
-        config: Optional[Path] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,
@@ -514,7 +514,7 @@ class DriverCycleAndLeadtimeBased(Driver):
         self,
         cycle: datetime,
         leadtime: timedelta,
-        config: Optional[Path] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,
@@ -548,7 +548,7 @@ class DriverTimeInvariant(Driver):
 
     def __init__(
         self,
-        config: Optional[Path] = None,
+        config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -69,9 +69,15 @@ class Assets(ABC):
         dryrun(enable=dry_run)
 
     def __repr__(self) -> str:
-        cycle = [self._cycle.strftime("%Y-%m-%dT%H:%M")] if self._cycle else []
-        leadtime = [str(self._leadtime)] if self._leadtime is not None else []
-        return " ".join([str(self), *cycle, *leadtime, "in", self._driver_config["run_dir"]])
+        cycle = self._cycle.strftime("%Y-%m-%dT%H:%M") if self._cycle else None
+        leadtime = None
+        if self._leadtime is not None:
+            h, r = divmod(self._leadtime.total_seconds(), 3600)
+            m, s = divmod(r, 60)
+            leadtime = "%02d:%02d:%02d" % (h, m, s)
+        return " ".join(
+            filter(None, [str(self), cycle, leadtime, "in", self._driver_config["run_dir"]])
+        )
 
     def __str__(self) -> str:
         return self._driver_name

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -213,28 +213,7 @@ class Assets(ABC):
         validate_internal(schema_name=schema_name, config=self._config)
 
 
-class AssetsTimeInvariant(Assets):
-    """
-    An abstract class to provision assets for time-invariant components.
-    """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, key_path=key_path)
-
-
-class AssetsWithCycle(Assets):
+class AssetsCycleBased(Assets):
     """
     An abstract class to provision assets for cycle-based components.
     """
@@ -258,7 +237,7 @@ class AssetsWithCycle(Assets):
         self._cycle = cycle
 
 
-class AssetsWithCycleAndLeadtime(Assets):
+class AssetsCycleAndLeadtimeBased(Assets):
     """
     An abstract class to provision assets for cycle-and-leadtime-based components.
     """
@@ -285,6 +264,27 @@ class AssetsWithCycleAndLeadtime(Assets):
         )
         self._cycle = cycle
         self._leadtime = leadtime
+
+
+class AssetsTimeInvariant(Assets):
+    """
+    An abstract class to provision assets for time-invariant components.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Path] = None,
+        dry_run: bool = False,
+        key_path: Optional[list[str]] = None,
+    ):
+        """
+        The driver.
+
+        :param config: Path to config file (read stdin if missing or None).
+        :param dry_run: Run in dry-run mode?
+        :param key_path: Keys leading through the config to the driver's configuration block.
+        """
+        super().__init__(config=config, dry_run=dry_run, key_path=key_path)
 
 
 class Driver(Assets):
@@ -476,30 +476,7 @@ class Driver(Assets):
         os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC)
 
 
-class DriverTimeInvariant(Driver):
-    """
-    An abstract class for standalone time-invariant component drivers.
-    """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
-
-
-class DriverWithCycle(Driver):
+class DriverCycleBased(Driver):
     """
     An abstract class for standalone cycle-based component drivers.
     """
@@ -527,7 +504,7 @@ class DriverWithCycle(Driver):
         self._cycle = cycle
 
 
-class DriverWithCycleAndLeadtime(Driver):
+class DriverCycleAndLeadtimeBased(Driver):
     """
     An abstract class for standalone cycle-and-leadtime-based component drivers.
     """
@@ -561,6 +538,29 @@ class DriverWithCycleAndLeadtime(Driver):
         )
         self._cycle = cycle
         self._leadtime = leadtime
+
+
+class DriverTimeInvariant(Driver):
+    """
+    An abstract class for standalone time-invariant component drivers.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Path] = None,
+        dry_run: bool = False,
+        batch: bool = False,
+        key_path: Optional[list[str]] = None,
+    ):
+        """
+        The driver.
+
+        :param config: Path to config file (read stdin if missing or None).
+        :param dry_run: Run in dry-run mode?
+        :param batch: Run component via the batch system?
+        :param key_path: Keys leading through the config to the driver's configuration block.
+        """
+        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
 
 DriverT = Union[type[Assets], type[Driver]]

--- a/src/uwtools/drivers/esg_grid.py
+++ b/src/uwtools/drivers/esg_grid.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class ESGGrid(Driver):
+class ESGGrid(DriverTimeInvariant):
     """
     A driver for esg_grid.
     """

--- a/src/uwtools/drivers/esg_grid.py
+++ b/src/uwtools/drivers/esg_grid.py
@@ -3,7 +3,6 @@ A driver for esg_grid.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -17,23 +16,6 @@ class ESGGrid(Driver):
     """
     A driver for esg_grid.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 from uwtools.utils.tasks import symlink
 
 
-class FilterTopo(Driver):
+class FilterTopo(DriverTimeInvariant):
     """
     A driver for filter_topo.
     """

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -3,7 +3,6 @@ A driver for filter_topo.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -17,23 +16,6 @@ class FilterTopo(Driver):
     """
     A driver for filter_topo.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -183,11 +183,3 @@ class FV3(DriverWithCycle):
         Returns the name of this driver.
         """
         return STR.fv3
-
-    def _taskname(self, suffix: str) -> str:
-        """
-        Returns a common tag for graph-task log messages.
-
-        :param suffix: Log-string suffix.
-        """
-        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -2,10 +2,8 @@
 A driver for the FV3 model.
 """
 
-from datetime import datetime
 from pathlib import Path
 from shutil import copy
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -21,27 +19,6 @@ class FV3(Driver):
     """
     A driver for the FV3 model.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -9,13 +9,13 @@ from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.drivers.driver import DriverWithCycle
+from uwtools.drivers.driver import DriverCycleBased
 from uwtools.logging import log
 from uwtools.strings import STR
 from uwtools.utils.tasks import file, filecopy, symlink
 
 
-class FV3(DriverWithCycle):
+class FV3(DriverCycleBased):
     """
     A driver for the FV3 model.
     """

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -42,7 +42,6 @@ class FV3(Driver):
         super().__init__(
             config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
         )
-        self._cycle = cycle
 
     # Workflow tasks
 
@@ -214,4 +213,4 @@ class FV3(Driver):
 
         :param suffix: Log-string suffix.
         """
-        return self._taskname_with_cycle(self._cycle, suffix)
+        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -9,13 +9,13 @@ from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverWithCycle
 from uwtools.logging import log
 from uwtools.strings import STR
 from uwtools.utils.tasks import file, filecopy, symlink
 
 
-class FV3(Driver):
+class FV3(DriverWithCycle):
     """
     A driver for the FV3 model.
     """

--- a/src/uwtools/drivers/global_equiv_resol.py
+++ b/src/uwtools/drivers/global_equiv_resol.py
@@ -6,11 +6,11 @@ from pathlib import Path
 
 from iotaa import asset, external, tasks
 
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 
 
-class GlobalEquivResol(Driver):
+class GlobalEquivResol(DriverTimeInvariant):
     """
     A driver for global_equiv_resol.
     """

--- a/src/uwtools/drivers/global_equiv_resol.py
+++ b/src/uwtools/drivers/global_equiv_resol.py
@@ -3,7 +3,6 @@ A driver for the global_equiv_resol component.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, external, tasks
 
@@ -15,23 +14,6 @@ class GlobalEquivResol(Driver):
     """
     A driver for global_equiv_resol.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/ioda.py
+++ b/src/uwtools/drivers/ioda.py
@@ -13,6 +13,8 @@ class IODA(JEDIBase):
     A driver for the IODA component.
     """
 
+    # Workflow tasks
+
     @tasks
     def provisioned_run_directory(self):
         """

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.drivers.driver import DriverWithCycle
+from uwtools.drivers.driver import DriverCycleBased
 from uwtools.utils.tasks import file, filecopy, symlink
 
 
-class JEDIBase(DriverWithCycle):
+class JEDIBase(DriverCycleBased):
     """
     A base class for the JEDI-like drivers.
     """

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -3,9 +3,7 @@ A base class for jedi-based drivers.
 """
 
 from abc import abstractmethod
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -18,27 +16,6 @@ class JEDIBase(Driver):
     """
     A base class for the JEDI-like drivers.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param cycle: The forecast cycle.
-        :param config: Path to config file.
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -39,7 +39,6 @@ class JEDIBase(Driver):
         super().__init__(
             config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
         )
-        self._cycle = cycle
 
     # Workflow tasks
 
@@ -104,4 +103,4 @@ class JEDIBase(Driver):
 
         :param suffix: Log-string suffix.
         """
-        return self._taskname_with_cycle(self._cycle, suffix)
+        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -73,11 +73,3 @@ class JEDIBase(DriverWithCycle):
         """
         Returns the name of the config file used in execution.
         """
-
-    def _taskname(self, suffix: str) -> str:
-        """
-        Returns a common tag for graph-task log messages.
-
-        :param suffix: Log-string suffix.
-        """
-        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverWithCycle
 from uwtools.utils.tasks import file, filecopy, symlink
 
 
-class JEDIBase(Driver):
+class JEDIBase(DriverWithCycle):
     """
     A base class for the JEDI-like drivers.
     """

--- a/src/uwtools/drivers/make_hgrid.py
+++ b/src/uwtools/drivers/make_hgrid.py
@@ -4,11 +4,11 @@ A driver for make_hgrid.
 
 from iotaa import tasks
 
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 
 
-class MakeHgrid(Driver):
+class MakeHgrid(DriverTimeInvariant):
     """
     A driver for make_hgrid.
     """

--- a/src/uwtools/drivers/make_hgrid.py
+++ b/src/uwtools/drivers/make_hgrid.py
@@ -2,9 +2,6 @@
 A driver for make_hgrid.
 """
 
-from pathlib import Path
-from typing import Optional
-
 from iotaa import tasks
 
 from uwtools.drivers.driver import Driver
@@ -15,23 +12,6 @@ class MakeHgrid(Driver):
     """
     A driver for make_hgrid.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -4,11 +4,11 @@ A driver for make_solo_mosaic.
 
 from iotaa import tasks
 
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 
 
-class MakeSoloMosaic(Driver):
+class MakeSoloMosaic(DriverTimeInvariant):
     """
     A driver for make_solo_mosaic.
     """

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -2,9 +2,6 @@
 A driver for make_solo_mosaic.
 """
 
-from pathlib import Path
-from typing import Optional
-
 from iotaa import tasks
 
 from uwtools.drivers.driver import Driver
@@ -15,23 +12,6 @@ class MakeSoloMosaic(Driver):
     """
     A driver for make_solo_mosaic.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -30,6 +30,7 @@ class MPAS(MPASBase):
         endhour = self._driver_config["length"]
         interval = lbcs["interval_hours"]
         symlinks = {}
+        assert self._cycle
         for boundary_hour in range(0, endhour + 1, interval):
             file_date = self._cycle + timedelta(hours=boundary_hour)
             fn = f"lbc.{file_date.strftime('%Y-%m-%d_%H.%M.%S')}.nc"
@@ -51,6 +52,7 @@ class MPAS(MPASBase):
         str_duration = str(duration).replace(" days, ", "")
         namelist = self._driver_config["namelist"]
         update_values = namelist.get("update_values", {})
+        assert self._cycle
         update_values.setdefault("nhyd_model", {}).update(
             {
                 "config_start_time": self._cycle.strftime("%Y-%m-%d_%H:00:00"),

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -30,7 +30,6 @@ class MPAS(MPASBase):
         endhour = self._driver_config["length"]
         interval = lbcs["interval_hours"]
         symlinks = {}
-        assert self._cycle
         for boundary_hour in range(0, endhour + 1, interval):
             file_date = self._cycle + timedelta(hours=boundary_hour)
             fn = f"lbc.{file_date.strftime('%Y-%m-%d_%H.%M.%S')}.nc"
@@ -52,7 +51,6 @@ class MPAS(MPASBase):
         str_duration = str(duration).replace(" days, ", "")
         namelist = self._driver_config["namelist"]
         update_values = namelist.get("update_values", {})
-        assert self._cycle
         update_values.setdefault("nhyd_model", {}).update(
             {
                 "config_start_time": self._cycle.strftime("%Y-%m-%d_%H:00:00"),

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -116,11 +116,3 @@ class MPASBase(DriverWithCycle):
         """
         The streams filename.
         """
-
-    def _taskname(self, suffix: str) -> str:
-        """
-        Returns a common tag for graph-task log messages.
-
-        :param suffix: Log-string suffix.
-        """
-        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -9,11 +9,11 @@ from iotaa import asset, task, tasks
 from lxml import etree
 from lxml.etree import Element, SubElement
 
-from uwtools.drivers.driver import DriverWithCycle
+from uwtools.drivers.driver import DriverCycleBased
 from uwtools.utils.tasks import filecopy, symlink
 
 
-class MPASBase(DriverWithCycle):
+class MPASBase(DriverCycleBased):
     """
     A base class for MPAS drivers.
     """

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -3,9 +3,7 @@ A base class for MPAS drivers.
 """
 
 from abc import abstractmethod
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 from lxml import etree
@@ -19,27 +17,6 @@ class MPASBase(Driver):
     """
     A base class for MPAS drivers.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config_file: Path to config file (read stdin if missing or None).
-        :param cycle: The cycle.
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config, cycle=cycle, dry_run=dry_run, batch=batch, key_path=key_path
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -9,11 +9,11 @@ from iotaa import asset, task, tasks
 from lxml import etree
 from lxml.etree import Element, SubElement
 
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverWithCycle
 from uwtools.utils.tasks import filecopy, symlink
 
 
-class MPASBase(Driver):
+class MPASBase(DriverWithCycle):
     """
     A base class for MPAS drivers.
     """

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -40,7 +40,6 @@ class MPASBase(Driver):
         super().__init__(
             config=config, cycle=cycle, dry_run=dry_run, batch=batch, key_path=key_path
         )
-        self._cycle = cycle
 
     # Workflow tasks
 
@@ -147,4 +146,4 @@ class MPASBase(Driver):
 
         :param suffix: Log-string suffix.
         """
-        return self._taskname_with_cycle(self._cycle, suffix)
+        return self._taskname_with_cycle(suffix)

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -31,6 +31,7 @@ class MPASInit(MPASBase):
         interval = lbcs["interval_hours"]
         symlinks = {}
         boundary_filepath = lbcs["path"]
+        assert self._cycle
         for boundary_hour in range(0, endhour + 1, interval):
             file_date = self._cycle + timedelta(hours=boundary_hour)
             fn = f"FILE:{file_date.strftime('%Y-%m-%d_%H')}"
@@ -50,6 +51,7 @@ class MPASInit(MPASBase):
         yield asset(path, path.is_file)
         base_file = self._driver_config["namelist"].get("base_file")
         yield file(Path(base_file)) if base_file else None
+        assert self._cycle
         stop_time = self._cycle + timedelta(
             hours=self._driver_config["boundary_conditions"]["length"]
         )

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -31,7 +31,6 @@ class MPASInit(MPASBase):
         interval = lbcs["interval_hours"]
         symlinks = {}
         boundary_filepath = lbcs["path"]
-        assert self._cycle
         for boundary_hour in range(0, endhour + 1, interval):
             file_date = self._cycle + timedelta(hours=boundary_hour)
             fn = f"FILE:{file_date.strftime('%Y-%m-%d_%H')}"
@@ -51,7 +50,6 @@ class MPASInit(MPASBase):
         yield asset(path, path.is_file)
         base_file = self._driver_config["namelist"].get("base_file")
         yield file(Path(base_file)) if base_file else None
-        assert self._cycle
         stop_time = self._cycle + timedelta(
             hours=self._driver_config["boundary_conditions"]["length"]
         )

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -3,7 +3,6 @@ A driver for orog_gsl.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -16,23 +15,6 @@ class OrogGSL(Driver):
     """
     A driver for orog_gsl.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 from iotaa import asset, task, tasks
 
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 from uwtools.utils.tasks import symlink
 
 
-class OrogGSL(Driver):
+class OrogGSL(DriverTimeInvariant):
     """
     A driver for orog_gsl.
     """

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.api.template import render
-from uwtools.drivers.driver import AssetsWithCycle
+from uwtools.drivers.driver import AssetsCycleBased
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class SCHISM(AssetsWithCycle):
+class SCHISM(AssetsCycleBased):
     """
     An assets driver for SCHISM.
     """

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -39,7 +39,6 @@ class SCHISM(Assets):
         super().__init__(
             config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
         )
-        self._cycle = cycle
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.api.template import render
-from uwtools.drivers.driver import Assets
+from uwtools.drivers.driver import AssetsWithCycle
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class SCHISM(Assets):
+class SCHISM(AssetsWithCycle):
     """
     An assets driver for SCHISM.
     """

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -2,9 +2,7 @@
 An assets driver for SCHISM.
 """
 
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -18,27 +16,6 @@ class SCHISM(Assets):
     """
     An assets driver for SCHISM.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -3,7 +3,6 @@ A driver for sfc_climo_gen.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -17,23 +16,6 @@ class SfcClimoGen(Driver):
     """
     A driver for sfc_climo_gen.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class SfcClimoGen(Driver):
+class SfcClimoGen(DriverTimeInvariant):
     """
     A driver for sfc_climo_gen.
     """

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -2,9 +2,6 @@
 A driver for shave.
 """
 
-from pathlib import Path
-from typing import Optional
-
 from iotaa import tasks
 
 from uwtools.drivers.driver import Driver
@@ -15,23 +12,6 @@ class Shave(Driver):
     """
     A driver for shave.
     """
-
-    def __init__(
-        self,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(config=config, dry_run=dry_run, batch=batch, key_path=key_path)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -4,11 +4,11 @@ A driver for shave.
 
 from iotaa import tasks
 
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 from uwtools.strings import STR
 
 
-class Shave(Driver):
+class Shave(DriverTimeInvariant):
     """
     A driver for shave.
     """

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverWithCycle
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class Ungrib(Driver):
+class Ungrib(DriverWithCycle):
     """
     A driver for ungrib.
     """

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import DriverWithCycle
+from uwtools.drivers.driver import DriverCycleBased
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class Ungrib(DriverWithCycle):
+class Ungrib(DriverCycleBased):
     """
     A driver for ungrib.
     """

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -2,9 +2,8 @@
 A driver for the ungrib component.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -18,27 +17,6 @@ class Ungrib(Driver):
     """
     A driver for ungrib.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -39,7 +39,6 @@ class Ungrib(Driver):
         super().__init__(
             config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
         )
-        self._cycle = cycle
 
     # Workflow tasks
 
@@ -53,6 +52,7 @@ class Ungrib(Driver):
         offset = abs(gfs_files["offset"])
         endhour = gfs_files["forecast_length"] + offset
         interval = gfs_files["interval_hours"]
+        assert self._cycle
         cycle_hour = int((self._cycle - timedelta(hours=offset)).strftime("%H"))
         links = []
         for n, boundary_hour in enumerate(range(offset, endhour + 1, interval)):
@@ -71,6 +71,7 @@ class Ungrib(Driver):
         # Do not use offset here. It's relative to the MPAS fcst to run.
         gfs_files = self._driver_config["gfs_files"]
         endhour = gfs_files["forecast_length"]
+        assert self._cycle
         end_date = self._cycle + timedelta(hours=endhour)
         interval = int(gfs_files["interval_hours"]) * 3600  # hour to sec
         d = {
@@ -154,7 +155,7 @@ class Ungrib(Driver):
 
         :param suffix: Log-string suffix.
         """
-        return self._taskname_with_cycle(self._cycle, suffix)
+        return self._taskname_with_cycle(suffix)
 
 
 def _ext(n):

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -30,7 +30,6 @@ class Ungrib(DriverWithCycle):
         offset = abs(gfs_files["offset"])
         endhour = gfs_files["forecast_length"] + offset
         interval = gfs_files["interval_hours"]
-        assert self._cycle
         cycle_hour = int((self._cycle - timedelta(hours=offset)).strftime("%H"))
         links = []
         for n, boundary_hour in enumerate(range(offset, endhour + 1, interval)):
@@ -49,7 +48,6 @@ class Ungrib(DriverWithCycle):
         # Do not use offset here. It's relative to the MPAS fcst to run.
         gfs_files = self._driver_config["gfs_files"]
         endhour = gfs_files["forecast_length"]
-        assert self._cycle
         end_date = self._cycle + timedelta(hours=endhour)
         interval = int(gfs_files["interval_hours"]) * 3600  # hour to sec
         d = {
@@ -126,14 +124,6 @@ class Ungrib(DriverWithCycle):
         yield file(path=infile)
         link.parent.mkdir(parents=True, exist_ok=True)
         link.symlink_to(infile)
-
-    def _taskname(self, suffix: str) -> str:
-        """
-        Returns a common tag for graph-task log messages.
-
-        :param suffix: Log-string suffix.
-        """
-        return self._taskname_with_cycle(suffix)
 
 
 def _ext(n):

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -101,11 +101,3 @@ class UPP(DriverWithCycleAndLeadtime):
             "%s < %s" % (execution["executable"], self._namelist_path.name),
         ]
         return " ".join(filter(None, components))
-
-    def _taskname(self, suffix: str) -> str:
-        """
-        Returns a common tag for graph-task log messages.
-
-        :param suffix: Log-string suffix.
-        """
-        return self._taskname_with_cycle_and_leadtime(suffix)

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverWithCycleAndLeadtime
 from uwtools.strings import STR
 from uwtools.utils.tasks import file, filecopy, symlink
 
 
-class UPP(Driver):
+class UPP(DriverWithCycleAndLeadtime):
     """
     A driver for UPP.
     """

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -2,9 +2,7 @@
 A driver for UPP.
 """
 
-from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -18,34 +16,6 @@ class UPP(Driver):
     """
     A driver for UPP.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        leadtime: timedelta,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param leadtime: The leadtime.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config,
-            dry_run=dry_run,
-            batch=batch,
-            cycle=cycle,
-            key_path=key_path,
-            leadtime=leadtime,
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -46,8 +46,6 @@ class UPP(Driver):
             key_path=key_path,
             leadtime=leadtime,
         )
-        self._cycle = cycle
-        self._leadtime = leadtime
 
     # Workflow tasks
 
@@ -140,4 +138,4 @@ class UPP(Driver):
 
         :param suffix: Log-string suffix.
         """
-        return self._taskname_with_cycle_and_leadtime(self._cycle, self._leadtime, suffix)
+        return self._taskname_with_cycle_and_leadtime(suffix)

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import DriverWithCycleAndLeadtime
+from uwtools.drivers.driver import DriverCycleAndLeadtimeBased
 from uwtools.strings import STR
 from uwtools.utils.tasks import file, filecopy, symlink
 
 
-class UPP(DriverWithCycleAndLeadtime):
+class UPP(DriverCycleAndLeadtimeBased):
     """
     A driver for UPP.
     """

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -2,9 +2,7 @@
 An assets driver for ww3.
 """
 
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from iotaa import asset, task, tasks
 
@@ -18,27 +16,6 @@ class WaveWatchIII(Assets):
     """
     A library driver for ww3.
     """
-
-    def __init__(
-        self,
-        cycle: datetime,
-        config: Optional[Path] = None,
-        dry_run: bool = False,
-        batch: bool = False,
-        key_path: Optional[list[str]] = None,
-    ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param batch: Run component via the batch system?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
-        super().__init__(
-            config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
-        )
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -39,7 +39,6 @@ class WaveWatchIII(Assets):
         super().__init__(
             config=config, dry_run=dry_run, batch=batch, cycle=cycle, key_path=key_path
         )
-        self._cycle = cycle
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.api.template import render
-from uwtools.drivers.driver import AssetsWithCycle
+from uwtools.drivers.driver import AssetsCycleBased
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class WaveWatchIII(AssetsWithCycle):
+class WaveWatchIII(AssetsCycleBased):
     """
     A library driver for ww3.
     """

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.api.template import render
-from uwtools.drivers.driver import Assets
+from uwtools.drivers.driver import AssetsWithCycle
 from uwtools.strings import STR
 from uwtools.utils.tasks import file
 
 
-class WaveWatchIII(Assets):
+class WaveWatchIII(AssetsWithCycle):
     """
     A library driver for ww3.
     """

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -148,21 +148,17 @@ def test_Assets_str(assetsobj):
 
 
 def test_Assets_config(assetsobj):
-    old = assetsobj._driver_config
-    new = assetsobj.config
     # The user-accessible object is equivalent to the internal driver config:
-    assert new == old
+    assert assetsobj.config == assetsobj._driver_config
     # But they are separate objects:
-    assert not new is old
+    assert not assetsobj.config is assetsobj._driver_config
 
 
 def test_Assets_config_full(assetsobj):
-    old = assetsobj._config
-    new = assetsobj.config_full
     # The user-accessible object is equivalent to the internal driver config:
-    assert new == old
+    assert assetsobj.config_full == assetsobj._config
     # But they are separate objects:
-    assert not new is old
+    assert not assetsobj.config_full is assetsobj._config
 
 
 @mark.parametrize("val", (True, False))

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -146,6 +146,24 @@ def test_Assets__str__(assetsobj):
     assert str(assetsobj) == "concrete"
 
 
+def test_Assets_config(assetsobj):
+    old = assetsobj._driver_config
+    new = assetsobj.config
+    # The user-accessible object is equivalent to the internal driver config:
+    assert new == old
+    # But they are separate objects:
+    assert not new is old
+
+
+def test_Assets_config_full(assetsobj):
+    old = assetsobj._config
+    new = assetsobj.config_full
+    # The user-accessible object is equivalent to the internal driver config:
+    assert new == old
+    # But they are separate objects:
+    assert not new is old
+
+
 @mark.parametrize("hours", [0, 24, 168])
 def test_Assets_cycle_leadtime_error(config, hours):
     with raises(UWError) as e:

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -26,25 +26,7 @@ from uwtools.tests.support import regex_logged
 # Helpers
 
 
-class ConcreteAssetsTimeInvariant(driver.AssetsTimeInvariant):
-
-    @task
-    def atask(self):
-        yield "atask"
-        yield asset("atask", lambda: True)
-
-    def provisioned_run_directory(self):
-        pass
-
-    @property
-    def _driver_name(self) -> str:
-        return "concrete"
-
-    def _validate(self) -> None:
-        pass
-
-
-class ConcreteDriverTimeInvariant(driver.DriverTimeInvariant):
+class Common:
 
     __test__ = False
 
@@ -62,6 +44,30 @@ class ConcreteDriverTimeInvariant(driver.DriverTimeInvariant):
 
     def _validate(self) -> None:
         pass
+
+
+class ConcreteAssetsTimeInvariant(Common, driver.AssetsTimeInvariant):
+    pass
+
+
+class ConcreteAssetsWithCycle(Common, driver.AssetsWithCycle):
+    pass
+
+
+class ConcreteAssetsWithCycleAndLeadtime(Common, driver.AssetsWithCycleAndLeadtime):
+    pass
+
+
+class ConcreteDriverTimeInvariant(Common, driver.DriverTimeInvariant):
+    pass
+
+
+class ConcreteDriverWithCycle(Common, driver.DriverWithCycle):
+    pass
+
+
+class ConcreteDriverWithCycleAndLeadtime(Common, driver.DriverWithCycleAndLeadtime):
+    pass
 
 
 def write(path, s):

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -5,7 +5,7 @@
 """
 Tests for uwtools.drivers.driver module.
 """
-# import datetime as dt
+import datetime as dt
 import json
 import logging
 from pathlib import Path
@@ -123,9 +123,24 @@ def test_Assets(assetsobj):
     assert Path(assetsobj._driver_config["base_file"]).name == "base.yaml"
 
 
-def test_Assets_repr(assetsobj):
-    expected = "concrete in %s" % assetsobj._driver_config["run_dir"]
-    assert repr(assetsobj) == expected
+def test_Assets_repr_time_invariant(config):
+    obj = ConcreteAssetsTimeInvariant(config=config)
+    expected = "concrete in %s" % obj._driver_config["run_dir"]
+    assert repr(obj) == expected
+
+
+def test_Assets_repr_with_cycle(config):
+    obj = ConcreteAssetsWithCycle(config=config, cycle=dt.datetime(2024, 7, 2, 12))
+    expected = "concrete 2024-07-02T12:00 in %s" % obj._driver_config["run_dir"]
+    assert repr(obj) == expected
+
+
+def test_Assets_repr_with_cycle_and_leadtime(config):
+    obj = ConcreteAssetsWithCycleAndLeadtime(
+        config=config, cycle=dt.datetime(2024, 7, 2, 12), leadtime=dt.timedelta(hours=6)
+    )
+    expected = "concrete 2024-07-02T12:00 06:00:00 in %s" % obj._driver_config["run_dir"]
+    assert repr(obj) == expected
 
 
 def test_Assets_str(assetsobj):

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -125,7 +125,7 @@ def test_Assets(assetsobj):
 
 def test_Assets_repr_cycle_based(config):
     obj = ConcreteAssetsCycleBased(config=config, cycle=dt.datetime(2024, 7, 2, 12))
-    expected = "concrete 2024-07-02T12:00 in %s" % obj._driver_config["run_dir"]
+    expected = "concrete 2024-07-02T12:00 in %s" % obj._driver_config["rundir"]
     assert repr(obj) == expected
 
 
@@ -133,13 +133,13 @@ def test_Assets_repr_cycle_and_leadtime_based(config):
     obj = ConcreteAssetsCycleAndLeadtimeBased(
         config=config, cycle=dt.datetime(2024, 7, 2, 12), leadtime=dt.timedelta(hours=6)
     )
-    expected = "concrete 2024-07-02T12:00 06:00:00 in %s" % obj._driver_config["run_dir"]
+    expected = "concrete 2024-07-02T12:00 06:00:00 in %s" % obj._driver_config["rundir"]
     assert repr(obj) == expected
 
 
 def test_Assets_repr_time_invariant(config):
     obj = ConcreteAssetsTimeInvariant(config=config)
-    expected = "concrete in %s" % obj._driver_config["run_dir"]
+    expected = "concrete in %s" % obj._driver_config["rundir"]
     assert repr(obj) == expected
 
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -23,7 +23,7 @@ from uwtools.tests.support import regex_logged
 # Helpers
 
 
-class ConcreteAssets(driver.AssetsWithCycleAndLeadtime):
+class ConcreteAssets(driver.Assets):
     """
     Driver subclass for testing purposes.
     """
@@ -112,7 +112,6 @@ def assetsobj(config):
     return ConcreteAssets(
         config=config,
         dry_run=False,
-        batch=True,
         cycle=dt.datetime(2024, 3, 22, 18),
         leadtime=dt.timedelta(hours=24),
     )
@@ -134,11 +133,10 @@ def driverobj(config):
 
 def test_Assets(assetsobj):
     assert Path(assetsobj._driver_config["base_file"]).name == "base.yaml"
-    assert assetsobj._batch is True
 
 
 def test_Assets_repr(assetsobj):
-    expected = "concrete 2024-03-22T18:00 24:00:00 in %s" % assetsobj._driver_config["run_dir"]
+    expected = "concrete in %s" % assetsobj._driver_config["run_dir"]
     assert repr(assetsobj) == expected
 
 
@@ -182,7 +180,6 @@ def test_key_path(config, tmp_path):
     assetsobj = ConcreteAssets(
         config=config_file,
         dry_run=False,
-        batch=True,
         cycle=dt.datetime(2024, 3, 22, 18),
         key_path=["foo", "bar"],
         leadtime=dt.timedelta(hours=24),

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -46,27 +46,27 @@ class Common:
         pass
 
 
+class ConcreteAssetsCycleBased(Common, driver.AssetsCycleBased):
+    pass
+
+
+class ConcreteAssetsCycleAndLeadtimeBased(Common, driver.AssetsCycleAndLeadtimeBased):
+    pass
+
+
 class ConcreteAssetsTimeInvariant(Common, driver.AssetsTimeInvariant):
     pass
 
 
-class ConcreteAssetsWithCycle(Common, driver.AssetsWithCycle):
+class ConcreteDriverCycleBased(Common, driver.DriverCycleBased):
     pass
 
 
-class ConcreteAssetsWithCycleAndLeadtime(Common, driver.AssetsWithCycleAndLeadtime):
+class ConcreteDriverCycleAndLeadtimeBased(Common, driver.DriverCycleAndLeadtimeBased):
     pass
 
 
 class ConcreteDriverTimeInvariant(Common, driver.DriverTimeInvariant):
-    pass
-
-
-class ConcreteDriverWithCycle(Common, driver.DriverWithCycle):
-    pass
-
-
-class ConcreteDriverWithCycleAndLeadtime(Common, driver.DriverWithCycleAndLeadtime):
     pass
 
 
@@ -123,23 +123,23 @@ def test_Assets(assetsobj):
     assert Path(assetsobj._driver_config["base_file"]).name == "base.yaml"
 
 
-def test_Assets_repr_time_invariant(config):
-    obj = ConcreteAssetsTimeInvariant(config=config)
-    expected = "concrete in %s" % obj._driver_config["run_dir"]
-    assert repr(obj) == expected
-
-
-def test_Assets_repr_with_cycle(config):
-    obj = ConcreteAssetsWithCycle(config=config, cycle=dt.datetime(2024, 7, 2, 12))
+def test_Assets_repr_cycle_based(config):
+    obj = ConcreteAssetsCycleBased(config=config, cycle=dt.datetime(2024, 7, 2, 12))
     expected = "concrete 2024-07-02T12:00 in %s" % obj._driver_config["run_dir"]
     assert repr(obj) == expected
 
 
-def test_Assets_repr_with_cycle_and_leadtime(config):
-    obj = ConcreteAssetsWithCycleAndLeadtime(
+def test_Assets_repr_cycle_and_leadtime_based(config):
+    obj = ConcreteAssetsCycleAndLeadtimeBased(
         config=config, cycle=dt.datetime(2024, 7, 2, 12), leadtime=dt.timedelta(hours=6)
     )
     expected = "concrete 2024-07-02T12:00 06:00:00 in %s" % obj._driver_config["run_dir"]
+    assert repr(obj) == expected
+
+
+def test_Assets_repr_time_invariant(config):
+    obj = ConcreteAssetsTimeInvariant(config=config)
+    expected = "concrete in %s" % obj._driver_config["run_dir"]
     assert repr(obj) == expected
 
 

--- a/src/uwtools/tests/drivers/test_schism.py
+++ b/src/uwtools/tests/drivers/test_schism.py
@@ -37,7 +37,7 @@ def cycle():
 
 @fixture
 def driverobj(config, cycle):
-    return SCHISM(config=config, cycle=cycle, batch=True)
+    return SCHISM(config=config, cycle=cycle)
 
 
 # Tests

--- a/src/uwtools/tests/drivers/test_schism.py
+++ b/src/uwtools/tests/drivers/test_schism.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import yaml
 from pytest import fixture, mark
 
-from uwtools.drivers.driver import Assets
+from uwtools.drivers.driver import AssetsWithCycle
 from uwtools.drivers.schism import SCHISM
 
 # Fixtures
@@ -52,7 +52,7 @@ def driverobj(config, cycle):
     ],
 )
 def test_SCHISM(method):
-    assert getattr(SCHISM, method) is getattr(Assets, method)
+    assert getattr(SCHISM, method) is getattr(AssetsWithCycle, method)
 
 
 def test_SCHISM_namelist_file(driverobj):

--- a/src/uwtools/tests/drivers/test_schism.py
+++ b/src/uwtools/tests/drivers/test_schism.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import yaml
 from pytest import fixture, mark
 
-from uwtools.drivers.driver import AssetsWithCycle
+from uwtools.drivers.driver import AssetsCycleBased
 from uwtools.drivers.schism import SCHISM
 
 # Fixtures
@@ -52,7 +52,7 @@ def driverobj(config, cycle):
     ],
 )
 def test_SCHISM(method):
-    assert getattr(SCHISM, method) is getattr(AssetsWithCycle, method)
+    assert getattr(SCHISM, method) is getattr(AssetsCycleBased, method)
 
 
 def test_SCHISM_namelist_file(driverobj):

--- a/src/uwtools/tests/drivers/test_support.py
+++ b/src/uwtools/tests/drivers/test_support.py
@@ -17,7 +17,6 @@ def test_graph():
     ready()
     assert support.graph().startswith("digraph")
 
-
     class SomeDriver(DriverTimeInvariant):
         def provisioned_rundir(self):
             pass

--- a/src/uwtools/tests/drivers/test_support.py
+++ b/src/uwtools/tests/drivers/test_support.py
@@ -5,7 +5,7 @@ Tests for uwtools.drivers.support module.
 from iotaa import asset, external, task, tasks
 
 from uwtools.drivers import support
-from uwtools.drivers.driver import Driver
+from uwtools.drivers.driver import DriverTimeInvariant
 
 
 def test_graph():
@@ -19,7 +19,7 @@ def test_graph():
 
 
 def test_tasks():
-    class SomeDriver(Driver):
+    class SomeDriver(DriverTimeInvariant):
         def provisioned_run_directory(self):
             pass
 

--- a/src/uwtools/tests/drivers/test_ww3.py
+++ b/src/uwtools/tests/drivers/test_ww3.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import yaml
 from pytest import fixture, mark
 
-from uwtools.drivers.driver import Assets
+from uwtools.drivers.driver import AssetsWithCycle
 from uwtools.drivers.ww3 import WaveWatchIII
 
 # Fixtures
@@ -52,7 +52,7 @@ def driverobj(config, cycle):
     ],
 )
 def test_WaveWatchIII(method):
-    assert getattr(WaveWatchIII, method) is getattr(Assets, method)
+    assert getattr(WaveWatchIII, method) is getattr(AssetsWithCycle, method)
 
 
 def test_WaveWatchIII_namelist_file(driverobj):

--- a/src/uwtools/tests/drivers/test_ww3.py
+++ b/src/uwtools/tests/drivers/test_ww3.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import yaml
 from pytest import fixture, mark
 
-from uwtools.drivers.driver import AssetsWithCycle
+from uwtools.drivers.driver import AssetsCycleBased
 from uwtools.drivers.ww3 import WaveWatchIII
 
 # Fixtures
@@ -52,7 +52,7 @@ def driverobj(config, cycle):
     ],
 )
 def test_WaveWatchIII(method):
-    assert getattr(WaveWatchIII, method) is getattr(AssetsWithCycle, method)
+    assert getattr(WaveWatchIII, method) is getattr(AssetsCycleBased, method)
 
 
 def test_WaveWatchIII_namelist_file(driverobj):

--- a/src/uwtools/tests/drivers/test_ww3.py
+++ b/src/uwtools/tests/drivers/test_ww3.py
@@ -37,7 +37,7 @@ def cycle():
 
 @fixture
 def driverobj(config, cycle):
-    return WaveWatchIII(config=config, cycle=cycle, batch=True)
+    return WaveWatchIII(config=config, cycle=cycle)
 
 
 # Tests

--- a/src/uwtools/tests/utils/test_api.py
+++ b/src/uwtools/tests/utils/test_api.py
@@ -9,6 +9,7 @@ from pytest import fixture, mark, raises
 
 from uwtools.exceptions import UWError
 from uwtools.tests.drivers.test_driver import ConcreteDriverTimeInvariant as TestDriver
+from uwtools.tests.drivers.test_driver import ConcreteDriverWithCycleAndLeadtime as TestDriverWCL
 from uwtools.utils import api
 
 
@@ -115,11 +116,10 @@ def test_str2path_convert():
     assert result == Path(val)
 
 
-@mark.skip("PM FIXME")
 @mark.parametrize("hours", [0, 24, 168])
 def test__execute(execute_kwargs, hours, tmp_path):
     graph_file = tmp_path / "g.dot"
-    with patch.object(sys.modules[__name__], "TestDriver", wraps=TestDriver) as cd:
+    with patch.object(sys.modules[__name__], "TestDriverWCL", wraps=TestDriverWCL) as cd:
         kwargs = {
             **execute_kwargs,
             "driver_class": cd,

--- a/src/uwtools/tests/utils/test_api.py
+++ b/src/uwtools/tests/utils/test_api.py
@@ -8,8 +8,8 @@ from unittest.mock import patch
 from pytest import fixture, mark, raises
 
 from uwtools.exceptions import UWError
+from uwtools.tests.drivers.test_driver import ConcreteDriverCycleAndLeadtimeBased as TestDriverWCL
 from uwtools.tests.drivers.test_driver import ConcreteDriverTimeInvariant as TestDriver
-from uwtools.tests.drivers.test_driver import ConcreteDriverWithCycleAndLeadtime as TestDriverWCL
 from uwtools.utils import api
 
 


### PR DESCRIPTION
**Synopsis**

- Add new property methods, `.config` and `.config_full`, to the `Assets` class (inherited by all subclasses, i.e. `Driver` and all the individual component drivers) to obtain _copies of_ the driver config and the full input config. Copies are provided for informational purposes and cannot be used to modify the driver's actual configuration.
- Now that driver objects can be directly created and manipulated via the `uwtools` API, provide `__repr__` and `__str__` methods.
- DRY out driver constructors and `_taskname()` methods by creating intermediate classes for time-invariant, cycle-based, and cycle-and-leadtime-based drivers. This results in a net reduction in code, and a simplification of all the driver modules.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
