### PR TITLE
Do not wrap YAML lines

### DIFF
--- a/docs/sections/user_guide/cli/tools/rocoto/realize-exec-stdout-verbose.out
+++ b/docs/sections/user_guide/cli/tools/rocoto/realize-exec-stdout-verbose.out
@@ -1,21 +1,21 @@
-[2024-05-23T19:39:16]    DEBUG Command: uw rocoto realize --config-file rocoto.yaml --verbose
-[2024-05-23T19:39:16]    DEBUG Dereferencing, current value:
-[2024-05-23T19:39:16]    DEBUG   workflow:
-[2024-05-23T19:39:16]    DEBUG     attrs:
-[2024-05-23T19:39:16]    DEBUG       realtime: false
-[2024-05-23T19:39:16]    DEBUG       scheduler: slurm
-[2024-05-23T19:39:16]    DEBUG     cycledef:
-[2024-05-23T19:39:16]    DEBUG     - attrs:
-[2024-05-23T19:39:16]    DEBUG         group: howdy
-[2024-05-23T19:39:16]    DEBUG       spec: 202209290000 202209300000 06:00:00
+[2024-07-09T00:31:39]    DEBUG Command: uw rocoto realize --config-file rocoto.yaml --verbose
+[2024-07-09T00:31:39]    DEBUG Dereferencing, current value:
+[2024-07-09T00:31:39]    DEBUG   workflow:
+[2024-07-09T00:31:39]    DEBUG     attrs:
+[2024-07-09T00:31:39]    DEBUG       realtime: false
+[2024-07-09T00:31:39]    DEBUG       scheduler: slurm
+[2024-07-09T00:31:39]    DEBUG     cycledef:
+[2024-07-09T00:31:39]    DEBUG     - attrs:
+[2024-07-09T00:31:39]    DEBUG         group: howdy
+[2024-07-09T00:31:39]    DEBUG       spec: 202209290000 202209300000 06:00:00
 ...
-[2024-05-23T19:39:16]    DEBUG   account: '&ACCOUNT;'
-[2024-05-23T19:39:16]    DEBUG   attrs:
-[2024-05-23T19:39:16]    DEBUG     cycledefs: howdy
-[2024-05-23T19:39:16]    DEBUG   command: echo hello $person
-[2024-05-23T19:39:16]    DEBUG   envars:
-[2024-05-23T19:39:16]    DEBUG     person: siri
-[2024-05-23T19:39:16]    DEBUG   jobname: hello
-[2024-05-23T19:39:16]    DEBUG   nodes: 1:ppn=1
-[2024-05-23T19:39:16]    DEBUG   walltime: 00:01:00
-[2024-05-23T19:39:16]     INFO 0 Rocoto validation errors found
+[2024-07-09T00:31:39]    DEBUG   attrs:
+[2024-07-09T00:31:39]    DEBUG     cycledefs: howdy
+[2024-07-09T00:31:39]    DEBUG   account: '&ACCOUNT;'
+[2024-07-09T00:31:39]    DEBUG   command: echo hello $person
+[2024-07-09T00:31:39]    DEBUG   jobname: hello
+[2024-07-09T00:31:39]    DEBUG   nodes: 1:ppn=1
+[2024-07-09T00:31:39]    DEBUG   walltime: 00:01:00
+[2024-07-09T00:31:39]    DEBUG   envars:
+[2024-07-09T00:31:39]    DEBUG     person: siri
+[2024-07-09T00:31:39]     INFO 0 Rocoto validation errors found

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -43,7 +43,7 @@ class Config(ABC, UserDict):
 
     def __repr__(self) -> str:
         """
-        The string representation of a YAMLConfig object.
+        Returns the string representation of a Config object.
         """
         return self._dict_to_str(self.data)
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -49,8 +49,8 @@ class Config(ABC, UserDict):
 
     # Private methods
 
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
         Returns the string representation of the given dict.

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -5,7 +5,6 @@ import re
 from abc import ABC, abstractmethod
 from collections import UserDict
 from copy import deepcopy
-from io import StringIO
 from pathlib import Path
 from typing import Optional, Union
 
@@ -42,13 +41,11 @@ class Config(ABC, UserDict):
                 % (self.get_depth_threshold(), type(self).__name__, self.depth)
             )
 
-    def __repr__(self) -> str:
-        """
-        Returns the YAML string representation of a Config object.
-        """
-        s = StringIO()
-        yaml.dump(self.data, s)
-        return s.getvalue()
+    # @abstractmethod
+    # def __repr__(self) -> str:
+    #     """
+    #     Returns the string representation of the config.
+    #     """
 
     # Private methods
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -11,7 +11,7 @@ from typing import Optional, Union
 import yaml
 
 from uwtools.config import jinja2
-from uwtools.config.support import INCLUDE_TAG, depth, log_and_error, yaml_dump
+from uwtools.config.support import INCLUDE_TAG, depth, log_and_error, yaml_to_str
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import INDENT, log
 
