### PR TITLE
UW-631 Provide mechanism to schema-check external drivers

### DIFF
--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -14,7 +14,7 @@ from uwtools.config.formats.yaml import Config as _Config
 from uwtools.config.formats.yaml import YAMLConfig as _YAMLConfig
 from uwtools.config.tools import compare_configs as _compare
 from uwtools.config.tools import realize_config as _realize
-from uwtools.config.validator import validate_yaml as _validate_yaml
+from uwtools.config.validator import validate_external as _validate_external
 from uwtools.utils.api import ensure_data_source as _ensure_data_source
 from uwtools.utils.api import str2path as _str2path
 from uwtools.utils.file import FORMAT as _FORMAT
@@ -177,7 +177,7 @@ def validate(
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if the YAML file conforms to the schema, ``False`` otherwise
     """
-    return _validate_yaml(
+    return _validate_external(
         schema_file=_str2path(schema_file), config=_ensure_data_source(_str2path(config), stdin_ok)
     )
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -60,11 +60,11 @@ def validate_internal(
     log.info("Validating config against internal schema %s", schema_name)
     schema_file = get_schema_file(schema_name)
     log.debug("Using schema file: %s", schema_file)
-    if not validate_yaml(config=config, schema_file=schema_file):
+    if not validate_external(config=config, schema_file=schema_file):
         raise UWConfigError("YAML validation errors")
 
 
-def validate_yaml(
+def validate_external(
     schema_file: Path, config: Union[dict, YAMLConfig, Optional[Path]] = None
 ) -> bool:
     """

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -515,16 +515,6 @@ class DriverCycleLeadtimeBased(Driver):
         batch: bool = False,
         schema_file: Optional[Path] = None,
     ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param leadtime: The leadtime.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        :param batch: Run component via the batch system?
-        """
         super().__init__(
             cycle=cycle,
             leadtime=leadtime,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -489,15 +489,6 @@ class DriverCycleBased(Driver):
         batch: bool = False,
         schema_file: Optional[Path] = None,
     ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        :param batch: Run component via the batch system?
-        """
         super().__init__(
             cycle=cycle,
             config=config,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -272,13 +272,6 @@ class AssetsTimeInvariant(Assets):
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
     ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
         super().__init__(
             config=config,
             dry_run=dry_run,
@@ -541,14 +534,6 @@ class DriverTimeInvariant(Driver):
         batch: bool = False,
         schema_file: Optional[Path] = None,
     ):
-        """
-        The driver.
-
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        :param batch: Run component via the batch system?
-        """
         super().__init__(
             config=config,
             dry_run=dry_run,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -213,7 +213,7 @@ class Assets(ABC):
         """
         schema_name = self._driver_name.replace("_", "-")
         if schema_file:
-            validate_external(...)
+            validate_external(schema_file=schema_file, config=self._config)
         else:
             validate_internal(schema_name=schema_name, config=self._config)
 
@@ -460,7 +460,7 @@ class Driver(Assets):
         Perform all necessary schema validation.
         """
         if schema_file:
-            validate_external(...)
+            validate_external(schema_file=schema_file, config=self._config)
         else:
             for schema_name in (self._driver_name.replace("_", "-"), "platform"):
                 validate_internal(schema_name=schema_name, config=self._config)

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -47,6 +47,7 @@ class Assets(ABC):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param schema_file: Path to schema file to use for validation.
         """
         self._config = YAMLConfig(config=config)
         self._config.dereference(
@@ -229,6 +230,7 @@ class AssetsCycleBased(Assets):
         config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
+        schema_file: Optional[Path] = None,
     ):
         """
         The driver.
@@ -237,8 +239,15 @@ class AssetsCycleBased(Assets):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param schema_file: Path to schema file to use for validation.
         """
-        super().__init__(cycle=cycle, config=config, dry_run=dry_run, key_path=key_path)
+        super().__init__(
+            cycle=cycle,
+            config=config,
+            dry_run=dry_run,
+            key_path=key_path,
+            schema_file=schema_file,
+        )
         self._cycle = cycle
 
 
@@ -254,6 +263,7 @@ class AssetsCycleAndLeadtimeBased(Assets):
         config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
+        schema_file: Optional[Path] = None,
     ):
         """
         The driver.
@@ -263,9 +273,15 @@ class AssetsCycleAndLeadtimeBased(Assets):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
-            cycle=cycle, leadtime=leadtime, config=config, dry_run=dry_run, key_path=key_path
+            cycle=cycle,
+            leadtime=leadtime,
+            config=config,
+            dry_run=dry_run,
+            key_path=key_path,
+            schema_file=schema_file,
         )
         self._cycle = cycle
         self._leadtime = leadtime
@@ -281,6 +297,7 @@ class AssetsTimeInvariant(Assets):
         config: Optional[Union[dict, Path]] = None,
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
+        schema_file: Optional[Path] = None,
     ):
         """
         The driver.
@@ -288,8 +305,14 @@ class AssetsTimeInvariant(Assets):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
+        :param schema_file: Path to schema file to use for validation.
         """
-        super().__init__(config=config, dry_run=dry_run, key_path=key_path)
+        super().__init__(
+            config=config,
+            dry_run=dry_run,
+            key_path=key_path,
+            schema_file=schema_file,
+        )
 
 
 class Driver(Assets):
@@ -305,6 +328,7 @@ class Driver(Assets):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,
+        schema_file: Optional[Path] = None,
     ):
         """
         The driver.
@@ -315,9 +339,15 @@ class Driver(Assets):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
+        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
-            cycle=cycle, leadtime=leadtime, config=config, dry_run=dry_run, key_path=key_path
+            cycle=cycle,
+            leadtime=leadtime,
+            config=config,
+            dry_run=dry_run,
+            key_path=key_path,
+            schema_file=schema_file,
         )
         self._batch = batch
 
@@ -496,6 +526,7 @@ class DriverCycleBased(Driver):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,
+        schema_file: Optional[Path] = None,
     ):
         """
         The driver.
