### PR TITLE
Expose driver base classes via API

### DIFF
--- a/docs/sections/user_guide/api/driver.rst
+++ b/docs/sections/user_guide/api/driver.rst
@@ -1,0 +1,6 @@
+``uwtools.api.driver``
+======================
+
+.. automodule:: uwtools.api.driver
+   :inherited-members:
+   :members:

--- a/docs/sections/user_guide/api/index.rst
+++ b/docs/sections/user_guide/api/index.rst
@@ -5,6 +5,7 @@ API
    chgres_cube
    config
    esg_grid
+   driver
    file
    filter_topo
    fv3

--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -2,13 +2,15 @@
 API access to the ``uwtools`` driver base classes.
 """
 
+import importlib
 import sys
-from importlib import import_module
+
+_CLASSNAMES = ["Assets"]
 
 
 def _add_classes():
-    m = import_module("uwtools.drivers.driver")
-    for classname in ["Assets"]:
+    m = importlib.import_module("uwtools.drivers.driver")
+    for classname in _CLASSNAMES:
         setattr(sys.modules[__name__], classname, getattr(m, classname))
         __all__.append(classname)
 

--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -1,0 +1,17 @@
+"""
+API access to the ``uwtools`` driver base classes.
+"""
+
+import sys
+from importlib import import_module
+
+
+def _add_classes():
+    m = import_module("uwtools.drivers.driver")
+    for classname in ["Assets"]:
+        setattr(sys.modules[__name__], classname, getattr(m, classname))
+        __all__.append(classname)
+
+
+__all__: list[str] = []
+_add_classes()

--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -5,7 +5,16 @@ API access to the ``uwtools`` driver base classes.
 import importlib
 import sys
 
-_CLASSNAMES = ["Assets"]
+_CLASSNAMES = [
+    "Assets",
+    "AssetsCycleBased",
+    "AssetsCycleAndLeadtimeBased",
+    "AssetsTimeInvariant",
+    "Driver",
+    "DriverCycleBased",
+    "DriverCycleAndLeadtimeBased",
+    "DriverTimeInvariant",
+]
 
 
 def _add_classes():

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -16,7 +16,7 @@ from uwtools.utils.tasks import file
 
 class WaveWatchIII(Assets):
     """
-    A library driver for ww3.
+    An assets driver for ww3.
     """
 
     def __init__(

--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -1,0 +1,22 @@
+# pylint: disable=missing-function-docstring,protected-access
+
+from inspect import isclass, ismodule
+
+from pytest import mark
+
+from uwtools.api import driver as driver_api
+from uwtools.drivers import driver as driver_lib
+
+
+@mark.parametrize("classname", ["Assets"])
+def test_driver(classname):
+    assert getattr(driver_api, classname) is getattr(driver_lib, classname)
+
+
+def test_no_extras():
+    for x in dir(driver_api):
+        if not x.startswith("_"):
+            obj = getattr(driver_api, x)
+            if not ismodule(obj):
+                assert isclass(obj)
+                assert x in driver_api._CLASSNAMES

--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -14,7 +14,7 @@ def test_driver(classname):
 
 
 def test_public_attributes():
-    # Check that the module is not accidentally exposing unexpected public atttributes. Ignore
+    # Check that the module is not accidentally exposing unexpected public attributes. Ignore
     # private attributes and imported modules and assert that what remains is an intentionally
     # exposed (driver) class.
     for name in dir(driver_api):

--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -13,10 +13,13 @@ def test_driver(classname):
     assert getattr(driver_api, classname) is getattr(driver_lib, classname)
 
 
-def test_no_extras():
-    for x in dir(driver_api):
-        if not x.startswith("_"):
-            obj = getattr(driver_api, x)
-            if not ismodule(obj):
-                assert isclass(obj)
-                assert x in driver_api._CLASSNAMES
+def test_public_attributes():
+    # Check that the module is not accidentally exposing unexpected public atttributes. Ignore
+    # private attributes and imported modules and assert that what remains is an intentionally
+    # exposed (driver) class.
+    for name in dir(driver_api):
+        obj = getattr(driver_api, name)
+        if name.startswith("_") or ismodule(obj):
+            continue
+        assert isclass(obj)
+        assert name in driver_api._CLASSNAMES

--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -8,7 +8,7 @@ from uwtools.api import driver as driver_api
 from uwtools.drivers import driver as driver_lib
 
 
-@mark.parametrize("classname", ["Assets"])
+@mark.parametrize("classname", driver_api._CLASSNAMES)
 def test_driver(classname):
     assert getattr(driver_api, classname) is getattr(driver_lib, classname)
 


### PR DESCRIPTION
**Synopsis**

#518 exposed component-driver classes via the `uwtools` API, but externally-developed coupled drivers will also need to access base driver classes (see #521) to inherit from and extend. This PR provides access.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