@@ -171,7 +171,7 @@ class Config(ABC, UserDict):
 
         def logstate(state: str) -> None:
             log.debug("Dereferencing, %s value:", state)
-            for line in yaml_dump(self.data).split("\n"):
+            for line in yaml_to_str(self.data).split("\n"):
                 log.debug("%s%s", INDENT, line)
 
         while True:

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -41,13 +41,22 @@ class Config(ABC, UserDict):
                 % (self.get_depth_threshold(), type(self).__name__, self.depth)
             )
 
-    # @abstractmethod
-    # def __repr__(self) -> str:
-    #     """
-    #     Returns the string representation of the config.
-    #     """
+    def __repr__(self) -> str:
+        """
+        The string representation of a YAMLConfig object.
+        """
+        return self._dict_to_str(self.data)
 
     # Private methods
+
+    @abstractmethod
+    @classmethod
+    def _dict_to_str(cls, cfg: dict) -> str:
+        """
+        Returns the string representation of the given dict.
+
+        :param cfg: The in-memory config object.
+        """
 
     @abstractmethod
     def _load(self, config_file: Optional[Path]) -> dict:

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -11,7 +11,7 @@ from typing import Optional, Union
 import yaml
 
 from uwtools.config import jinja2
-from uwtools.config.support import INCLUDE_TAG, depth, log_and_error
+from uwtools.config.support import INCLUDE_TAG, depth, log_and_error, yaml_dump
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import INDENT, log
 
@@ -55,7 +55,7 @@ class Config(ABC, UserDict):
         """
         Returns the string representation of the given dict.
 
-        :param cfg: The in-memory config object.
+        :param cfg: A dict object.
         """
 
     @abstractmethod
@@ -171,7 +171,7 @@ class Config(ABC, UserDict):
 
         def logstate(state: str) -> None:
             log.debug("Dereferencing, %s value:", state)
-            for line in str(self).split("\n"):
+            for line in yaml_dump(self.data).split("\n"):
                 log.debug("%s%s", INDENT, line)
 
         while True:

--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -19,7 +19,7 @@ class FieldTableConfig(YAMLConfig):
         """
         Returns the field-table representation of the given dict.
 
-        :param cfg: The in-memory config object.
+        :param cfg: A dict object.
         """
         lines = []
         for field, settings in cfg.items():

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -23,7 +23,35 @@ class INIConfig(Config):
         super().__init__(config)
         self.parse_include()
 
+    def __repr__(self) -> str:
+        """
+        Returns the string representation of the config.
+        """
+        return self._dict_to_str(self.data)
+
     # Private methods
+
+    @classmethod
+    def _dict_to_str(cls, cfg: dict) -> str:
+        """
+        Returns the YAML representation of the given dict.
+
+        :param cfg: The in-memory config object.
+        """
+
+        # Configparser adds a newline after each section, presumably to create nice-looking output
+        # when an INI contains multiple sections. Unfortunately, it also adds a newline after the
+        # _final_ section, resulting in an anomalous trailing newline. To avoid this, write first to
+        # memory, then strip the trailing newline.
+
+        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.ini)
+        parser = configparser.ConfigParser()
+        sio = StringIO()
+        parser.read_dict(cfg)
+        parser.write(sio)
+        s = sio.getvalue().strip()
+        sio.close()
+        return s
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """
@@ -46,31 +74,18 @@ class INIConfig(Config):
 
         :param path: Path to dump config to.
         """
-        config_check_depths_dump(config_obj=self, target_format=FORMAT.ini)
         self.dump_dict(self.data, path)
 
-    @staticmethod
-    def dump_dict(cfg: dict, path: Optional[Path] = None) -> None:
+    @classmethod
+    def dump_dict(cls, cfg: dict, path: Optional[Path] = None) -> None:
         """
         Dumps a provided config dictionary in INI format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to.
         """
-
-        # Configparser adds a newline after each section, presumably to create nice-looking output
-        # when an INI contains multiple sections. Unfortunately, it also adds a newline after the
-        # _final_ section, resulting in an anomalous trailing newline. To avoid this, write first to
-        # memory, then strip the trailing newline.
-
-        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.ini)
-        parser = configparser.ConfigParser()
-        s = StringIO()
-        parser.read_dict(cfg)
-        parser.write(s)
         with writable(path) as f:
-            print(s.getvalue().strip(), file=f)
-        s.close()
+            print(cls._dict_to_str(cfg), file=f)
 
     @staticmethod
     def get_depth_threshold() -> Optional[int]:

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -30,7 +30,7 @@ class INIConfig(Config):
         """
         Returns the INI representation of the given dict.
 
-        :param cfg: The in-memory config object.
+        :param cfg: A dict object.
         """
 
         # Configparser adds a newline after each section, presumably to create nice-looking output

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -23,18 +23,12 @@ class INIConfig(Config):
         super().__init__(config)
         self.parse_include()
 