@@ -505,9 +536,15 @@ class DriverCycleBased(Driver):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
+        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
-            cycle=cycle, config=config, dry_run=dry_run, key_path=key_path, batch=batch
+            cycle=cycle,
+            config=config,
+            dry_run=dry_run,
+            key_path=key_path,
+            batch=batch,
+            schema_file=schema_file,
         )
         self._cycle = cycle
 
@@ -525,6 +562,7 @@ class DriverCycleAndLeadtimeBased(Driver):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,
+        schema_file: Optional[Path] = None,
     ):
         """
         The driver.
@@ -535,6 +573,7 @@ class DriverCycleAndLeadtimeBased(Driver):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
+        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             cycle=cycle,
@@ -543,6 +582,7 @@ class DriverCycleAndLeadtimeBased(Driver):
             dry_run=dry_run,
             key_path=key_path,
             batch=batch,
+            schema_file=schema_file,
         )
         self._cycle = cycle
         self._leadtime = leadtime
@@ -559,6 +599,7 @@ class DriverTimeInvariant(Driver):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         batch: bool = False,
+        schema_file: Optional[Path] = None,
     ):
         """
         The driver.
@@ -567,8 +608,15 @@ class DriverTimeInvariant(Driver):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
+        :param schema_file: Path to schema file to use for validation.
         """
-        super().__init__(config=config, dry_run=dry_run, key_path=key_path, batch=batch)
+        super().__init__(
+            config=config,
+            dry_run=dry_run,
+            key_path=key_path,
+            batch=batch,
+            schema_file=schema_file,
+        )
 
 
 DriverT = Union[type[Assets], type[Driver]]

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -49,7 +49,6 @@ class Assets(ABC):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
-        :param schema_file: Path to schema file to use for validation.
         """
         self._config = YAMLConfig(config=config)
         self._config.dereference(
@@ -241,7 +240,6 @@ class AssetsCycleBased(Assets):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
-        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             cycle=cycle,
@@ -275,7 +273,6 @@ class AssetsCycleLeadtimeBased(Assets):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
-        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             cycle=cycle,
@@ -307,7 +304,6 @@ class AssetsTimeInvariant(Assets):
         :param config: Path to config file (read stdin if missing or None).
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
-        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             config=config,
@@ -341,7 +337,6 @@ class Driver(Assets):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
-        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             cycle=cycle,
@@ -538,7 +533,6 @@ class DriverCycleBased(Driver):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
-        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             cycle=cycle,
@@ -575,7 +569,6 @@ class DriverCycleLeadtimeBased(Driver):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
-        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             cycle=cycle,
@@ -610,7 +603,6 @@ class DriverTimeInvariant(Driver):
         :param dry_run: Run in dry-run mode?
         :param key_path: Keys leading through the config to the driver's configuration block.
         :param batch: Run component via the batch system?
-        :param schema_file: Path to schema file to use for validation.
         """
         super().__init__(
             config=config,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -302,16 +302,6 @@ class Driver(Assets):
         batch: bool = False,
         schema_file: Optional[Path] = None,
     ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param leadtime: The leadtime.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        :param batch: Run component via the batch system?
-        """
         super().__init__(
             cycle=cycle,
             leadtime=leadtime,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -41,15 +41,6 @@ class Assets(ABC):
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
     ) -> None:
-        """
-        A component driver.
-
-        :param cycle: The cycle.
-        :param leadtime: The leadtime.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
         self._config = YAMLConfig(config=config)
         self._config.dereference(
             context={

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -248,15 +248,6 @@ class AssetsCycleLeadtimeBased(Assets):
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
     ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param leadtime: The leadtime.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
         super().__init__(
             cycle=cycle,
             leadtime=leadtime,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -632,6 +632,7 @@ def _add_docstring(class_: type, omit: Optional[list[str]] = None) -> None:
     :param dry_run: Run in dry-run mode?
     :param key_path: Keys leading through the config to the driver's configuration block.
     :param batch: Run component via the batch system?
+    :param schema_file: Path to schema file to use to validate an external driver.
     """
     setattr(
         class_,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -489,8 +489,8 @@ class Driver(Assets):
         if schema_file:
             validate_external(schema_file=schema_file, config=self._config)
         else:
-            for schema_name in (self._driver_name.replace("_", "-"), "platform"):
-                validate_internal(schema_name=schema_name, config=self._config)
+            validate_internal(schema_name=self._driver_name.replace("_", "-"), config=self._config)
+        validate_internal(schema_name="platform", config=self._config)
 
     def _write_runscript(self, path: Path, envvars: Optional[dict[str, str]] = None) -> None:
         """

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -224,14 +224,6 @@ class AssetsCycleBased(Assets):
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
     ):
-        """
-        The driver.
-
-        :param cycle: The cycle.
-        :param config: Path to config file (read stdin if missing or None).
-        :param dry_run: Run in dry-run mode?
-        :param key_path: Keys leading through the config to the driver's configuration block.
-        """
         super().__init__(
             cycle=cycle,
             config=config,

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -12,7 +12,7 @@ from lxml import etree
 from lxml.etree import Element, SubElement, _Element
 
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.config.validator import validate_yaml
+from uwtools.config.validator import validate_external
 from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import log
 from uwtools.utils.file import readable, resource_path, writable
@@ -348,7 +348,7 @@ class _RocotoXML:
         :raises: UWConfigError if config fails validation.
         """
         schema_file = resource_path("jsonschema/rocoto.jsonschema")
-        ok = validate_yaml(schema_file=schema_file, config=config)
+        ok = validate_external(schema_file=schema_file, config=config)
         if not ok:
             raise UWConfigError("YAML validation errors")
 

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -12,7 +12,7 @@ from lxml import etree
 from lxml.etree import Element, SubElement, _Element
 
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.config.validator import validate_external
+from uwtools.config.validator import validate_external as validate_yaml
 from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import log
 from uwtools.utils.file import readable, resource_path, writable
@@ -348,7 +348,7 @@ class _RocotoXML:
         :raises: UWConfigError if config fails validation.
         """
         schema_file = resource_path("jsonschema/rocoto.jsonschema")
-        ok = validate_external(schema_file=schema_file, config=config)
+        ok = validate_yaml(schema_file=schema_file, config=config)
         if not ok:
             raise UWConfigError("YAML validation errors")
 

--- a/src/uwtools/tests/api/test_config.py
+++ b/src/uwtools/tests/api/test_config.py
@@ -94,9 +94,9 @@ def test_realize_to_dict():
 @mark.parametrize("cfg", [{"foo": "bar"}, YAMLConfig(config={})])
 def test_validate(cfg):
     kwargs: dict = {"schema_file": "schema-file", "config": cfg}
-    with patch.object(config, "_validate_yaml", return_value=True) as _validate_yaml:
+    with patch.object(config, "_validate_external", return_value=True) as _validate_external:
         assert config.validate(**kwargs)
-    _validate_yaml.assert_called_once_with(
+    _validate_external.assert_called_once_with(
         schema_file=Path(kwargs["schema_file"]), config=kwargs["config"]
     )
 
@@ -106,6 +106,6 @@ def test_validate_config_file(tmp_path):
     with open(cfg, "w", encoding="utf-8") as f:
         yaml.dump({}, f)
     kwargs: dict = {"schema_file": "schema-file", "config": cfg}
-    with patch.object(config, "_validate_yaml", return_value=True) as _validate_yaml:
+    with patch.object(config, "_validate_external", return_value=True) as _validate_external:
         assert config.validate(**kwargs)
-    _validate_yaml.assert_called_once_with(schema_file=Path(kwargs["schema_file"]), config=cfg)
+    _validate_external.assert_called_once_with(schema_file=Path(kwargs["schema_file"]), config=cfg)

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -163,10 +163,10 @@ def test_validate_internal_ok(schema_file):
         validator.validate_internal(schema_name="a", config={"color": "blue"})
 
 
-def test_validate_yaml(assets, config, schema):
+def test_validate_external(assets, config, schema):
     schema_file, _, cfgobj = assets
     with patch.object(validator, "validate") as validate:
-        validator.validate_yaml(schema_file=schema_file, config=cfgobj)
+        validator.validate_external(schema_file=schema_file, config=cfgobj)
     validate.assert_called_once_with(schema=schema, config=config)
 
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -549,6 +549,6 @@ def test__add_docstring():
     assert getattr(C, "__doc__") is None
     with patch.object(driver, "C", C, create=True):
         class_ = driver.C  # type: ignore # pylint: disable=no-member
-        omit = ["cycle", "leadtime", "config", "dry_run", "key_path", "batch"]
+        omit = ["cycle", "leadtime", "config", "dry_run", "key_path", "batch", "schema_file"]
         driver._add_docstring(class_=class_, omit=omit)
     assert getattr(C, "__doc__").strip() == "The driver."

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -247,9 +247,9 @@ def test_Assets__validate_internal(assetsobj):
 
 
 def test_Assets__validate_external(config):
-    schema_file = "/path/to/jsonschema"
+    schema_file = Path("/path/to/jsonschema")
     with patch.object(ConcreteAssetsTimeInvariant, "_validate", driver.Assets._validate):
-        with patch.object(driver, "validate_external") as validate_external: 
+        with patch.object(driver, "validate_external") as validate_external:
             assetsobj = ConcreteAssetsTimeInvariant(schema_file=schema_file, config=config)
         assert validate_external.call_args_list[0].kwargs == {
             "schema_file": schema_file,
@@ -491,7 +491,7 @@ def test_Driver__scheduler(driverobj):
         JobScheduler.get_scheduler.assert_called_with(driverobj._resources)
 
 
-def test_Driver__validate(assetsobj):
+def test_Driver__validate_internal(assetsobj):
     with patch.object(assetsobj, "_validate", driver.Driver._validate):
         with patch.object(driver, "validate_internal") as validate_internal:
             assetsobj._validate(assetsobj)
@@ -501,6 +501,17 @@ def test_Driver__validate(assetsobj):
         }
         assert validate_internal.call_args_list[1].kwargs == {
             "schema_name": "platform",
+            "config": assetsobj._config,
+        }
+
+
+def test_Driver__validate_external(config):
+    schema_file = Path("/path/to/jsonschema")
+    with patch.object(ConcreteAssetsTimeInvariant, "_validate", driver.Driver._validate):
+        with patch.object(driver, "validate_external") as validate_external:
+            assetsobj = ConcreteAssetsTimeInvariant(schema_file=schema_file, config=config)
+        assert validate_external.call_args_list[0].kwargs == {
+            "schema_file": schema_file,
             "config": assetsobj._config,
         }
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -236,7 +236,7 @@ def test_Assets__rundir(assetsobj):
     assert assetsobj._rundir == Path(assetsobj._driver_config["rundir"])
 
 
-def test_Assets__validate(assetsobj):
+def test_Assets__validate_internal(assetsobj):
     with patch.object(assetsobj, "_validate", driver.Assets._validate):
         with patch.object(driver, "validate_internal") as validate_internal:
             assetsobj._validate(assetsobj)
@@ -246,8 +246,15 @@ def test_Assets__validate(assetsobj):
         }
 
 
-def test_Assets__validate_external(assetsobj):
-    pass
+def test_Assets__validate_external(config):
+    schema_file = "/path/to/jsonschema"
+    with patch.object(ConcreteAssetsTimeInvariant, "_validate", driver.Assets._validate):
+        with patch.object(driver, "validate_external") as validate_external: 
+            assetsobj = ConcreteAssetsTimeInvariant(schema_file=schema_file, config=config)
+        assert validate_external.call_args_list[0].kwargs == {
+            "schema_file": schema_file,
+            "config": assetsobj._config,
+        }
 
 
 # Driver Tests
@@ -496,10 +503,6 @@ def test_Driver__validate(assetsobj):
             "schema_name": "platform",
             "config": assetsobj._config,
         }
-
-
-def test_Driver__validate_external(assetsobj):
-    pass
 
 
 def test_Driver__write_runscript(driverobj):

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -10,6 +10,7 @@ import json
 import logging
 from pathlib import Path
 from textwrap import dedent
+from typing import Optional
 from unittest.mock import Mock, PropertyMock, patch
 
 import yaml
@@ -42,7 +43,7 @@ class Common:
     def _driver_name(self) -> str:
         return "concrete"
 
-    def _validate(self) -> None:
+    def _validate(self, schema_file: Optional[Path] = None) -> None:
         pass
 
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -246,6 +246,10 @@ def test_Assets__validate(assetsobj):
         }
 
 
+def test_Assets__validate_external(assetsobj):
+    pass
+
+
 # Driver Tests
 
 
@@ -492,6 +496,10 @@ def test_Driver__validate(assetsobj):
             "schema_name": "platform",
             "config": assetsobj._config,
         }
+
+
+def test_Driver__validate_external(assetsobj):
+    pass
 
 
 def test_Driver__write_runscript(driverobj):

--- a/src/uwtools/tests/drivers/test_support.py
+++ b/src/uwtools/tests/drivers/test_support.py
@@ -2,6 +2,9 @@
 """
 Tests for uwtools.drivers.support module.
 """
+from pathlib import Path
+from typing import Optional
+
 from iotaa import asset, external, task, tasks
 
 from uwtools.drivers import support
@@ -48,7 +51,7 @@ def test_graph():
         def _taskname(self, suffix):
             pass
 
-        def _validate(self):
+        def _validate(self, schema_file: Optional[Path] = None):
             pass
 
     assert support.tasks(SomeDriver) == {

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -332,13 +332,13 @@ def test__dispatch_config_validate_config_obj():
         STR.schemafile: Path("/path/to/a.jsonschema"),
         STR.infile: Path("/path/to/config.yaml"),
     }
-    with patch.object(uwtools.api.config, "_validate_yaml") as _validate_yaml:
+    with patch.object(uwtools.api.config, "_validate_external") as _validate_external:
         cli._dispatch_config_validate(_dispatch_config_validate_args)
-    _validate_yaml_args = {
+    _validate_external_args = {
         STR.schemafile: _dispatch_config_validate_args[STR.schemafile],
         STR.config: _dispatch_config_validate_args[STR.infile],
     }
-    _validate_yaml.assert_called_once_with(**_validate_yaml_args)
+    _validate_external.assert_called_once_with(**_validate_external_args)
 
 
 @mark.parametrize(


### PR DESCRIPTION
**Synopsis**
User supplied schemas are now required to be validated. We can do this by allowing external drivers to provide a JSON Schema file to validate the unique part of their configs. 

Utilizing existing functionality from the `schema_file` argument from the CLI that already returns the path to a schema file to use for validation and within `uwtools.config.validator` module an existing method,`validate_yaml`, validates a YAML config against the JSON Schema given the schema file. With both of these in action we were able to add the `schema_file` parameter to each of the Classes in the `uwtools.drivers.driver` module, and then add an if/else that does two checks:

1. If the `schema_file` parameter was passed from the user, we will validate an external driver via the JSON Schema file path provided to us.
2. If the `schema_file` was **_NOT_** passed from the user, then we will continue with an internal validation of a uwtools standalone driver, which will be schema checked by a JSON Schema in the `uwtools.resources.jsonschema` module.

**Type**
- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [ ] I have reviewed the documentation and have made any updates necessitated by this change.
