### PR TITLE
file tool updates

### DIFF
--- a/docs/sections/user_guide/cli/tools/file.rst
+++ b/docs/sections/user_guide/cli/tools/file.rst
@@ -43,6 +43,15 @@ The ``--cycle`` and ``--leadtime`` options can be used to make Python ``datetime
 .. literalinclude:: file/copy-exec-timedep.out
    :language: text
 
+The ``--target-dir`` option is optional when all destination paths are absolute, and will never be applied to absolute destination paths. If any destination paths are relative, however, it is an error not to provide a target directory:
+
+.. literalinclude:: file/copy-config.yaml
+   :language: yaml
+.. literalinclude:: file/copy-exec-no-target-dir-err.cmd
+   :emphasize-lines: 1
+.. literalinclude:: file/copy-exec-no-target-dir-err.out
+   :language: text
+
 .. _cli_file_link_examples:
 
 ``link``
@@ -76,4 +85,13 @@ The ``--cycle`` and ``--leadtime`` options can be used to make Python ``datetime
 .. literalinclude:: file/link-exec-timedep.cmd
    :emphasize-lines: 2
 .. literalinclude:: file/link-exec-timedep.out
+   :language: text
+
+The ``--target-dir`` option is optional when all linkname paths are absolute, and will never be applied to absolute linkname paths. If any linkname paths are relative, however, it is an error not to provide a target directory:
+
+.. literalinclude:: file/link-config.yaml
+   :language: yaml
+.. literalinclude:: file/link-exec-no-target-dir-err.cmd
+   :emphasize-lines: 1
+.. literalinclude:: file/link-exec-no-target-dir-err.out
    :language: text

--- a/docs/sections/user_guide/cli/tools/file/copy-exec-no-target-dir-err.cmd
+++ b/docs/sections/user_guide/cli/tools/file/copy-exec-no-target-dir-err.cmd
@@ -1,0 +1,1 @@
+uw file copy --config-file copy-config.yaml config files

--- a/docs/sections/user_guide/cli/tools/file/copy-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/file/copy-exec-no-target-dir-err.out
@@ -1,0 +1,1 @@
+[2024-07-26T21:51:23]    ERROR Relative path 'foo' requires the target directory to be specified

--- a/docs/sections/user_guide/cli/tools/file/copy-help.out
+++ b/docs/sections/user_guide/cli/tools/file/copy-help.out
@@ -1,13 +1,9 @@
-usage: uw file copy --target-dir PATH [-h] [--version] [--config-file PATH]
+usage: uw file copy [-h] [--version] [--config-file PATH] [--target-dir PATH]
                     [--cycle CYCLE] [--leadtime LEADTIME] [--dry-run]
                     [--quiet] [--verbose]
                     [KEY ...]
 
 Copy files
-
-Required arguments:
-  --target-dir PATH
-      Path to target directory
 
 Optional arguments:
   -h, --help
@@ -16,6 +12,8 @@ Optional arguments:
       Show version info and exit
   --config-file PATH, -c PATH
       Path to UW YAML config file (default: read from stdin)
+  --target-dir PATH
+      Root directory for relative destination paths
   --cycle CYCLE
       The cycle in ISO8601 format (e.g. 2024-05-29T12)
   --leadtime LEADTIME

--- a/docs/sections/user_guide/cli/tools/file/link-exec-no-target-dir-err.cmd
+++ b/docs/sections/user_guide/cli/tools/file/link-exec-no-target-dir-err.cmd
@@ -1,0 +1,1 @@
+uw file link --config-file link-config.yaml config files

--- a/docs/sections/user_guide/cli/tools/file/link-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/file/link-exec-no-target-dir-err.out
@@ -1,0 +1,1 @@
+[2024-07-26T21:51:23]    ERROR Relative path 'foo' requires the target directory to be specified

--- a/docs/sections/user_guide/cli/tools/file/link-help.out
+++ b/docs/sections/user_guide/cli/tools/file/link-help.out
@@ -1,13 +1,9 @@
-usage: uw file link --target-dir PATH [-h] [--version] [--config-file PATH]
+usage: uw file link [-h] [--version] [--config-file PATH] [--target-dir PATH]
                     [--cycle CYCLE] [--leadtime LEADTIME] [--dry-run]
                     [--quiet] [--verbose]
                     [KEY ...]
 
 Link files
-
-Required arguments:
-  --target-dir PATH
-      Path to target directory
 
 Optional arguments:
   -h, --help
@@ -16,6 +12,8 @@ Optional arguments:
       Show version info and exit
   --config-file PATH, -c PATH
       Path to UW YAML config file (default: read from stdin)