-    def __repr__(self) -> str:
-        """
-        Returns the string representation of the config.
-        """
-        return self._dict_to_str(self.data)
-
     # Private methods
 
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
-        Returns the YAML representation of the given dict.
+        Returns the INI representation of the given dict.
 
         :param cfg: The in-memory config object.
         """

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from io import StringIO
 from pathlib import Path
 from typing import Optional, Union
 
@@ -27,6 +28,27 @@ class NMLConfig(Config):
 
     # Private methods
 
+    @classmethod
+    def _dict_to_str(cls, cfg: dict) -> str:
+        """
+        Returns the field-table representation of the given dict.
+
+        :param cfg: The in-memory config object.
+        """
+
+        def to_od(d):
+            return OrderedDict(
+                {key: to_od(val) if isinstance(val, dict) else val for key, val in d.items()}
+            )
+
+        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.nml)
+        nml: Namelist = Namelist(to_od(cfg)) if not isinstance(cfg, Namelist) else cfg
+        sio = StringIO()
+        nml.write(sio, sort=False)
+        s = sio.getvalue()
+        sio.close()
+        return s.strip()
+
     def _load(self, config_file: Optional[Path]) -> dict:
         """
         Reads and parses a Fortran namelist file.
@@ -49,24 +71,16 @@ class NMLConfig(Config):
         """
         self.dump_dict(cfg=self.data, path=path)
 
-    @staticmethod
-    def dump_dict(cfg: Union[dict, Namelist], path: Optional[Path] = None) -> None:
+    @classmethod
+    def dump_dict(cls, cfg: Union[dict, Namelist], path: Optional[Path] = None) -> None:
         """
         Dumps a provided config dictionary in Fortran namelist format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to.
         """
-
-        def to_od(d):
-            return OrderedDict(
-                {key: to_od(val) if isinstance(val, dict) else val for key, val in d.items()}
-            )
-
-        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.nml)
-        nml: Namelist = Namelist(to_od(cfg)) if not isinstance(cfg, Namelist) else cfg
         with writable(path) as f:
-            nml.write(f, sort=False)
+            print(cls._dict_to_str(cfg), file=f)
 
     @staticmethod
     def get_depth_threshold() -> Optional[int]:

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -33,7 +33,7 @@ class NMLConfig(Config):
         """
         Returns the field-table representation of the given dict.
 
-        :param cfg: The in-memory config object.
+        :param cfg: A dict object.
         """
 
         def to_od(d):

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -31,7 +31,7 @@ class SHConfig(Config):
         """
         Returns the field-table representation of the given dict.
 
-        :param cfg: The in-memory config object.
+        :param cfg: A dict object.
         """
         config_check_depths_dump(config_obj=cfg, target_format=FORMAT.sh)
         lines = []

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -1,6 +1,5 @@
 import re
 import shlex
-from io import StringIO
 from pathlib import Path
 from typing import Optional, Union
 
@@ -26,6 +25,19 @@ class SHConfig(Config):
         self.parse_include()
 
     # Private methods
+
+    @classmethod
+    def _dict_to_str(cls, cfg: dict) -> str:
+        """
+        Returns the field-table representation of the given dict.
+
+        :param cfg: The in-memory config object.
+        """
+        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.sh)
+        lines = []
+        for key, value in cfg.items():
+            lines.append("%s=%s" % (key, shlex.quote(str(value))))
+        return "\n".join(lines)
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """
@@ -58,25 +70,16 @@ class SHConfig(Config):
         config_check_depths_dump(config_obj=self, target_format=FORMAT.sh)
         self.dump_dict(self.data, path)
 
-    @staticmethod
-    def dump_dict(cfg: dict, path: Optional[Path] = None) -> None:
+    @classmethod
+    def dump_dict(cls, cfg: dict, path: Optional[Path] = None) -> None:
         """
         Dumps a provided config dictionary in bash format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to.
         """
-
-        # Write first to a StringIO object to avoid creating a partial file in case of problems
-        # rendering or quoting config values.
-
-        config_check_depths_dump(config_obj=cfg, target_format=FORMAT.sh)
-        s = StringIO()
-        for key, value in cfg.items():
-            print("%s=%s" % (key, shlex.quote(str(value))), file=s)
         with writable(path) as f:
