### PR TITLE
Accept str values for config, target_dir in file tool

### DIFF
--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -23,7 +23,7 @@ lint() {
   msg Running linter
   (
     set -eux
-    pylint -j 4 .
+    pylint -j 4 setup.py uwtools
   )
   msg OK
 }

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -23,7 +23,7 @@ lint() {
   msg Running linter
   (
     set -eux
-    pylint -j 4 setup.py uwtools
+    pylint -j 4 .
   )
   msg OK
 }

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -23,7 +23,7 @@ lint() {
   msg Running linter
   (
     set -eux
-    pylint -j 4 .
+    pylint -j 1 .
   )
   msg OK
 }

--- a/src/uwtools/api/file.py
+++ b/src/uwtools/api/file.py
@@ -10,7 +10,6 @@ from iotaa import Asset
 
 from uwtools.file import Copier, Linker
 from uwtools.utils.api import ensure_data_source as _ensure_data_source
-from uwtools.utils.api import str2path as _str2path
 
 
 def copy(
@@ -36,7 +35,7 @@ def copy(
     """
     copier = Copier(
         target_dir=Path(target_dir) if target_dir else None,
-        config=_ensure_data_source(_str2path(config), stdin_ok),
+        config=_ensure_data_source(config, stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
         keys=keys,
@@ -69,7 +68,7 @@ def link(
     """
     linker = Linker(
         target_dir=Path(target_dir) if target_dir else None,
-        config=_ensure_data_source(_str2path(config), stdin_ok),
+        config=_ensure_data_source(config, stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
         keys=keys,

--- a/src/uwtools/file.py
+++ b/src/uwtools/file.py
@@ -13,10 +13,11 @@ from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.validator import validate_internal
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
+from uwtools.utils.api import str2path
 from uwtools.utils.tasks import filecopy, symlink
 
 
-class FileStager:
+class Stager:
     """
     The base class for staging files.
     """
@@ -24,7 +25,7 @@ class FileStager:
     def __init__(
         self,
         config: Optional[Union[dict, Path]] = None,
-        target_dir: Optional[Path] = None,
+        target_dir: Optional[Union[str, Path]] = None,
         cycle: Optional[dt.datetime] = None,
         leadtime: Optional[dt.timedelta] = None,
         keys: Optional[list[str]] = None,
@@ -42,7 +43,7 @@ class FileStager:
         :raises: UWConfigError if config fails validation.
         """
         dryrun(enable=dry_run)
-        self._target_dir = target_dir
+        self._target_dir = str2path(target_dir)
         self._config = YAMLConfig(config=config)
         self._keys = keys or []
         self._config.dereference(
@@ -98,7 +99,7 @@ class FileStager:
         return True
 
 
-class Copier(FileStager):
+class Copier(Stager):
     """
     Stage files by copying.
     """
@@ -113,7 +114,7 @@ class Copier(FileStager):
         yield [filecopy(src=Path(v), dst=dst(k)) for k, v in self._file_map.items()]
 
 
-class Linker(FileStager):
+class Linker(Stager):
     """
     Stage files by linking.
     """

--- a/src/uwtools/file.py
+++ b/src/uwtools/file.py
@@ -24,7 +24,7 @@ class Stager:
 
     def __init__(
         self,
-        config: Optional[Union[dict, Path]] = None,
+        config: Optional[Union[dict, str, Path]] = None,
         target_dir: Optional[Union[str, Path]] = None,
         cycle: Optional[dt.datetime] = None,
         leadtime: Optional[dt.timedelta] = None,
@@ -44,7 +44,7 @@ class Stager:
         """
         dryrun(enable=dry_run)
         self._target_dir = str2path(target_dir)
-        self._config = YAMLConfig(config=config)
+        self._config = YAMLConfig(config=str2path(config))
         self._keys = keys or []
         self._config.dereference(
             context={

--- a/src/uwtools/tests/test_file.py
+++ b/src/uwtools/tests/test_file.py
@@ -74,27 +74,27 @@ def test_Linker(assets, source):
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_FileStager(assets, source):
+def test_Stager(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
-    stager = file.FileStager(target_dir=dstdir, config=config, keys=["a", "b"])
+    stager = file.Stager(target_dir=dstdir, config=config, keys=["a", "b"])
     assert set(stager._file_map.keys()) == {"foo", "subdir/bar"}
     assert stager._validate() is True
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_FileStager_bad_key(assets, source):
+def test_Stager_bad_key(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     with raises(UWConfigError) as e:
-        file.FileStager(target_dir=dstdir, config=config, keys=["a", "x"])
+        file.Stager(target_dir=dstdir, config=config, keys=["a", "x"])
     assert str(e.value) == "Failed following YAML key(s): a -> x"
 
 
 @mark.parametrize("val", [None, True, False, "str", 88, 3.14, [], tuple()])
-def test_FileStager_empty_val(assets, val):
+def test_Stager_empty_val(assets, val):
     dstdir, cfgdict, _ = assets
     cfgdict["a"]["b"] = val
     with raises(UWConfigError) as e:
-        file.FileStager(target_dir=dstdir, config=cfgdict, keys=["a", "b"])
+        file.Stager(target_dir=dstdir, config=cfgdict, keys=["a", "b"])
     assert str(e.value) == "No file map found at key path: a -> b"


### PR DESCRIPTION
**Synopsis**

1. In addition to the `copy()` and `link()` convenience functions we provide via `uwtools.api.file`, we now also provide direct access to the `Copier` and `Linker` objects, so that external drivers can instantiate them and use their tasks directly, e.g. `yield`ing them as dependency tasks in their own `iotaa` tasks. We already ensured that `str` values provided by users in `copy()` or `link()` calls are converted to the `Path` objects expected by `Copier` and `Linker`. But it will be convenient for users to be able to provide `str` values when they directly call the constructors of those classes. So, the necessary conversions are added.
2. We previously renamed `FileCopier` -> `Copier` (and similarly `FileLinker` -> `Linker`) to avoid the awkward repetition in e.g. `uwtools.file.FileLinker`. `FileStager` -> `Stager` is added here.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