+  --target-dir PATH
+      Root directory for relative destination paths
   --cycle CYCLE
       The cycle in ISO8601 format (e.g. 2024-05-29T12)
   --leadtime LEADTIME

--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -45,10 +45,9 @@ def get_fieldtable_config(
     """
     Get a ``FieldTableConfig`` object.
 
-    :param config: FieldTable file to load (``None`` or unspecified => read ``stdin``), or initial
-        ``dict``
+    :param config: FieldTable file (``None`` => read ``stdin``), or initial ``dict``.
     :param stdin_ok: OK to read from ``stdin``?
-    :return: An initialized ``FieldTableConfig`` object
+    :return: An initialized ``FieldTableConfig`` object.
     """
     return _FieldTableConfig(config=_ensure_data_source(_str2path(config), stdin_ok))
 
@@ -60,9 +59,9 @@ def get_ini_config(
     """
     Get an ``INIConfig`` object.
 
-    :param config: INI file to load (``None`` or unspecified => read ``stdin``), or initial ``dict``
+    :param config: INI file or ``dict`` (``None`` => read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: An initialized ``INIConfig`` object
+    :return: An initialized ``INIConfig`` object.
     """
     return _INIConfig(config=_ensure_data_source(_str2path(config), stdin_ok))
 
@@ -74,10 +73,9 @@ def get_nml_config(
     """
     Get an ``NMLConfig`` object.
 
-    :param config: Fortran namelist file to load (``None`` or unspecified => read ``stdin``), or
-        initial ``dict``
+    :param config: Namelist file of ``dict`` (``None`` => read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: An initialized ``NMLConfig`` object
+    :return: An initialized ``NMLConfig`` object.
     """
     return _NMLConfig(config=_ensure_data_source(_str2path(config), stdin_ok))
 
@@ -89,10 +87,9 @@ def get_sh_config(
     """
     Get an ``SHConfig`` object.
 
-    :param config: File of shell 'key=value' pairs to load (``None`` or unspecified => read
-        ``stdin``), or initial ``dict``
+    :param config: Shell key=value pairs file or ``dict`` (``None`` => read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: An initialized ``SHConfig`` object
+    :return: An initialized ``SHConfig`` object.
     """
     return _SHConfig(config=_ensure_data_source(_str2path(config), stdin_ok))
 
@@ -104,10 +101,9 @@ def get_yaml_config(
     """
     Get a ``YAMLConfig`` object.
 
-    :param config: YAML file to load (``None`` or unspecified => read ``stdin``), or initial
-        ``dict``
+    :param config: YAML file or ``dict`` (``None`` => read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: An initialized ``YAMLConfig`` object
+    :return: An initialized ``YAMLConfig`` object.
     """
     return _YAMLConfig(config=_ensure_data_source(_str2path(config), stdin_ok))
 
@@ -172,10 +168,10 @@ def validate(
     If no config is specified, ``stdin`` is read and will be parsed as YAML and then validated. A
     ``dict`` or a YAMLConfig instance may also be provided for validation.
 
-    :param schema_file: The JSON Schema file to use for validation
-    :param config: The config to validate
+    :param schema_file: The JSON Schema file to use for validation.
+    :param config: The config to validate.
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if the YAML file conforms to the schema, ``False`` otherwise
+    :return: ``True`` if the YAML file conforms to the schema, ``False`` otherwise.
     """
     return _validate_external(
         schema_file=_str2path(schema_file), config=_ensure_data_source(_str2path(config), stdin_ok)
@@ -193,11 +189,11 @@ Compare two config files.
 
 Recognized file extensions are: {extensions}
 
-:param config_1_path: Path to 1st config file
-:param config_2_path: Path to 2nd config file
-:param config_1_format: Format of 1st config file (optional if file's extension is recognized)
-:param config_2_format: Format of 2nd config file (optional if file's extension is recognized)
-:return: ``False`` if config files had differences, otherwise ``True``
+:param config_1_path: Path to 1st config file.
+:param config_2_path: Path to 2nd config file.
+:param config_1_format: Format of 1st config file (optional if file's extension is recognized).
+:param config_2_format: Format of 2nd config file (optional if file's extension is recognized).
+:return: ``False`` if config files had differences, otherwise ``True``.
 """.format(
     extensions=", ".join(_FORMAT.extensions())
 ).strip()
@@ -228,19 +224,19 @@ rendered. Otherwise, such variables/expressions will be passed through unchanged
 
 Recognized file extensions are: {extensions}
 
-:param input_config: Input config file (``None`` or unspecified => read ``stdin``)
-:param input_format: Format of the input config (optional if file's extension is recognized)
-:param update_config: Update config file (``None`` or unspecified => read ``stdin``)
-:param update_format: Format of the update config (optional if file's extension is recognized)
-:param output_file: Output config file (``None`` or unspecified => write to ``stdout``)
-:param output_format: Format of the output config (optional if file's extension is recognized)
-:param key_path: Path through keys to the desired output block
-:param values_needed: Report complete, missing, and template values
-:param total: Require rendering of all Jinja2 variables/expressions
-:param dry_run: Log output instead of writing to output
+:param input_config: Input config file (``None`` => read ``stdin``).
+:param input_format: Format of the input config (optional if file's extension is recognized).
+:param update_config: Update config file (``None`` => read ``stdin``).
+:param update_format: Format of the update config (optional if file's extension is recognized).
+:param output_file: Output config file (``None`` => write to ``stdout``).
+:param output_format: Format of the output config (optional if file's extension is recognized).
+:param key_path: Path through keys to the desired output block.
+:param values_needed: Report complete, missing, and template values.
+:param total: Require rendering of all Jinja2 variables/expressions.
+:param dry_run: Log output instead of writing to output.
 :param stdin_ok: OK to read from ``stdin``?
-:return: The ``dict`` representation of the realized config
-:raises: UWConfigRealizeError if ``total`` is ``True`` and any Jinja2 variable/expression was not rendered
+:return: The ``dict`` representation of the realized config.
+:raises: UWConfigRealizeError if ``total`` is ``True`` and any Jinja2 variable/expression was not rendered.
 """.format(
     extensions=", ".join(_FORMAT.extensions())
 ).strip()

--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -37,7 +37,7 @@ def execute(
     If ``batch`` is specified, a runscript will be written and submitted to the batch system.
     Otherwise, the executable will be run directly on the current system.
 
-    :param module: Path to driver module or name of module on sys.path
+    :param module: Path to driver module or name of module on sys.path.
     :param classname: Name of driver class to instantiate.
     :param task: Name of driver task to execute.
     :param schema_file: Path to schema file.

--- a/src/uwtools/api/file.py
+++ b/src/uwtools/api/file.py
@@ -15,8 +15,8 @@ from uwtools.utils.api import str2path as _str2path
 
 
 def copy(
-    target_dir: Union[Path, str],
     config: Optional[Union[Path, dict, str]] = None,
+    target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
     keys: Optional[list[str]] = None,
@@ -26,8 +26,8 @@ def copy(
     """
     Copy files.
 
-    :param target_dir: Path to target directory.
     :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).
+    :param target_dir: Path to target directory.
     :param cycle: A datetime object to make available for use in the config.
     :param leadtime: A timedelta object to make available for use in the config.
     :param keys: YAML keys leading to file dst/src block.
@@ -36,7 +36,7 @@ def copy(
     :return: ``True`` if all copies were created.
     """
     copier = _FileCopier(
-        target_dir=Path(target_dir),
+        target_dir=Path(target_dir) if target_dir else None,
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
@@ -48,8 +48,8 @@ def copy(
 
 
 def link(
-    target_dir: Union[Path, str],
     config: Optional[Union[Path, dict, str]] = None,
+    target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
     keys: Optional[list[str]] = None,
@@ -59,8 +59,8 @@ def link(
     """
     Link files.
 
-    :param target_dir: Path to target directory.
     :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).
+    :param target_dir: Path to target directory.
     :param cycle: A datetime object to make available for use in the config.
     :param leadtime: A timedelta object to make available for use in the config.
     :param keys: YAML keys leading to file dst/src block.
@@ -69,7 +69,7 @@ def link(
     :return: ``True`` if all links were created.
     """
     linker = _FileLinker(
-        target_dir=Path(target_dir),
+        target_dir=Path(target_dir) if target_dir else None,
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
         leadtime=leadtime,

--- a/src/uwtools/api/file.py
+++ b/src/uwtools/api/file.py
@@ -8,8 +8,7 @@ from typing import Optional, Union
 
 from iotaa import Asset
 
-from uwtools.file import FileCopier as _FileCopier
-from uwtools.file import FileLinker as _FileLinker
+from uwtools.file import FileCopier, FileLinker
 from uwtools.utils.api import ensure_data_source as _ensure_data_source
 from uwtools.utils.api import str2path as _str2path
 
@@ -35,7 +34,7 @@ def copy(
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if all copies were created.
     """
-    copier = _FileCopier(
+    copier = FileCopier(
         target_dir=Path(target_dir) if target_dir else None,
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
@@ -68,7 +67,7 @@ def link(
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if all links were created.
     """
-    linker = _FileLinker(
+    linker = FileLinker(
         target_dir=Path(target_dir) if target_dir else None,
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
@@ -78,3 +77,6 @@ def link(
     )
     assets: list[Asset] = linker.go()  # type: ignore
     return all(asset.ready() for asset in assets)
+
+
+__all__ = ["FileCopier", "FileLinker", "copy", "link"]

--- a/src/uwtools/api/file.py
+++ b/src/uwtools/api/file.py
@@ -24,14 +24,14 @@ def copy(
     """
     Copy files.
 
-    :param target_dir: Path to target directory
+    :param target_dir: Path to target directory.
     :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).
     :param cycle: A datetime object to make available for use in the config.
     :param leadtime: A timedelta object to make available for use in the config.
-    :param keys: YAML keys leading to file dst/src block
-    :param dry_run: Do not copy files
+    :param keys: YAML keys leading to file dst/src block.
+    :param dry_run: Do not copy files.
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if no exception is raised
+    :return: ``True`` if all files were copied.
     """
     _FileCopier(
         target_dir=Path(target_dir),
@@ -56,14 +56,14 @@ def link(
     """
     Link files.
 
-    :param target_dir: Path to target directory
+    :param target_dir: Path to target directory.
     :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).
     :param cycle: A datetime object to make available for use in the config.
     :param leadtime: A timedelta object to make available for use in the config.
-    :param keys: YAML keys leading to file dst/src block
-    :param dry_run: Do not link files
+    :param keys: YAML keys leading to file dst/src block.
+    :param dry_run: Do not link files.
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if no exception is raised
+    :return: ``True`` if no exception is raised.
     """
     _FileLinker(
         target_dir=Path(target_dir),

--- a/src/uwtools/api/file.py
+++ b/src/uwtools/api/file.py
@@ -6,6 +6,8 @@ import datetime as dt
 from pathlib import Path
 from typing import Optional, Union
 
+from iotaa import Asset
+
 from uwtools.file import FileCopier as _FileCopier
 from uwtools.file import FileLinker as _FileLinker
 from uwtools.utils.api import ensure_data_source as _ensure_data_source
@@ -31,17 +33,18 @@ def copy(
     :param keys: YAML keys leading to file dst/src block.
     :param dry_run: Do not copy files.
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if all files were copied.
+    :return: ``True`` if all copies were created.
     """
-    _FileCopier(
+    copier = _FileCopier(
         target_dir=Path(target_dir),
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
         keys=keys,
         dry_run=dry_run,
-    ).go()
-    return True
+    )
+    assets: list[Asset] = copier.go()  # type: ignore
+    return all(asset.ready() for asset in assets)
 
 
 def link(
@@ -63,14 +66,15 @@ def link(
     :param keys: YAML keys leading to file dst/src block.
     :param dry_run: Do not link files.
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if no exception is raised.
+    :return: ``True`` if all links were created.
     """
-    _FileLinker(
+    linker = _FileLinker(
         target_dir=Path(target_dir),
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
         keys=keys,
         dry_run=dry_run,
-    ).go()
-    return True
+    )
+    assets: list[Asset] = linker.go()  # type: ignore
+    return all(asset.ready() for asset in assets)

--- a/src/uwtools/api/file.py
+++ b/src/uwtools/api/file.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 from iotaa import Asset
 
-from uwtools.file import FileCopier, FileLinker
+from uwtools.file import Copier, Linker
 from uwtools.utils.api import ensure_data_source as _ensure_data_source
 from uwtools.utils.api import str2path as _str2path
 
@@ -34,7 +34,7 @@ def copy(
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if all copies were created.
     """
-    copier = FileCopier(
+    copier = Copier(
         target_dir=Path(target_dir) if target_dir else None,
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
@@ -67,7 +67,7 @@ def link(
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if all links were created.
     """
-    linker = FileLinker(
+    linker = Linker(
         target_dir=Path(target_dir) if target_dir else None,
         config=_ensure_data_source(_str2path(config), stdin_ok),
         cycle=cycle,
@@ -79,4 +79,4 @@ def link(
     return all(asset.ready() for asset in assets)
 
 
-__all__ = ["FileCopier", "FileLinker", "copy", "link"]
+__all__ = ["Copier", "Linker", "copy", "link"]

--- a/src/uwtools/api/logging.py
+++ b/src/uwtools/api/logging.py
@@ -12,7 +12,7 @@ def use_custom_logger(logger: logging.Logger) -> None:
     """
     Log to the specified ``Logger`` object, configured according to your needs.
 
-    :param logger: The custom logger to use
+    :param logger: The custom logger to use.
     """
     _use_logger(logger=logger)
 
@@ -21,7 +21,7 @@ def use_uwtools_logger(quiet: bool = False, verbose: bool = False) -> None:
     """
     Log to a ``Logger`` configured to follow ``uwtools`` conventions.
 
-    :param quiet: Supress all logging output
-    :param verbose: Log all messages
+    :param quiet: Supress all logging output.
+    :param verbose: Log all messages.
     """
     _setup_logging(quiet=quiet, verbose=verbose)

--- a/src/uwtools/api/rocoto.py
+++ b/src/uwtools/api/rocoto.py
@@ -24,12 +24,10 @@ def realize(
     as input. If no output file is specified, ``stdout`` is written to. Both the input config and
     output Rocoto XML will be validated against appropriate schcemas.
 
-    :param config: Path to YAML input file (``None`` or unspecified => read ``stdin``), or
-        ``YAMLConfig`` object
-    :param output_file: Path to write rendered XML file (``None`` or unspecified => write to
-        ``stdout``)
+    :param config: YAML input file or ``YAMLConfig`` object (``None`` => read ``stdin``).
+    :param output_file: XML output file path (``None`` => write to ``stdout``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True``
+    :return: ``True``.
     """
     _realize(
         config=_ensure_data_source(_str2path(config), stdin_ok), output_file=_str2path(output_file)
@@ -44,8 +42,8 @@ def validate(
     """
     Validate purported Rocoto XML file against its schema.
 
-    :param xml_file: Path to XML file (``None`` or unspecified => read ``stdin``)
+    :param xml_file: Path to XML file (``None`` or unspecified => read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if the XML conforms to the schema, ``False`` otherwise
+    :return: ``True`` if the XML conforms to the schema, ``False`` otherwise.
     """
     return _validate(xml_file=_ensure_data_source(_str2path(xml_file), stdin_ok))

--- a/src/uwtools/api/template.py
+++ b/src/uwtools/api/template.py
@@ -34,20 +34,18 @@ def render(
     primary values source. If no input file is specified, ``stdin`` is read. If no output file is
     specified, ``stdout`` is written to.
 
-    :param values_src: Source of values to render the template
-    :param values_format: Format of values when sourced from file
-    :param input_file: Path to read raw Jinja2 template from (``None`` or unspecified => read
-        ``stdin``)
-    :param output_file: Path to write rendered Jinja2 template to (``None`` or unspecified => write
-        to ``stdout``)
-    :param overrides: Supplemental override values
+    :param values_src: Source of values to render the template.
+    :param values_format: Format of values when sourced from file.
+    :param input_file: Raw input template file (``None`` => read ``stdin``).
+    :param output_file: Rendered template output file (``None`` => write to ``stdout``).
+    :param overrides: Supplemental override values.
     :param env: Supplement values with environment variables?
-    :param searchpath: Paths to search for extra templates
+    :param searchpath: Paths to search for extra templates.
     :param values_needed: Just report variables needed to render the template?
     :param dry_run: Run in dry-run mode?
     :param stdin_ok: OK to read from ``stdin``?
-    :return: The rendered template string
-    :raises: UWTemplateRenderError if template could not be rendered
+    :return: The rendered template string.
+    :raises: UWTemplateRenderError if template could not be rendered.
     """
     result = _render(
         values_src=_str2path(values_src),
@@ -96,12 +94,11 @@ def translate(
     ``stdin`` is read. If no output file is specified, ``stdout`` is written to. In ``dry_run``
     mode, output is written to ``stderr``.
 
-    :param input_file: Path to the template containing atparse syntax (``None`` or unspecified =>
-        read ``stdin``)
-    :param output_file: Path to the file to write the converted template to
+    :param input_file: Path to atparse file (``None`` => read ``stdin``).
+    :param output_file: Path to the file to write the converted template to.
     :param dry_run: Run in dry-run mode?
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True``
+    :return: ``True``.
     """
     _convert_atparse_to_jinja2(
         input_file=_ensure_data_source(_str2path(input_file), stdin_ok),

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -328,10 +328,9 @@ def _add_subparser_file_common(parser: Parser) -> ActionChecks:
 
     :param parser: The parser to configure.
     """
-    required = parser.add_argument_group(TITLE_REQ_ARG)
-    _add_arg_target_dir(required, required=True)
     optional = _basic_setup(parser)
     _add_arg_config_file(optional)
+    _add_arg_target_dir(optional, helpmsg="Root directory for relative destination paths")
     _add_arg_cycle(optional)
     _add_arg_leadtime(optional)
     _add_arg_dry_run(optional)
@@ -803,10 +802,12 @@ def _add_arg_search_path(group: Group) -> None:
     )
 
 
-def _add_arg_target_dir(group: Group, required: bool) -> None:
+def _add_arg_target_dir(
+    group: Group, required: bool = False, helpmsg: Optional[str] = None
+) -> None:
     group.add_argument(
         _switch(STR.targetdir),
-        help="Path to target directory",
+        help=helpmsg or "Path to target directory",
         metavar="PATH",
         required=required,
         type=Path,

--- a/src/uwtools/file.py
+++ b/src/uwtools/file.py
@@ -83,7 +83,7 @@ class FileStager:
             log.debug("Following config key '%s'", key)
             cfg = cfg[key]
         if not isinstance(cfg, dict):
-            raise UWConfigError("No file map found at %s" % " -> ".join(self._keys))
+            raise UWConfigError("No file map found at key path: %s" % " -> ".join(self._keys))
         self._check_dst_paths(cfg)
         return cfg
 

--- a/src/uwtools/file.py
+++ b/src/uwtools/file.py
@@ -98,7 +98,7 @@ class FileStager:
         return True
 
 
-class FileCopier(FileStager):
+class Copier(FileStager):
     """
     Stage files by copying.
     """
@@ -113,7 +113,7 @@ class FileCopier(FileStager):
         yield [filecopy(src=Path(v), dst=dst(k)) for k, v in self._file_map.items()]
 
 
-class FileLinker(FileStager):
+class Linker(FileStager):
     """
     Stage files by linking.
     """

--- a/src/uwtools/file.py
+++ b/src/uwtools/file.py
@@ -23,8 +23,8 @@ class FileStager:
 
     def __init__(
         self,
-        target_dir: Path,
         config: Optional[Union[dict, Path]] = None,
+        target_dir: Optional[Path] = None,
         cycle: Optional[dt.datetime] = None,
         leadtime: Optional[dt.timedelta] = None,
         keys: Optional[list[str]] = None,
@@ -33,12 +33,12 @@ class FileStager:
         """
         Handle files.
 
-        :param target_dir: Path to target directory
         :param config: YAML-file path, or dict (read stdin if missing or None).
+        :param target_dir: Path to target directory.
         :param cycle: A datetime object to make available for use in the config.
         :param leadtime: A timedelta object to make available for use in the config.
-        :param keys: YAML keys leading to file dst/src block
-        :param dry_run: Do not copy files
+        :param keys: YAML keys leading to file dst/src block.
+        :param dry_run: Do not copy files.
         :raises: UWConfigError if config fails validation.
         """
         dryrun(enable=dry_run)
@@ -53,6 +53,19 @@ class FileStager:
             }
         )
         self._validate()
+
+    def _check_dst_paths(self, cfg: dict[str, str]) -> None:
+        """
+        Check that all destination paths are absolute if no target directory is specified.
+
+        :parm cfg: The dst/linkname -> src/target map.
+        :raises: UWConfigError if no target directory is specified and a relative path is.
+        """
+        if not self._target_dir:
+            errmsg = "Relative path '%s' requires the target directory to be specified"
+            for dst in cfg.keys():
+                if not Path(dst).is_absolute():
+                    raise UWConfigError(errmsg % dst)
 
     @cached_property
     def _file_map(self) -> dict:
@@ -71,6 +84,7 @@ class FileStager:
             cfg = cfg[key]
         if not isinstance(cfg, dict):
             raise UWConfigError("No file map found at %s" % " -> ".join(self._keys))
+        self._check_dst_paths(cfg)
         return cfg
 
     def _validate(self) -> bool:
@@ -94,8 +108,9 @@ class FileCopier(FileStager):
         """
         Copy files.
         """
+        dst = lambda k: Path(self._target_dir / k if self._target_dir else k)
         yield "File copies"
-        yield [filecopy(src=Path(v), dst=self._target_dir / k) for k, v in self._file_map.items()]
+        yield [filecopy(src=Path(v), dst=dst(k)) for k, v in self._file_map.items()]
 
 
 class FileLinker(FileStager):
@@ -108,8 +123,6 @@ class FileLinker(FileStager):
         """
         Link files.
         """
+        linkname = lambda k: Path(self._target_dir / k if self._target_dir else k)
         yield "File links"
-        yield [
-            symlink(target=Path(v), linkname=self._target_dir / k)
-            for k, v in self._file_map.items()
-        ]
+        yield [symlink(target=Path(v), linkname=linkname(k)) for k, v in self._file_map.items()]

--- a/src/uwtools/tests/api/test_file.py
+++ b/src/uwtools/tests/api/test_file.py
@@ -2,7 +2,6 @@
 
 import datetime as dt
 from pathlib import Path
-from unittest.mock import patch
 
 from pytest import fixture
 
@@ -10,10 +9,16 @@ from uwtools.api import file
 
 
 @fixture
-def kwargs():
+def kwargs(tmp_path):
+    dstdir, srcdir = tmp_path / "dst", tmp_path / "src"
+    srcfile1, srcfile2 = srcdir / "f1", srcdir / "f2"
+    srcdir.mkdir()
+    for f in [srcfile1, srcfile2]:
+        f.touch()
+    config = {"a": {"b": {str(dstdir / "f1"): str(srcfile1), str(dstdir / "f2"): str(srcfile2)}}}
     return {
-        "target_dir": "/target/dir",
-        "config": "/config/file",
+        "target_dir": dstdir,
+        "config": config,
         "cycle": dt.datetime.now(),
         "leadtime": dt.timedelta(hours=6),
         "keys": ["a", "b"],
@@ -21,19 +26,39 @@ def kwargs():
     }
 
 
-def test_copy(kwargs):
-    with patch.object(file, "_FileCopier") as FileCopier:
-        file.copy(**kwargs)
-    FileCopier.assert_called_once_with(
-        **{**kwargs, "target_dir": Path(kwargs["target_dir"]), "config": Path(kwargs["config"])}
-    )
-    FileCopier().go.assert_called_once_with()
+def test_copy_fail(kwargs):
+    paths = kwargs["config"]["a"]["b"]
+    for p in paths:
+        assert not Path(p).exists()
+    Path(list(paths.values())[0]).unlink()
+    assert file.copy(**kwargs) is False
+    assert not Path(list(paths.keys())[0]).exists()
+    assert Path(list(paths.keys())[1]).is_file()
 
 
-def test_link(kwargs):
-    with patch.object(file, "_FileLinker") as FileLinker:
-        file.link(**kwargs)
-    FileLinker.assert_called_once_with(
-        **{**kwargs, "target_dir": Path(kwargs["target_dir"]), "config": Path(kwargs["config"])}
-    )
-    FileLinker().go.assert_called_once_with()
+def test_copy_pass(kwargs):
+    paths = kwargs["config"]["a"]["b"]
+    for p in paths:
+        assert not Path(p).exists()
+    assert file.copy(**kwargs) is True
+    for p in paths:
+        assert Path(p).is_file()
+
+
+def test_link_fail(kwargs):
+    paths = kwargs["config"]["a"]["b"]
+    for p in paths:
+        assert not Path(p).exists()
+    Path(list(paths.values())[0]).unlink()
+    assert file.link(**kwargs) is False
+    assert not Path(list(paths.keys())[0]).exists()
+    assert Path(list(paths.keys())[1]).is_symlink()
+
+
+def test_link_pass(kwargs):
+    paths = kwargs["config"]["a"]["b"]
+    for p in paths:
+        assert not Path(p).exists()
+    assert file.link(**kwargs) is True
+    for p in paths:
+        assert Path(p).is_symlink()

--- a/src/uwtools/tests/test_file.py
+++ b/src/uwtools/tests/test_file.py
@@ -26,49 +26,49 @@ def assets(tmp_path):
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_FileCopier(assets, source):
+def test_Copier(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    file.FileCopier(target_dir=dstdir, config=config, keys=["a", "b"]).go()
+    file.Copier(target_dir=dstdir, config=config, keys=["a", "b"]).go()
     assert (dstdir / "foo").is_file()
     assert (dstdir / "subdir" / "bar").is_file()
 
 
-def test_FileCopier_config_file_dry_run(assets):
+def test_Copier_config_file_dry_run(assets):
     dstdir, cfgdict, _ = assets
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    file.FileCopier(target_dir=dstdir, config=cfgdict, keys=["a", "b"], dry_run=True).go()
+    file.Copier(target_dir=dstdir, config=cfgdict, keys=["a", "b"], dry_run=True).go()
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
     iotaa.dryrun(False)
 
 
-def test_FileCopier_no_targetdir_abspath_pass(assets):
+def test_Copier_no_targetdir_abspath_pass(assets):
     dstdir, cfgdict, _ = assets
     old = cfgdict["a"]["b"]
     cfgdict = {str(dstdir / "foo"): old["foo"], str(dstdir / "bar"): old["subdir/bar"]}
-    assets = file.FileCopier(config=cfgdict).go()
+    assets = file.Copier(config=cfgdict).go()
     assert all(asset.ready() for asset in assets)  # type: ignore
 
 
-def test_FileCopier_no_targetdir_relpath_fail(assets):
+def test_Copier_no_targetdir_relpath_fail(assets):
     _, cfgdict, _ = assets
     with raises(UWConfigError) as e:
-        file.FileCopier(config=cfgdict, keys=["a", "b"]).go()
+        file.Copier(config=cfgdict, keys=["a", "b"]).go()
     errmsg = "Relative path '%s' requires the target directory to be specified"
     assert errmsg % "foo" in str(e.value)
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_FileLinker(assets, source):
+def test_Linker(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    file.FileLinker(target_dir=dstdir, config=config, keys=["a", "b"]).go()
+    file.Linker(target_dir=dstdir, config=config, keys=["a", "b"]).go()
     assert (dstdir / "foo").is_symlink()
     assert (dstdir / "subdir" / "bar").is_symlink()
 

--- a/src/uwtools/tests/test_file.py
+++ b/src/uwtools/tests/test_file.py
@@ -31,8 +31,7 @@ def test_FileCopier(assets, source):
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    stager = file.FileCopier(target_dir=dstdir, config=config, keys=["a", "b"])
-    stager.go()
+    file.FileCopier(target_dir=dstdir, config=config, keys=["a", "b"]).go()
     assert (dstdir / "foo").is_file()
     assert (dstdir / "subdir" / "bar").is_file()
 
@@ -41,11 +40,26 @@ def test_FileCopier_config_file_dry_run(assets):
     dstdir, cfgdict, _ = assets
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    stager = file.FileCopier(target_dir=dstdir, config=cfgdict, keys=["a", "b"], dry_run=True)
-    stager.go()
+    file.FileCopier(target_dir=dstdir, config=cfgdict, keys=["a", "b"], dry_run=True).go()
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
     iotaa.dryrun(False)
+
+
+def test_FileCopier_no_targetdir_abspath_pass(assets):
+    dstdir, cfgdict, _ = assets
+    old = cfgdict["a"]["b"]
+    cfgdict = {str(dstdir / "foo"): old["foo"], str(dstdir / "bar"): old["subdir/bar"]}
+    assets = file.FileCopier(config=cfgdict).go()
+    assert all(asset.ready() for asset in assets)  # type: ignore
+
+
+def test_FileCopier_no_targetdir_relpath_fail(assets):
+    _, cfgdict, _ = assets
+    with raises(UWConfigError) as e:
+        file.FileCopier(config=cfgdict, keys=["a", "b"]).go()
+    errmsg = "Relative path '%s' requires the target directory to be specified"
+    assert errmsg % "foo" in str(e.value)
 
 
 @mark.parametrize("source", ("dict", "file"))
@@ -54,8 +68,7 @@ def test_FileLinker(assets, source):
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    stager = file.FileLinker(target_dir=dstdir, config=config, keys=["a", "b"])
-    stager.go()
+    file.FileLinker(target_dir=dstdir, config=config, keys=["a", "b"]).go()
     assert (dstdir / "foo").is_symlink()
     assert (dstdir / "subdir" / "bar").is_symlink()
 

--- a/src/uwtools/tests/test_file.py
+++ b/src/uwtools/tests/test_file.py
@@ -97,4 +97,4 @@ def test_FileStager_empty_val(assets, val):
     cfgdict["a"]["b"] = val
     with raises(UWConfigError) as e:
         file.FileStager(target_dir=dstdir, config=cfgdict, keys=["a", "b"])
-    assert str(e.value) == "No file map found at a -> b"
+    assert str(e.value) == "No file map found at key path: a -> b"


### PR DESCRIPTION
**Synopsis**

1. Return a more useful value from the `file` tool API functions: `True` when all the assets (file copies or links) requested are ready, `False` otherwise.
2. Make the `--target-dir` CLI option / `target_dir` API argument optional, but demand that it be set when any destination path is relative.
3. Expose the `FileCopier` and `FileLinker` classes via the API, in the same way that driver classes are now exposed, so that they can be used in higher-level workflows.
4. Rename `FileCopier` -> `Copier`, `FileLinker` -> `Linker`. It feels silly to `from uwtools.api import file` and then write `file.FileCopier`: `file.Copier` feels better.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