-            print(s.getvalue().strip(), file=f)
-        s.close()
+            print(cls._dict_to_str(cfg), file=f)
 
     @staticmethod
     def get_depth_threshold() -> Optional[int]:

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -45,12 +45,6 @@ class YAMLConfig(Config):
     Concrete class to handle YAML config files.
     """
 
-    def __repr__(self) -> str:
-        """
-        The string representation of a YAMLConfig object.
-        """
-        return self._dict_to_str(self.data)
-
     # Private methods
 
     @classmethod

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -49,10 +49,19 @@ class YAMLConfig(Config):
         """
         The string representation of a YAMLConfig object.
         """
-        self._add_yaml_representers()
-        return yaml.dump(self.data, default_flow_style=False, width=math.inf).strip()
+        return self._dict_to_str(self.data)
 
     # Private methods
+
+    @classmethod
+    def _dict_to_str(cls, cfg: dict) -> str:
+        """
+        Returns the YAML representation of the given dict.
+
+        :param cfg: The in-memory config object.
+        """
+        cls._add_yaml_representers()
+        return yaml.dump(cfg, default_flow_style=False, sort_keys=False, width=math.inf).strip()
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """
@@ -125,9 +134,8 @@ class YAMLConfig(Config):
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to.
         """
-        cls._add_yaml_representers()
         with writable(path) as f:
-            yaml.dump(cfg, f, sort_keys=False, width=math.inf)
+            print(cls._dict_to_str(cfg), file=f)
 
     @staticmethod
     def get_depth_threshold() -> Optional[int]:

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -13,7 +13,7 @@ from uwtools.config.support import (
     UWYAMLRemove,
     from_od,
     log_and_error,
-    yaml_dump,
+    yaml_to_str,
 )
 from uwtools.exceptions import UWConfigError
 from uwtools.strings import FORMAT
@@ -61,7 +61,7 @@ class YAMLConfig(Config):
         :param cfg: The in-memory config object.
         """
         cls._add_yaml_representers()
-        return yaml_dump(cfg)
+        return yaml_to_str(cfg)
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -1,3 +1,4 @@
+import math
 from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace as ns
@@ -49,7 +50,7 @@ class YAMLConfig(Config):
         The string representation of a YAMLConfig object.
         """
         self._add_yaml_representers()
-        return yaml.dump(self.data, default_flow_style=False).strip()
+        return yaml.dump(self.data, default_flow_style=False, width=math.inf).strip()
 
     # Private methods
 
@@ -126,7 +127,7 @@ class YAMLConfig(Config):
         """
         cls._add_yaml_representers()
         with writable(path) as f:
-            yaml.dump(cfg, f, sort_keys=False)
+            yaml.dump(cfg, f, sort_keys=False, width=math.inf)
 
     @staticmethod
     def get_depth_threshold() -> Optional[int]:

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -1,4 +1,3 @@
-import math
 from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace as ns
@@ -8,7 +7,14 @@ import yaml
 from f90nml import Namelist  # type: ignore
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import INCLUDE_TAG, UWYAMLConvert, UWYAMLRemove, from_od, log_and_error
+from uwtools.config.support import (
+    INCLUDE_TAG,
+    UWYAMLConvert,
+    UWYAMLRemove,
+    from_od,
+    log_and_error,
+    yaml_dump,
+)
 from uwtools.exceptions import UWConfigError
 from uwtools.strings import FORMAT
 from uwtools.utils.file import readable, writable
@@ -55,7 +61,7 @@ class YAMLConfig(Config):
         :param cfg: The in-memory config object.
         """
         cls._add_yaml_representers()
-        return yaml.dump(cfg, default_flow_style=False, sort_keys=False, width=math.inf).strip()
+        return yaml_dump(cfg)
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -67,7 +67,7 @@ def log_and_error(msg: str) -> Exception:
     return UWConfigError(msg)
 
 
-def yaml_dump(cfg: dict) -> str:
+def yaml_to_str(cfg: dict) -> str:
     """
     Returns a uwtools-conventional YAML representation of the given dict.
 

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections import OrderedDict
 from importlib import import_module
 from typing import Type, Union
@@ -64,6 +65,15 @@ def log_and_error(msg: str) -> Exception:
     """
     log.error(msg)
     return UWConfigError(msg)
+
+
+def yaml_dump(cfg: dict) -> str:
+    """
+    Returns a uwtools-conventional YAML representation of the given dict.
+
+    :param cfg: A dict object.
+    """
+    return yaml.dump(cfg, default_flow_style=False, sort_keys=False, width=math.inf).strip()
 
 
 class UWYAMLTag:

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -39,6 +39,10 @@ class ConcreteConfig(Config):
     Config subclass for testing purposes.
     """
 
+    @classmethod
+    def _dict_to_str(cls, cfg):
+        pass
+
     def _load(self, config_file):
         with readable(config_file) as f:
             return yaml.safe_load(f.read())
@@ -60,11 +64,6 @@ class ConcreteConfig(Config):
 
 
 # Tests
-
-
-def test___repr__(capsys, config):
-    print(config)
-    assert yaml.safe_load(capsys.readouterr().out)["foo"] == 88
 
 
 def test__load_paths(config, tmp_path):

