### PR TITLE
Support derived types in Fortran namelists

### DIFF
--- a/docs/sections/user_guide/cli/tools/config.rst
+++ b/docs/sections/user_guide/cli/tools/config.rst
@@ -199,7 +199,12 @@ and YAML file ``update.yaml`` with contents:
    .. literalinclude:: config/realize-depth-mismatch.out
       :language: text
 
-   ``nml`` configs are technically depth-2, but in order to support specification of Fortran derived type (aka user-defined type) members, a mapping between arbitrary-depth YAML and Fortran namelist is supported. For example:
+   ``nml`` configs are technically depth-2, but in order to support specification of Fortran derived type (aka user-defined type) members, a mapping between arbitrary-depth YAML and Fortran namelist is supported. For example, ``derived-type.yaml`` with contents
+
+   .. literalinclude:: config/derived-type.yaml
+     :language: yaml
+
+   would be rendered as a Fortran namelist like this:
 
    .. literalinclude:: config/realize-nml-derived-type.cmd
       :language: text

--- a/docs/sections/user_guide/cli/tools/config.rst
+++ b/docs/sections/user_guide/cli/tools/config.rst
@@ -189,7 +189,7 @@ and YAML file ``update.yaml`` with contents:
   .. literalinclude:: config/realize-combo.out
      :language: text
 
-.. note:: Combining configs with incompatible depths is not supported. ``ini`` and ``nml`` configs are depth-2, as they organize their key-value pairs (one level) under top-level sections or namelists (a second level). ``sh`` configs are depth-1, and ``yaml`` configs have arbitrary depth.
+.. note:: Combining configs with incompatible depths is not supported. ``ini`` configs are depth-2, as they organize their key-value pairs (one level) under top-level sections or namelists (a second level). ``sh`` configs are depth-1, and ``yaml`` configs have arbitrary depth.
 
    For example, when attempting to generate a ``sh`` config from the original depth-2 ``config.yaml``:
 
@@ -197,6 +197,14 @@ and YAML file ``update.yaml`` with contents:
       :language: text
       :emphasize-lines: 1
    .. literalinclude:: config/realize-depth-mismatch.out
+      :language: text
+
+   ``nml`` configs are technically depth-2, but in order to support specification of Fortran derived type (aka user-defined type) members, a mapping between arbitrary-depth YAML and Fortran namelist is supported. For example:
+
+   .. literalinclude:: config/realize-nml-derived-type.cmd
+      :language: text
+      :emphasize-lines: 1
+   .. literalinclude:: config/realize-nml-derived-type.out
       :language: text
 
 * It is possible to provide the update config, rather than the input config, on ``stdin``. Usage rules are as follows:

--- a/docs/sections/user_guide/cli/tools/config.rst
+++ b/docs/sections/user_guide/cli/tools/config.rst
@@ -212,6 +212,8 @@ and YAML file ``update.yaml`` with contents:
    .. literalinclude:: config/realize-nml-derived-type.out
       :language: text
 
+   Fortran array-item/slice syntax (e.g. ``a(1) = 11``, ``a(2,3) = 22, 33``, etc.) is not currently supported.
+
 * It is possible to provide the update config, rather than the input config, on ``stdin``. Usage rules are as follows:
 
   * Only if either ``--update-file`` or ``--update-config`` are specified will ``uw`` attempt to read and apply update values to the input config.

--- a/docs/sections/user_guide/cli/tools/config.rst
+++ b/docs/sections/user_guide/cli/tools/config.rst
@@ -189,7 +189,7 @@ and YAML file ``update.yaml`` with contents:
   .. literalinclude:: config/realize-combo.out
      :language: text
 
-.. note:: Combining configs with incompatible depths is not supported. ``ini`` configs are depth-2, as they organize their key-value pairs (one level) under top-level sections or namelists (a second level). ``sh`` configs are depth-1, and ``yaml`` configs have arbitrary depth.
+.. note:: Combining configs with incompatible depths is not supported. ``ini`` configs are depth-2, as they organize their key-value pairs (one level) under top-level sections (a second level). ``sh`` configs are depth-1, and ``yaml`` configs have arbitrary depth.
 
    For example, when attempting to generate a ``sh`` config from the original depth-2 ``config.yaml``:
 

