### PR TITLE
Make schema file optional for execute mode

### DIFF
--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -30,7 +30,7 @@ def execute(
     module: Union[Path, str],
     classname: str,
     task: str,
-    schema_file: str,
+    schema_file: Optional[str] = None,
     config: Optional[Union[Path, str]] = None,
     cycle: Optional[datetime] = None,  # pylint: disable=unused-argument
     leadtime: Optional[timedelta] = None,  # pylint: disable=unused-argument
@@ -69,7 +69,7 @@ def execute(
         config=ensure_data_source(config, bool(stdin_ok)),
         dry_run=dry_run,
         key_path=key_path,
-        schema_file=schema_file,
+        schema_file=schema_file or Path(module).with_suffix(".jsonschema"),
     )
     for arg in sorted(non_optional):
         if arg in accepted and locals()[arg] is None:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -177,7 +177,7 @@ def _add_subparser_config_validate(subparsers: Subparsers) -> ActionChecks:
     """
     parser = _add_subparser(subparsers, STR.validate, "Validate config")
     required = parser.add_argument_group(TITLE_REQ_ARG)
-    _add_arg_schema_file(required)
+    _add_arg_schema_file(required, required=True)
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
     return _add_args_verbosity(optional)
@@ -266,9 +266,9 @@ def _add_subparser_execute(subparsers: Subparsers) -> ModeChecks:
     _add_arg_module(required)
     _add_arg_classname(required)
     _add_arg_task(required)
-    _add_arg_schema_file(required)
     optional = _basic_setup(parser)
     _add_arg_config_file(optional)
+    _add_arg_schema_file(optional)
     _add_arg_cycle(optional)
     _add_arg_leadtime(optional)
     _add_arg_batch(optional)
@@ -780,12 +780,12 @@ def _add_arg_quiet(group: Group) -> None:
     )
 
 
-def _add_arg_schema_file(group: Group) -> None:
+def _add_arg_schema_file(group: Group, required: bool = False) -> None:
     group.add_argument(
         _switch(STR.schemafile),
         help="Path to schema file to use for validation",
         metavar="PATH",
-        required=True,
+        required=required,
         type=Path,
     )
 

--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -73,7 +73,10 @@ def test_execute_fail_stdin_not_ok(kwargs):
     assert str(e.value) == "Set stdin_ok=True to permit read from stdin"
 
 
-def test_execute_pass(caplog, kwargs, tmp_path):
+@mark.parametrize("remove", ([], ["schema_file"]))
+def test_execute_pass(caplog, kwargs, remove, tmp_path):
+    for kwarg in remove:
+        del kwargs[kwarg]
     kwargs["cycle"] = dt.datetime.now()
     log.setLevel(logging.DEBUG)
     graph_file = tmp_path / "g.dot"


### PR DESCRIPTION
**Synopsis**

As a user convenience, make the `uw execute` `--schema-file` flag (and its API `schema_file` counterpart) optional, favoring the convention that an external driver module `d.py` will have a sibling `d.jsonschema` file available. This removes one argument from what is already a long `uw` invocation. For example:
```
uw execute --module coastal.py --classname Coastal --task run --config coastal.yaml --cycle 2024-08-05T12 --schema-file coastal.jsonschema
```
becomes
```
uw execute --module coastal.py --classname Coastal --task run --config coastal.yaml --cycle 2024-08-05T12
```
`--schema-file` / `schema_file` can still be used to specify schema files in other locations.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