--- a/src/uwtools/tests/config/formats/test_fieldtable.py
+++ b/src/uwtools/tests/config/formats/test_fieldtable.py
@@ -3,7 +3,7 @@
 Tests for uwtools.config.formats.fieldtable module.
 """
 
-from pytest import fixture
+from pytest import fixture, mark
 
 from uwtools.config.formats.fieldtable import FieldTableConfig
 from uwtools.tests.support import fixture_path
@@ -36,8 +36,9 @@ def test_fieldtable_instantiation_depth():
     assert FieldTableConfig(config={1: {2: {3: 4}}})
 
 
-def test_fieldtable_repr(config, ref):
-    assert repr(FieldTableConfig(config=config)).strip() == ref
+@mark.parametrize("func", [repr, str])
+def test_fieldtable_repr_str(config, func, ref):
+    assert func(FieldTableConfig(config=config)).strip() == ref
 
 
 def test_fieldtable_simple(config, ref, tmp_path):
@@ -45,7 +46,3 @@ def test_fieldtable_simple(config, ref, tmp_path):
     FieldTableConfig(config=config).dump(outfile)
     with open(outfile, "r", encoding="utf-8") as out:
         assert out.read().strip() == ref
-
-
-def test_fieldtable_str(config, ref):
-    assert str(FieldTableConfig(config=config)).strip() == ref

--- a/src/uwtools/tests/config/formats/test_fieldtable.py
+++ b/src/uwtools/tests/config/formats/test_fieldtable.py
@@ -1,7 +1,9 @@
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring,redefined-outer-name
 """
 Tests for uwtools.config.formats.fieldtable module.
 """
+
+from pytest import fixture
 
 from uwtools.config.formats.fieldtable import FieldTableConfig
 from uwtools.tests.support import fixture_path
@@ -10,30 +12,40 @@ from uwtools.utils.file import FORMAT
 # Tests
 
 
-def test_get_format():
+@fixture(scope="module")
+def config():
+    return fixture_path("FV3_GFS_v16.yaml")
+
+
+@fixture(scope="module")
+def ref():
+    with open(fixture_path("field_table.FV3_GFS_v16"), "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def test_fieldtable_get_format():
     assert FieldTableConfig.get_format() == FORMAT.fieldtable
 
 
-def test_get_depth_threshold():
+def test_fieldtable_get_depth_threshold():
     assert FieldTableConfig.get_depth_threshold() is None
 
 
-def test_instantiation_depth():
+def test_fieldtable_instantiation_depth():
     # Any depth is fine.
     assert FieldTableConfig(config={1: {2: {3: 4}}})
 
 
-def test_simple(tmp_path):
-    """
-    Test reading a YAML config object and generating a field table file.
-    """
-    cfgfile = fixture_path("FV3_GFS_v16.yaml")
+def test_fieldtable_repr(config, ref):
+    assert repr(FieldTableConfig(config=config)).strip() == ref
+
+
+def test_fieldtable_simple(config, ref, tmp_path):
     outfile = tmp_path / "field_table_from_yaml.FV3_GFS"
-    reference = fixture_path("field_table.FV3_GFS_v16")
-    FieldTableConfig(cfgfile).dump(outfile)
-    with open(reference, "r", encoding="utf-8") as f1:
-        reflines = [line.strip().replace("'", "") for line in f1]
-    with open(outfile, "r", encoding="utf-8") as f2:
-        outlines = [line.strip().replace("'", "") for line in f2]
-    for line1, line2 in zip(outlines, reflines):
-        assert line1 == line2
+    FieldTableConfig(config=config).dump(outfile)
+    with open(outfile, "r", encoding="utf-8") as out:
+        assert out.read().strip() == ref
+
+
+def test_fieldtable_str(config, ref):
+    assert str(FieldTableConfig(config=config)).strip() == ref

--- a/src/uwtools/tests/config/formats/test_ini.py
+++ b/src/uwtools/tests/config/formats/test_ini.py
@@ -5,7 +5,7 @@ Tests for uwtools.config.formats.ini module.
 
 import filecmp
 
-from pytest import raises
+from pytest import mark, raises
 
 from uwtools.config.formats.ini import INIConfig
 from uwtools.exceptions import UWConfigError
@@ -15,21 +15,21 @@ from uwtools.utils.file import FORMAT
 # Tests
 
 
-def test_get_format():
+def test_ini_get_format():
     assert INIConfig.get_format() == FORMAT.ini
 
 
-def test_get_depth_threshold():
+def test_ini_get_depth_threshold():
     assert INIConfig.get_depth_threshold() == 2
 
 
-def test_instantiation_depth():
+def test_ini_instantiation_depth():
     with raises(UWConfigError) as e:
         INIConfig(config={1: {2: {3: 4}}})
     assert str(e.value) == "Cannot instantiate depth-2 INIConfig with depth-3 config"
 
 
-def test_parse_include():
+def test_ini_parse_include():
     """
     Test that an INI file handles include tags properly.
     """
@@ -40,7 +40,14 @@ def test_parse_include():
     assert len(cfgobj["config"]) == 5
 
 
-def test_simple(salad_base, tmp_path):
+@mark.parametrize("func", [repr, str])
+def test_ini_repr_str(func):
+    config = fixture_path("simple.ini")
+    with open(config, "r", encoding="utf-8") as f:
+        assert func(INIConfig(config)) == f.read().strip()
+
+
+def test_ini_simple(salad_base, tmp_path):
     """
     Test that INI config load and dump work with a basic INI file.
 

