### PR TITLE
Base driver kwargs on constructor signature

### DIFF
--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -17,15 +17,15 @@ from uwtools.logging import log
 from uwtools.utils.api import ensure_data_source
 
 
-def execute(  # pylint: disable=unused-argument
+def execute(
     module: Union[Path, str],
     classname: str,
     task: str,
     schema_file: str,
     config: Optional[Union[Path, str]] = None,
-    cycle: Optional[datetime] = None,
-    leadtime: Optional[timedelta] = None,
-    batch: Optional[bool] = False,
+    cycle: Optional[datetime] = None,  # pylint: disable=unused-argument
+    leadtime: Optional[timedelta] = None,  # pylint: disable=unused-argument
+    batch: Optional[bool] = False,  # pylint: disable=unused-argument
     dry_run: Optional[bool] = False,
     graph_file: Optional[Union[Path, str]] = None,
     key_path: Optional[list[str]] = None,

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -1073,16 +1073,14 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
     kwargs = {
         "task": args[STR.action],
         "config": args[STR.cfgfile],
-        "batch": args[STR.batch],
         "dry_run": args[STR.dryrun],
         "graph_file": args[STR.graphfile],
         "key_path": args[STR.keypath],
         "stdin_ok": True,
     }
-    if cycle := args.get(STR.cycle):
-        kwargs[STR.cycle] = cycle
-    if (leadtime := args.get(STR.leadtime)) is not None:
-        kwargs[STR.leadtime] = leadtime
+    for k in [STR.batch, STR.cycle, STR.leadtime]:
+        if k in args:
+            kwargs[k] = args.get(k)
     return execute(**kwargs)
 
 

--- a/src/uwtools/tests/utils/test_api.py
+++ b/src/uwtools/tests/utils/test_api.py
@@ -1,14 +1,13 @@
 # pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
 
 import datetime as dt
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 from pytest import fixture, mark, raises
 
 from uwtools.exceptions import UWError
-from uwtools.tests.drivers.test_driver import ConcreteDriverCycleLeadtimeBased as TestDriverWCL
+from uwtools.tests.drivers.test_driver import ConcreteDriverCycleLeadtimeBased as TestDriverCL
 from uwtools.tests.drivers.test_driver import ConcreteDriverTimeInvariant as TestDriver
 from uwtools.utils import api
 
@@ -105,16 +104,14 @@ def test_str2path_convert():
 @mark.parametrize("hours", [0, 24, 168])
 def test__execute(execute_kwargs, hours, tmp_path):
     graph_file = tmp_path / "g.dot"
-    with patch.object(sys.modules[__name__], "TestDriverWCL", wraps=TestDriverWCL) as cd:
-        kwargs = {
-            **execute_kwargs,
-            "driver_class": cd,
-            "config": {"some": "config"},
-            "cycle": dt.datetime.now(),
-            "leadtime": dt.timedelta(hours=hours),
-            "graph_file": graph_file,
-        }
-        assert not graph_file.is_file()
-        assert api._execute(**kwargs) is True
-        assert cd.call_args.kwargs["leadtime"] == dt.timedelta(hours=hours)
+    kwargs = {
+        **execute_kwargs,
+        "driver_class": TestDriverCL,
+        "config": {"some": "config"},
+        "cycle": dt.datetime.now(),
+        "leadtime": dt.timedelta(hours=hours),
+        "graph_file": graph_file,
+    }
+    assert not graph_file.is_file()
+    assert api._execute(**kwargs) is True
     assert graph_file.is_file()


### PR DESCRIPTION
**Synopsis**

Discovered via work on CDEPS integration, arguments like `batch`, `cycle`, and `leadtime` are potentially passed to constructors that do not accept them. Inspect the constructor signature and only add kwargs that are accepts.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