--- a/docs/sections/user_guide/cli/tools/config/derived-type.yaml
+++ b/docs/sections/user_guide/cli/tools/config/derived-type.yaml
@@ -1,0 +1,4 @@
+config:
+  resolution:
+    nx: 1440
+    ny: 721

--- a/docs/sections/user_guide/cli/tools/config/realize-nml-derived-type.cmd
+++ b/docs/sections/user_guide/cli/tools/config/realize-nml-derived-type.cmd
@@ -1,0 +1,1 @@
+uw config realize --input-file derived-type.yaml --output-format nml

--- a/docs/sections/user_guide/cli/tools/config/realize-nml-derived-type.out
+++ b/docs/sections/user_guide/cli/tools/config/realize-nml-derived-type.out
@@ -1,0 +1,4 @@
+&config
+    resolution%nx = 1440
+    resolution%ny = 721
+/

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -85,7 +85,7 @@ class NMLConfig(Config):
         """
         Returns the config's depth threshold.
         """
-        return 2
+        return None
 
     @staticmethod
     def get_format() -> str:

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -163,7 +163,7 @@ def test_derefernce_context_override(tmp_path):
     assert config["file"] == "gfs.t06z.atmanl.nc"
 
 
-@mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.sh])
+@mark.parametrize("fmt2", [FORMAT.ini, FORMAT.sh])
 def test_invalid_config(fmt2, tmp_path):
     """
     Test that invalid config files will error when attempting to dump.

--- a/src/uwtools/tests/config/formats/test_nml.py
+++ b/src/uwtools/tests/config/formats/test_nml.py
@@ -4,6 +4,7 @@ Tests for uwtools.config.formats.nml module.
 """
 
 import filecmp
+from textwrap import dedent
 
 import f90nml  # type: ignore
 from pytest import fixture, mark
@@ -23,8 +24,22 @@ def data():
 # Tests
 
 
-def test_nml_derived_type():
+def test_nml_derived_type_dict():
     nml = NMLConfig(config={"nl": {"o": {"i": 77, "j": 88}}})
+    assert nml["nl"]["o"] == {"i": 77, "j": 88}
+
+
+def test_nml_derived_type_file(tmp_path):
+    s = """
+    &nl
+      o%i = 77
+      o%j = 88
+    /
+    """
+    path = tmp_path / "a.nml"
+    with open(path, "w", encoding="utf-8") as f:
+        print(dedent(s).strip(), file=f)
+    nml = NMLConfig(config=path)
     assert nml["nl"]["o"] == {"i": 77, "j": 88}
 
 

--- a/src/uwtools/tests/config/formats/test_nml.py
+++ b/src/uwtools/tests/config/formats/test_nml.py
@@ -6,10 +6,9 @@ Tests for uwtools.config.formats.nml module.
 import filecmp
 
 import f90nml  # type: ignore
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.exceptions import UWConfigError
 from uwtools.tests.support import fixture_path
 from uwtools.utils.file import FORMAT
 
@@ -22,6 +21,11 @@ def data():
 
 
 # Tests
+
+
+def test_nml_derived_type():
+    nml = NMLConfig(config={"nl": {"o": {"i": 77, "j": 88}}})
+    assert nml["nl"]["o"] == {"i": 77, "j": 88}
 
 
 def test_nml_dump_dict_dict(data, tmp_path):
@@ -43,13 +47,7 @@ def test_nml_get_format():
 
 
 def test_nml_get_depth_threshold():
-    assert NMLConfig.get_depth_threshold() == 2
-
-
-def test_nml_instantiation_depth():
-    with raises(UWConfigError) as e:
-        NMLConfig(config={1: {2: {3: 4}}})
-    assert str(e.value) == "Cannot instantiate depth-2 NMLConfig with depth-3 config"
+    assert NMLConfig.get_depth_threshold() is None
 
 
 def test_nml_parse_include():


### PR DESCRIPTION
**Synopsis**

Given `config.yaml`
```
a:
  b:
    i: 77
    j: 88
```
Old behavior:
```
$ uw config realize --input-file config.yaml --output-format nml
[2024-07-24T15:53:51]    ERROR Cannot realize depth-3 config to type-'nml' config
```
New behavior:
```
$ uw config realize --input-file config.yaml --output-format nml
&a
    b%i = 77
    b%j = 88
/
```
This involves removing the restriction on depth of `NMLConfig` initialization data, as any level of derived-type member access via `%` separators. I have added some content to the `config realize` CLI docs to clarify this.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