--- a/src/uwtools/tests/config/formats/test_nml.py
+++ b/src/uwtools/tests/config/formats/test_nml.py
@@ -6,7 +6,7 @@ Tests for uwtools.config.formats.nml module.
 import filecmp
 
 import f90nml  # type: ignore
-from pytest import fixture, raises
+from pytest import fixture, mark, raises
 
 from uwtools.config.formats.nml import NMLConfig
 from uwtools.exceptions import UWConfigError
@@ -24,35 +24,35 @@ def data():
 # Tests
 
 
-def test_dump_dict_dict(data, tmp_path):
+def test_nml_dump_dict_dict(data, tmp_path):
     path = tmp_path / "a.nml"
     NMLConfig.dump_dict(cfg=data, path=path)
     nml = f90nml.read(path)
     assert nml == data
 
 
-def test_dump_dict_Namelist(data, tmp_path):
+def test_nml_dump_dict_Namelist(data, tmp_path):
     path = tmp_path / "a.nml"
     NMLConfig.dump_dict(cfg=f90nml.Namelist(data), path=path)
     nml = f90nml.read(path)
     assert nml == data
 
 
-def test_get_format():
+def test_nml_get_format():
     assert NMLConfig.get_format() == FORMAT.nml
 
 
-def test_get_depth_threshold():
+def test_nml_get_depth_threshold():
     assert NMLConfig.get_depth_threshold() == 2
 
 
-def test_instantiation_depth():
+def test_nml_instantiation_depth():
     with raises(UWConfigError) as e:
         NMLConfig(config={1: {2: {3: 4}}})
     assert str(e.value) == "Cannot instantiate depth-2 NMLConfig with depth-3 config"
 
 
-def test_parse_include():
+def test_nml_parse_include():
     """
     Test that non-YAML handles include tags properly.
     """
@@ -63,7 +63,7 @@ def test_parse_include():
     assert len(cfgobj["config"]) == 5
 
 
-def test_parse_include_mult_sect():
+def test_nml_parse_include_mult_sect():
     """
     Test that non-YAML handles include tags with files that have multiple sections in separate file.
     """
@@ -77,7 +77,14 @@ def test_parse_include_mult_sect():
     assert len(cfgobj["setting"]) == 3
 
 
-def test_simple(salad_base, tmp_path):
+@mark.parametrize("func", [repr, str])
+def test_ini_repr_str(func):
+    config = fixture_path("simple.nml")
+    with open(config, "r", encoding="utf-8") as f:
+        assert func(NMLConfig(config)) == f.read().strip()
+
+
+def test_nml_simple(salad_base, tmp_path):
     """
     Test that namelist load, update, and dump work with a basic namelist file.
     """

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -3,9 +3,10 @@
 Tests for uwtools.config.formats.sh module.
 """
 
+from textwrap import dedent
 from typing import Any
 
-from pytest import raises
+from pytest import mark, raises
 
 from uwtools.config.formats.sh import SHConfig
 from uwtools.exceptions import UWConfigError
@@ -15,21 +16,21 @@ from uwtools.utils.file import FORMAT
 # Tests
 
 
-def test_get_format():
+def test_sh_get_format():
     assert SHConfig.get_format() == FORMAT.sh
 
 
-def test_get_depth_threshold():
+def test_sh_get_depth_threshold():
     assert SHConfig.get_depth_threshold() == 1
 
 
-def test_instantiation_depth():
+def test_sh_instantiation_depth():
     with raises(UWConfigError) as e:
         SHConfig(config={1: {2: {3: 4}}})
     assert str(e.value) == "Cannot instantiate depth-1 SHConfig with depth-3 config"
 
 
-def test_parse_include():
+def test_sh_parse_include():
     """
     Test that an sh file with no sections handles include tags properly.
     """
@@ -40,7 +41,20 @@ def test_parse_include():
     assert len(cfgobj) == 5
 
 
-def test_sh(salad_base):
+@mark.parametrize("func", [repr, str])
+def test_sh_repr_str(func):
+    config = fixture_path("simple.sh")
+    expected = """
+    base=kale
+    fruit=banana
+    vegetable=tomato
+    how_many=12
+    dressing=balsamic
+    """
+    assert func(SHConfig(config)) == dedent(expected).strip()
+
+
+def test_sh_sh(salad_base):
     """
     Test that sh config load and dump work with a basic sh file.
     """

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -54,7 +54,7 @@ def test_sh_repr_str(func):
     assert func(SHConfig(config)) == dedent(expected).strip()
 
 
-def test_sh_sh(salad_base):
+def test_sh(salad_base):
     """
     Test that sh config load and dump work with a basic sh file.
     """

--- a/src/uwtools/tests/config/formats/test_yaml.py
+++ b/src/uwtools/tests/config/formats/test_yaml.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 import f90nml  # type: ignore
 import yaml
-from pytest import raises
+from pytest import mark, raises
 
 from uwtools import exceptions
 from uwtools.config import support
@@ -27,20 +27,20 @@ from uwtools.utils.file import FORMAT, _stdinproxy
 # Tests
 
 
-def test_get_format():
+def test_yaml_get_format():
     assert YAMLConfig.get_format() == FORMAT.yaml
 
 
-def test_get_depth_threshold():
+def test_yaml_get_depth_threshold():
     assert YAMLConfig.get_depth_threshold() is None
 
 
-def test_instantiation_depth():
+def test_yaml_instantiation_depth():
     # Any depth is fine.
     assert YAMLConfig(config={1: {2: {3: 4}}})
 
 
-def test_composite_types():
+def test_yaml_composite_types():
     """
     Test that YAML load and dump work with a YAML file that has multiple data structures and levels.
     """
@@ -58,7 +58,7 @@ def test_composite_types():
     assert models[0]["config"]["vertical_resolution"] == 64
 
 
-def test_include_files():
+def test_yaml_include_files():
     """
     Test that including files via the include constructor works as expected.
     """
@@ -82,7 +82,7 @@ def test_include_files():
     assert cfgobj["reverse_files"]["vegetable"] == "eggplant"
 
 
-def test_long_line(capsys):
+def test_yaml_long_line(capsys):
     xs = " ".join("x" * 999)
     expected = f"xs: {xs}"
     cfgobj = YAMLConfig({"xs": xs})
@@ -92,7 +92,7 @@ def test_long_line(capsys):
     assert capsys.readouterr().out.strip() == expected
 
 
-def test_simple(tmp_path):
+def test_yaml_simple(tmp_path):
     """
     Test that YAML load, update, and dump work with a basic YAML file.
     """
@@ -117,7 +117,7 @@ def test_simple(tmp_path):
     assert cfgobj == expected
 
 
-def test_constructor_error_no_quotes(tmp_path):
+def test_yaml_constructor_error_no_quotes(tmp_path):
     # Test that Jinja2 template without quotes raises UWConfigError.
     tmpfile = tmp_path / "test.yaml"
     with tmpfile.open("w", encoding="utf-8") as f:
@@ -131,7 +131,7 @@ def test_constructor_error_no_quotes(tmp_path):
     assert "value is enclosed in quotes" in str(e.value)
 
 
-def test_constructor_error_not_dict_from_file(tmp_path):
+def test_yaml_constructor_error_not_dict_from_file(tmp_path):
     # Test that a useful exception is raised if the YAML file input is a non-dict value.
     tmpfile = tmp_path / "test.yaml"
     with tmpfile.open("w", encoding="utf-8") as f:
@@ -141,7 +141,7 @@ def test_constructor_error_not_dict_from_file(tmp_path):
     assert f"Parsed a str value from {tmpfile}, expected a dict" in str(e.value)
 
 
-def test_constructor_error_not_dict_from_stdin():
+def test_yaml_constructor_error_not_dict_from_stdin():
     # Test that a useful exception is raised if the YAML stdin input is a non-dict value.
     with patch.object(sys, "stdin", new=StringIO("a string")):
         with raises(exceptions.UWConfigError) as e:
@@ -149,7 +149,7 @@ def test_constructor_error_not_dict_from_stdin():
     assert "Parsed a str value from stdin, expected a dict" in str(e.value)
 
 
-def test_constructor_error_unregistered_constructor(tmp_path):
+def test_yaml_constructor_error_unregistered_constructor(tmp_path):
     # Test that unregistered constructor raises UWConfigError.
 
     tmpfile = tmp_path / "test.yaml"
@@ -161,7 +161,15 @@ def test_constructor_error_unregistered_constructor(tmp_path):
     assert "Define the constructor before proceeding" in str(e.value)
 
 
-def test_stdin_plus_relpath_failure(caplog):
+@mark.parametrize("func", [repr, str])
+def test_yaml_repr_str(func):
+    config = fixture_path("simple.yaml")
+    with open(config, "r", encoding="utf-8") as f:
+        for actual, expected in zip(func(YAMLConfig(config)).split("\n"), f.readlines()):
+            assert actual.strip() == expected.strip()
+
+
+def test_yaml_stdin_plus_relpath_failure(caplog):
     # Instantiate a YAMLConfig with no input file, triggering a read from stdin. Patch stdin to
     # provide YAML with an include directive specifying a relative path. Since a relative path
     # is meaningless relative to stdin, assert that an appropriate error is logged and exception
@@ -177,7 +185,7 @@ def test_stdin_plus_relpath_failure(caplog):
     assert logged(caplog, msg)
 
 
-def test_unexpected_error(tmp_path):
+def test_yaml_unexpected_error(tmp_path):
     cfgfile = tmp_path / "cfg.yaml"
     with open(cfgfile, "w", encoding="utf-8") as f:
         print("{n: 88}", file=f)
@@ -189,7 +197,7 @@ def test_unexpected_error(tmp_path):
         assert msg in str(e.value)
 
 
-def test__add_yaml_representers():
+def test_yaml__add_yaml_representers():
     YAMLConfig._add_yaml_representers()
     representers = yaml.Dumper.yaml_representers
     assert support.UWYAMLConvert in representers
@@ -197,14 +205,14 @@ def test__add_yaml_representers():
     assert f90nml.Namelist in representers
 
 
-def test__represent_namelist():
+def test_yaml__represent_namelist():
     YAMLConfig._add_yaml_representers()
     namelist = f90nml.reads("&namelist\n key = value\n/\n")
     expected = "{namelist: {key: value}}"
     assert yaml.dump(namelist, default_flow_style=True).strip() == expected
 
 
-def test__represent_ordereddict():
+def test_yaml__represent_ordereddict():
     YAMLConfig._add_yaml_representers()
     ordereddict_values = OrderedDict([("example", OrderedDict([("key", "value")]))])
     expected = "{example: {key: value}}"

--- a/src/uwtools/tests/config/formats/test_yaml.py
+++ b/src/uwtools/tests/config/formats/test_yaml.py
@@ -82,16 +82,6 @@ def test_yaml_include_files():
     assert cfgobj["reverse_files"]["vegetable"] == "eggplant"
 
 
-def test_yaml_long_line(capsys):
-    xs = " ".join("x" * 999)
-    expected = f"xs: {xs}"
-    cfgobj = YAMLConfig({"xs": xs})
-    assert repr(cfgobj) == expected
-    assert str(cfgobj) == expected
-    cfgobj.dump()
-    assert capsys.readouterr().out.strip() == expected
-
-
 def test_yaml_simple(tmp_path):
     """
     Test that YAML load, update, and dump work with a basic YAML file.

--- a/src/uwtools/tests/config/formats/test_yaml.py
+++ b/src/uwtools/tests/config/formats/test_yaml.py
@@ -82,6 +82,15 @@ def test_include_files():
     assert cfgobj["reverse_files"]["vegetable"] == "eggplant"
 
 
+def test_long_line(capsys):
+    xs = " ".join("x" * 999)
+    expected = f"xs: {xs}"
+    cfgobj = YAMLConfig({"xs": xs})
+    assert str(cfgobj) == expected
+    cfgobj.dump()
+    assert capsys.readouterr().out.strip() == expected
+
+
 def test_simple(tmp_path):
     """
     Test that YAML load, update, and dump work with a basic YAML file.

--- a/src/uwtools/tests/config/formats/test_yaml.py
+++ b/src/uwtools/tests/config/formats/test_yaml.py
@@ -86,6 +86,7 @@ def test_long_line(capsys):
     xs = " ".join("x" * 999)
     expected = f"xs: {xs}"
     cfgobj = YAMLConfig({"xs": xs})
+    assert repr(cfgobj) == expected
     assert str(cfgobj) == expected
     cfgobj.dump()
     assert capsys.readouterr().out.strip() == expected

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -60,6 +60,16 @@ def test_log_and_error(caplog):
     assert logged(caplog, msg)
 
 
+def test_yaml_to_str(capsys):
+    xs = " ".join("x" * 999)
+    expected = f"xs: {xs}"
+    cfgobj = YAMLConfig({"xs": xs})
+    assert repr(cfgobj) == expected
+    assert str(cfgobj) == expected
+    cfgobj.dump()
+    assert capsys.readouterr().out.strip() == expected
+
+
 class Test_UWYAMLConvert:
     """
     Tests for class uwtools.config.support.UWYAMLConvert.


### PR DESCRIPTION
**Synopsis**

1. Set the width of YAML output lines to infinity to avoid them wrapping. See example below.
2. Factor `yaml.dump()` calls out to a support function for consistency across call sites.
3. Improve `__repr__` dunder methods on `Config` subclasses.
4. Add format components to `Config`-subclass test names (e.g. `test_something()` -> `test_yaml_something()` for easier targeting with `pytest -k`

Previously, given `config.yaml`
```
foo: bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar
```
we would get
```
$ uw config realize --input-file config.yaml --output-format yaml
foo: bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar
  bar
```
The new behavior is
```
$ uw config realize --input-file config.yaml --output-format yaml
foo: bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar
```

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

Technically this is a breaking change because it changes (and improves) the output of `repr()` and `str()` on `Config` objects, though it's unlikely anyone was relying on these.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
