### PR TITLE
Updates for Coastal App coupled driver

### DIFF
--- a/src/uwtools/api/cdeps.py
+++ b/src/uwtools/api/cdeps.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = CDEPS
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["CDEPS", "execute", "graph", "tasks"]

--- a/src/uwtools/api/chgres_cube.py
+++ b/src/uwtools/api/chgres_cube.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = ChgresCube
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["ChgresCube", "execute", "graph", "tasks"]

--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -152,18 +152,15 @@ def _get_driver_module_implicit(module: str) -> Optional[ModuleType]:
 
 
 __all__ = [
-    getattr(x, "__name__")
-    for x in (
-        Assets,
-        AssetsCycleBased,
-        AssetsCycleLeadtimeBased,
-        AssetsTimeInvariant,
-        Driver,
-        DriverCycleBased,
-        DriverCycleLeadtimeBased,
-        DriverTimeInvariant,
-        execute,
-        graph,
-        tasks,
-    )
+    "Assets",
+    "AssetsCycleBased",
+    "AssetsCycleLeadtimeBased",
+    "AssetsTimeInvariant",
+    "Driver",
+    "DriverCycleBased",
+    "DriverCycleLeadtimeBased",
+    "DriverTimeInvariant",
+    "execute",
+    "graph",
+    "tasks",
 ]

--- a/src/uwtools/api/esg_grid.py
+++ b/src/uwtools/api/esg_grid.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = ESGGrid
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["ESGGrid", "execute", "graph", "tasks"]

--- a/src/uwtools/api/filter_topo.py
+++ b/src/uwtools/api/filter_topo.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = FilterTopo
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["FilterTopo", "execute", "graph", "tasks"]

--- a/src/uwtools/api/fv3.py
+++ b/src/uwtools/api/fv3.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = FV3
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["FV3", "execute", "graph", "tasks"]

--- a/src/uwtools/api/global_equiv_resol.py
+++ b/src/uwtools/api/global_equiv_resol.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = GlobalEquivResol
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["GlobalEquivResol", "execute", "graph", "tasks"]

--- a/src/uwtools/api/ioda.py
+++ b/src/uwtools/api/ioda.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = IODA
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["IODA", "execute", "graph", "tasks"]

--- a/src/uwtools/api/jedi.py
+++ b/src/uwtools/api/jedi.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = JEDI
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["JEDI", "execute", "graph", "tasks"]

--- a/src/uwtools/api/make_hgrid.py
+++ b/src/uwtools/api/make_hgrid.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = MakeHgrid
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["MakeHgrid", "execute", "graph", "tasks"]

--- a/src/uwtools/api/make_solo_mosaic.py
+++ b/src/uwtools/api/make_solo_mosaic.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = MakeSoloMosaic
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["MakeSoloMosaic", "execute", "graph", "tasks"]

--- a/src/uwtools/api/mpas.py
+++ b/src/uwtools/api/mpas.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = MPAS
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["MPAS", "execute", "graph", "tasks"]

--- a/src/uwtools/api/mpas_init.py
+++ b/src/uwtools/api/mpas_init.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = MPASInit
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["MPASInit", "execute", "graph", "tasks"]

--- a/src/uwtools/api/orog_gsl.py
+++ b/src/uwtools/api/orog_gsl.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = OrogGSL
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["OrogGSL", "execute", "graph", "tasks"]

--- a/src/uwtools/api/schism.py
+++ b/src/uwtools/api/schism.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = SCHISM
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["SCHISM", "execute", "graph", "tasks"]

--- a/src/uwtools/api/sfc_climo_gen.py
+++ b/src/uwtools/api/sfc_climo_gen.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = SfcClimoGen
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["SfcClimoGen", "execute", "graph", "tasks"]

--- a/src/uwtools/api/shave.py
+++ b/src/uwtools/api/shave.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = Shave
 execute = _make_execute(_driver)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["Shave", "execute", "graph", "tasks"]

--- a/src/uwtools/api/ungrib.py
+++ b/src/uwtools/api/ungrib.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = Ungrib
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["Ungrib", "execute", "graph", "tasks"]

--- a/src/uwtools/api/upp.py
+++ b/src/uwtools/api/upp.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = UPP
 execute = _make_execute(_driver, with_cycle=True, with_leadtime=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["UPP", "execute", "graph", "tasks"]

--- a/src/uwtools/api/ww3.py
+++ b/src/uwtools/api/ww3.py
@@ -11,4 +11,4 @@ from uwtools.utils.api import make_execute as _make_execute
 _driver = WaveWatchIII
 execute = _make_execute(_driver, with_cycle=True)
 tasks = partial(tasks, _driver)
-__all__ = [_driver.__name__, "execute", "graph", "tasks"]
+__all__ = ["WaveWatchIII", "execute", "graph", "tasks"]

--- a/src/uwtools/drivers/cdeps.py
+++ b/src/uwtools/drivers/cdeps.py
@@ -26,7 +26,7 @@ class CDEPS(AssetsCycleBased):
         """
         Create data atmosphere configuration with all required content.
         """
-        yield self._taskname("data atmosphere configuration")
+        yield self.taskname("data atmosphere configuration")
         yield [
             self.atm_nml(),
             self.atm_stream(),
@@ -38,7 +38,7 @@ class CDEPS(AssetsCycleBased):
         Create data atmosphere Fortran namelist file (datm_in).
         """
         fn = "datm_in"
-        yield self._taskname(f"namelist file {fn}")
+        yield self.taskname(f"namelist file {fn}")
         path = self.rundir / fn
         yield asset(path, path.is_file)
         yield None
@@ -50,7 +50,7 @@ class CDEPS(AssetsCycleBased):
         Create data atmosphere stream config file (datm.streams).
         """
         fn = "datm.streams"
-        yield self._taskname(f"stream file {fn}")
+        yield self.taskname(f"stream file {fn}")
         path = self.rundir / fn
         yield asset(path, path.is_file)
         template_file = self.config["atm_streams"]["template_file"]
@@ -62,7 +62,7 @@ class CDEPS(AssetsCycleBased):
         """
         Create data ocean configuration with all required content.
         """
-        yield self._taskname("data atmosphere configuration")
+        yield self.taskname("data atmosphere configuration")
         yield [
             self.ocn_nml(),
             self.ocn_stream(),
@@ -74,7 +74,7 @@ class CDEPS(AssetsCycleBased):
         Create data ocean Fortran namelist file (docn_in).
         """
         fn = "docn_in"
-        yield self._taskname(f"namelist file {fn}")
+        yield self.taskname(f"namelist file {fn}")
         path = self.rundir / fn
         yield asset(path, path.is_file)
         yield None
@@ -86,7 +86,7 @@ class CDEPS(AssetsCycleBased):
         Create data ocean stream config file (docn.streams).
         """
         fn = "docn.streams"
-        yield self._taskname(f"stream file {fn}")
+        yield self.taskname(f"stream file {fn}")
         path = self.rundir / fn
         yield asset(path, path.is_file)
         template_file = self.config["ocn_streams"]["template_file"]

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -26,7 +26,7 @@ class ChgresCube(DriverCycleBased):
         The namelist file.
         """
         fn = "fort.41"
-        yield self._taskname(f"namelist file {fn}")
+        yield self.taskname(f"namelist file {fn}")
         path = self.rundir / fn
         yield asset(path, path.is_file)
         input_files = []
@@ -67,7 +67,7 @@ class ChgresCube(DriverCycleBased):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.namelist_file(),
             self.runscript(),
@@ -79,7 +79,7 @@ class ChgresCube(DriverCycleBased):
         The runscript.
         """
         path = self._runscript_path
-        yield self._taskname(path.name)
+        yield self.taskname(path.name)
         yield asset(path, path.is_file)
         yield None
         envvars = {

--- a/src/uwtools/drivers/esg_grid.py
+++ b/src/uwtools/drivers/esg_grid.py
@@ -26,7 +26,7 @@ class ESGGrid(DriverTimeInvariant):
         The namelist file.
         """
         fn = "regional_grid.nml"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         base_file = self.config[STR.namelist].get(STR.basefile)
@@ -43,7 +43,7 @@ class ESGGrid(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.namelist_file(),
             self.runscript(),

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -27,7 +27,7 @@ class FilterTopo(DriverTimeInvariant):
         """
         src = Path(self.config["config"]["input_grid_file"])
         dst = Path(self.config[STR.rundir], src.name)
-        yield self._taskname("Input grid")
+        yield self.taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)
 
@@ -38,7 +38,7 @@ class FilterTopo(DriverTimeInvariant):
         """
         fn = "input.nml"
         path = self.rundir / fn
-        yield self._taskname(f"namelist file {fn}")
+        yield self.taskname(f"namelist file {fn}")
         yield asset(path, path.is_file)
         yield None
         self._create_user_updated_config(
@@ -53,7 +53,7 @@ class FilterTopo(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.input_grid_file(),
             self.namelist_file(),

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -28,7 +28,7 @@ class FV3(DriverCycleBased):
         """
         Lateral boundary-condition files.
         """
-        yield self._taskname("lateral boundary-condition files")
+        yield self.taskname("lateral boundary-condition files")
         lbcs = self.config["lateral_boundary_conditions"]
         offset = abs(lbcs["offset"])
         endhour = self.config["length"] + offset + 1
@@ -49,7 +49,7 @@ class FV3(DriverCycleBased):
         The diag_table file.
         """
         fn = "diag_table"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         yield None
@@ -65,7 +65,7 @@ class FV3(DriverCycleBased):
         The field_table file.
         """
         fn = "field_table"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         yield filecopy(src=Path(self.config["field_table"][STR.basefile]), dst=path)
@@ -75,7 +75,7 @@ class FV3(DriverCycleBased):
         """
         Files copied for run.
         """
-        yield self._taskname("files copied")
+        yield self.taskname("files copied")
         yield [
             filecopy(src=Path(src), dst=self.rundir / dst)
             for dst, src in self.config.get("files_to_copy", {}).items()
@@ -86,7 +86,7 @@ class FV3(DriverCycleBased):
         """
         Files linked for run.
         """
-        yield self._taskname("files linked")
+        yield self.taskname("files linked")
         yield [
             symlink(target=Path(target), linkname=self.rundir / linkname)
             for linkname, target in self.config.get("files_to_link", {}).items()
@@ -98,7 +98,7 @@ class FV3(DriverCycleBased):
         The model_configure file.
         """
         fn = "model_configure"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         base_file = self.config["model_configure"].get(STR.basefile)
@@ -115,7 +115,7 @@ class FV3(DriverCycleBased):
         The namelist file.
         """
         fn = "input.nml"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         base_file = self.config[STR.namelist].get(STR.basefile)
@@ -132,7 +132,7 @@ class FV3(DriverCycleBased):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         required = [
             self.diag_table(),
             self.field_table(),
@@ -152,7 +152,7 @@ class FV3(DriverCycleBased):
         """
         The RESTART directory.
         """
-        yield self._taskname("RESTART directory")
+        yield self.taskname("RESTART directory")
         path = self.rundir / "RESTART"
         yield asset(path, path.is_dir)
         yield None
@@ -164,7 +164,7 @@ class FV3(DriverCycleBased):
         The runscript.
         """
         path = self._runscript_path
-        yield self._taskname(path.name)
+        yield self.taskname(path.name)
         yield asset(path, path.is_file)
         yield None
         envvars = {

--- a/src/uwtools/drivers/global_equiv_resol.py
+++ b/src/uwtools/drivers/global_equiv_resol.py
@@ -24,7 +24,7 @@ class GlobalEquivResol(DriverTimeInvariant):
         Ensure the specified input grid file exists.
         """
         path = Path(self.config["input_grid_file"])
-        yield self._taskname(path.name)
+        yield self.taskname(path.name)
         yield asset(path, path.is_file)
 
     @tasks
@@ -32,7 +32,7 @@ class GlobalEquivResol(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.input_file(),
             self.runscript(),

--- a/src/uwtools/drivers/ioda.py
+++ b/src/uwtools/drivers/ioda.py
@@ -21,7 +21,7 @@ class IODA(JEDIBase):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.configuration_file(),
             self.files_copied(),

--- a/src/uwtools/drivers/jedi.py
+++ b/src/uwtools/drivers/jedi.py
@@ -25,7 +25,7 @@ class JEDI(JEDIBase):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.configuration_file(),
             self.files_copied(),
@@ -39,7 +39,7 @@ class JEDI(JEDIBase):
         """
         Validate JEDI config YAML.
         """
-        taskname = self._taskname("validate_only")
+        taskname = self.taskname("validate_only")
         yield taskname
         a = asset(None, lambda: False)
         yield a

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -26,7 +26,7 @@ class JEDIBase(DriverCycleBased):
         The executable's YAML configuration file.
         """
         fn = self._config_fn
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         base_file = self.config["configuration_file"].get(STR.basefile)
@@ -42,7 +42,7 @@ class JEDIBase(DriverCycleBased):
         """
         Files copied for run.
         """
-        yield self._taskname("files copied")
+        yield self.taskname("files copied")
         yield [
             filecopy(src=Path(src), dst=self.rundir / dst)
             for dst, src in self.config.get("files_to_copy", {}).items()
@@ -53,7 +53,7 @@ class JEDIBase(DriverCycleBased):
         """
         Files linked for run.
         """
-        yield self._taskname("files linked")
+        yield self.taskname("files linked")
         yield [
             symlink(target=Path(target), linkname=self.rundir / linkname)
             for linkname, target in self.config.get("files_to_link", {}).items()

--- a/src/uwtools/drivers/make_hgrid.py
+++ b/src/uwtools/drivers/make_hgrid.py
@@ -21,7 +21,7 @@ class MakeHgrid(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield self.runscript()
 
     # Private helper methods

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -21,8 +21,18 @@ class MakeSoloMosaic(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield self.runscript()
+
+    # Public helper methods
+
+    def taskname(self, suffix: str) -> str:
+        """
+        Returns a common tag for graph-task log messages.
+
+        :param suffix: Log-string suffix.
+        """
+        return "%s %s" % (self._driver_name, suffix)
 
     # Private helper methods
 
@@ -41,14 +51,6 @@ class MakeSoloMosaic(DriverTimeInvariant):
         executable = self.config[STR.execution][STR.executable]
         flags = " ".join(f"--{k} {v}" for k, v in self.config["config"].items())
         return f"{executable} {flags}"
-
-    def _taskname(self, suffix: str) -> str:
-        """
-        Returns a common tag for graph-task log messages.
-
-        :param suffix: Log-string suffix.
-        """
-        return "%s %s" % (self._driver_name, suffix)
 
 
 set_driver_docstring(MakeSoloMosaic)

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -26,7 +26,7 @@ class MPAS(MPASBase):
         """
         Boundary files.
         """
-        yield self._taskname("boundary files")
+        yield self.taskname("boundary files")
         lbcs = self.config["lateral_boundary_conditions"]
         endhour = self.config["length"]
         interval = lbcs["interval_hours"]
@@ -44,7 +44,7 @@ class MPAS(MPASBase):
         The namelist file.
         """
         path = self.rundir / "namelist.atmosphere"
-        yield self._taskname(str(path))
+        yield self.taskname(str(path))
         yield asset(path, path.is_file)
         base_file = self.config[STR.namelist].get(STR.basefile)
         yield file(Path(base_file)) if base_file else None

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -32,7 +32,7 @@ class MPASBase(DriverCycleBased):
         """
         Files copied for run.
         """
-        yield self._taskname("files copied")
+        yield self.taskname("files copied")
         yield [
             filecopy(src=Path(src), dst=self.rundir / dst)
             for dst, src in self.config.get("files_to_copy", {}).items()
@@ -43,7 +43,7 @@ class MPASBase(DriverCycleBased):
         """
         Files linked for run.
         """
-        yield self._taskname("files linked")
+        yield self.taskname("files linked")
         yield [
             symlink(target=Path(target), linkname=self.rundir / linkname)
             for linkname, target in self.config.get("files_to_link", {}).items()
@@ -61,7 +61,7 @@ class MPASBase(DriverCycleBased):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.boundary_files(),
             self.files_copied(),
@@ -77,7 +77,7 @@ class MPASBase(DriverCycleBased):
         The streams file.
         """
         fn = self._streams_fn
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         yield None

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -26,7 +26,7 @@ class MPASInit(MPASBase):
         """
         Boundary files.
         """
-        yield self._taskname("boundary files")
+        yield self.taskname("boundary files")
         lbcs = self.config["boundary_conditions"]
         endhour = lbcs["length"]
         interval = lbcs["interval_hours"]
@@ -46,7 +46,7 @@ class MPASInit(MPASBase):
         The namelist file.
         """
         fn = "namelist.init_atmosphere"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         base_file = self.config[STR.namelist].get(STR.basefile)

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -29,7 +29,7 @@ class OrogGSL(DriverTimeInvariant):
         )
         src = Path(self.config["config"]["input_grid_file"])
         dst = Path(self.config[STR.rundir], fn)
-        yield self._taskname("Input grid")
+        yield self.taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)
 
@@ -38,7 +38,7 @@ class OrogGSL(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.input_grid_file(),
             self.runscript(),
@@ -54,7 +54,7 @@ class OrogGSL(DriverTimeInvariant):
         fn = "geo_em.d01.lat-lon.2.5m.HGT_M.nc"
         src = Path(self.config["config"]["topo_data_2p5m"])
         dst = Path(self.config[STR.rundir], fn)
-        yield self._taskname("Input grid")
+        yield self.taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)
 
@@ -66,7 +66,7 @@ class OrogGSL(DriverTimeInvariant):
         fn = "HGT.Beljaars_filtered.lat-lon.30s_res.nc"
         src = Path(self.config["config"]["topo_data_30s"])
         dst = Path(self.config[STR.rundir], fn)
-        yield self._taskname("Input grid")
+        yield self.taskname("Input grid")
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)
 

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -26,7 +26,7 @@ class SCHISM(AssetsCycleBased):
         Render the namelist from the template file.
         """
         fn = "param.nml"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         template_file = Path(self.config[STR.namelist]["template_file"])
@@ -42,7 +42,7 @@ class SCHISM(AssetsCycleBased):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield self.namelist_file()
 
     # Private helper methods

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -26,7 +26,7 @@ class SfcClimoGen(DriverTimeInvariant):
         The namelist file.
         """
         fn = "fort.41"
-        yield self._taskname(f"namelist file {fn}")
+        yield self.taskname(f"namelist file {fn}")
         path = self.rundir / fn
         yield asset(path, path.is_file)
         vals = self.config[STR.namelist][STR.updatevalues]["config"]
@@ -46,7 +46,7 @@ class SfcClimoGen(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.namelist_file(),
             self.runscript(),

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -21,7 +21,7 @@ class Shave(DriverTimeInvariant):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield self.runscript()
 
     # Private helper methods

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -26,7 +26,7 @@ class Ungrib(DriverCycleBased):
         """
         Symlinks to all the GRIB files.
         """
-        yield self._taskname("GRIB files")
+        yield self.taskname("GRIB files")
         gfs_files = self.config["gfs_files"]
         offset = abs(gfs_files["offset"])
         endhour = gfs_files["forecast_length"] + offset
@@ -67,7 +67,7 @@ class Ungrib(DriverCycleBased):
             }
         }
         path = self.rundir / "namelist.wps"
-        yield self._taskname(str(path))
+        yield self.taskname(str(path))
         yield asset(path, path.is_file)
         yield None
         self._create_user_updated_config(
@@ -81,7 +81,7 @@ class Ungrib(DriverCycleBased):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.gribfiles(),
             self.namelist_file(),
@@ -95,7 +95,7 @@ class Ungrib(DriverCycleBased):
         A symlink to the Vtable file.
         """
         path = self.rundir / "Vtable"
-        yield self._taskname(str(path))
+        yield self.taskname(str(path))
         yield asset(path, path.is_symlink)
         infile = Path(self.config["vtable"])
         yield file(path=infile)
@@ -119,7 +119,7 @@ class Ungrib(DriverCycleBased):
         :param link: Link name.
         :param infile: File to link.
         """
-        yield self._taskname(str(link))
+        yield self.taskname(str(link))
         yield asset(link, link.is_symlink)
         yield file(path=infile)
         link.parent.mkdir(parents=True, exist_ok=True)

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -25,7 +25,7 @@ class UPP(DriverCycleLeadtimeBased):
         """
         Files copied for run.
         """
-        yield self._taskname("files copied")
+        yield self.taskname("files copied")
         yield [
             filecopy(src=Path(src), dst=self.rundir / dst)
             for dst, src in self.config.get("files_to_copy", {}).items()
@@ -36,7 +36,7 @@ class UPP(DriverCycleLeadtimeBased):
         """
         Files linked for run.
         """
-        yield self._taskname("files linked")
+        yield self.taskname("files linked")
         yield [
             symlink(target=Path(target), linkname=self.rundir / linkname)
             for linkname, target in self.config.get("files_to_link", {}).items()
@@ -48,7 +48,7 @@ class UPP(DriverCycleLeadtimeBased):
         The namelist file.
         """
         path = self._namelist_path
-        yield self._taskname(str(path))
+        yield self.taskname(str(path))
         yield asset(path, path.is_file)
         base_file = self.config[STR.namelist].get(STR.basefile)
         yield file(Path(base_file)) if base_file else None
@@ -64,7 +64,7 @@ class UPP(DriverCycleLeadtimeBased):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.files_copied(),
             self.files_linked(),

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -26,7 +26,7 @@ class WaveWatchIII(AssetsCycleBased):
         Render the namelist from the template file.
         """
         fn = "ww3_shel.nml"
-        yield self._taskname(fn)
+        yield self.taskname(fn)
         path = self.rundir / fn
         yield asset(path, path.is_file)
         template_file = Path(self.config[STR.namelist]["template_file"])
@@ -42,7 +42,7 @@ class WaveWatchIII(AssetsCycleBased):
         """
         Run directory provisioned with all required content.
         """
-        yield self._taskname("provisioned run directory")
+        yield self.taskname("provisioned run directory")
         yield [
             self.namelist_file(),
             self.restart_directory(),
@@ -53,7 +53,7 @@ class WaveWatchIII(AssetsCycleBased):
         """
         The restart directory.
         """
-        yield self._taskname("restart directory")
+        yield self.taskname("restart directory")
         path = self.rundir / "restart_wave"
         yield asset(path, path.is_dir)
         yield None

--- a/src/uwtools/resources/jsonschema/batchargs.jsonschema
+++ b/src/uwtools/resources/jsonschema/batchargs.jsonschema
@@ -1,0 +1,57 @@
+{
+  "additionalProperties": true,
+  "properties": {
+    "cores": {
+      "type": "integer"
+    },
+    "debug": {
+      "type": "boolean"
+    },
+    "exclusive": {
+      "type": "boolean"
+    },
+    "export": {
+      "type": "string"
+    },
+    "jobname": {
+      "type": "string"
+    },
+    "memory": {
+      "type": "string"
+    },
+    "nodes": {
+      "type": "integer"
+    },
+    "partition": {
+      "type": "string"
+    },
+    "queue": {
+      "type": "string"
+    },
+    "rundir": {
+      "type": "string"
+    },
+    "shell": {
+      "type": "string"
+    },
+    "stderr": {
+      "type": "string"
+    },
+    "stdout": {
+      "type": "string"
+    },
+    "tasks_per_node": {
+      "type": "integer"
+    },
+    "threads": {
+      "not": {}
+    },
+    "walltime": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "walltime"
+  ],
+  "type": "object"
+}

--- a/src/uwtools/resources/jsonschema/cdeps.jsonschema
+++ b/src/uwtools/resources/jsonschema/cdeps.jsonschema
@@ -43,7 +43,10 @@
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": [
+                "array",
+                "string"
+              ]
             },
             "taxmode": {
               "type": "string"

--- a/src/uwtools/resources/jsonschema/execution-serial.jsonschema
+++ b/src/uwtools/resources/jsonschema/execution-serial.jsonschema
@@ -2,16 +2,7 @@
   "additionalProperties": false,
   "properties": {
     "batchargs": {
-      "additionalProperties": true,
-      "properties": {
-        "walltime": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "walltime"
-      ],
-      "type": "object"
+      "$ref": "urn:uwtools:batchargs"
     },
     "envcmds": {
       "items": {

--- a/src/uwtools/resources/jsonschema/execution.jsonschema
+++ b/src/uwtools/resources/jsonschema/execution.jsonschema
@@ -4,6 +4,48 @@
     "batchargs": {
       "additionalProperties": true,
       "properties": {
+        "cores": {
+          "type": "integer"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "exclusive": {
+          "type": "boolean"
+        },
+        "export": {
+          "type": "string"
+        },
+        "jobname": {
+          "type": "string"
+        },
+        "memory": {
+          "type": "string"
+        },
+        "nodes": {
+          "type": "integer"
+        },
+        "partition": {
+          "type": "string"
+        },
+        "queue": {
+          "type": "string"
+        },
+        "rundir": {
+          "type": "string"
+        },
+        "shell": {
+          "type": "string"
+        },
+        "stderr": {
+          "type": "string"
+        },
+        "stdout": {
+          "type": "string"
+        },
+        "tasks_per_node": {
+          "type": "integer"
+        },
         "threads": {
           "not": {}
         },

--- a/src/uwtools/resources/jsonschema/execution.jsonschema
+++ b/src/uwtools/resources/jsonschema/execution.jsonschema
@@ -2,61 +2,7 @@
   "additionalProperties": false,
   "properties": {
     "batchargs": {
-      "additionalProperties": true,
-      "properties": {
-        "cores": {
-          "type": "integer"
-        },
-        "debug": {
-          "type": "boolean"
-        },
-        "exclusive": {
-          "type": "boolean"
-        },
-        "export": {
-          "type": "string"
-        },
-        "jobname": {
-          "type": "string"
-        },
-        "memory": {
-          "type": "string"
-        },
-        "nodes": {
-          "type": "integer"
-        },
-        "partition": {
-          "type": "string"
-        },
-        "queue": {
-          "type": "string"
-        },
-        "rundir": {
-          "type": "string"
-        },
-        "shell": {
-          "type": "string"
-        },
-        "stderr": {
-          "type": "string"
-        },
-        "stdout": {
-          "type": "string"
-        },
-        "tasks_per_node": {
-          "type": "integer"
-        },
-        "threads": {
-          "not": {}
-        },
-        "walltime": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "walltime"
-      ],
-      "type": "object"
+      "$ref": "urn:uwtools:batchargs"
     },
     "envcmds": {
       "items": {

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
+from uwtools.strings import STR
 from uwtools.utils.processing import execute
 
 
@@ -22,7 +23,8 @@ class JobScheduler(ABC):
     """
 
     def __init__(self, props: dict[str, Any]):
-        self._props = {k: v for k, v in props.items() if k != "scheduler"}
+        self._scheduler = props[STR.scheduler]
+        self._props = {k: v for k, v in props.items() if k != STR.scheduler}
         self._validate_props()
 
     # Public methods
@@ -37,7 +39,7 @@ class JobScheduler(ABC):
         for key, value in self._processed_props.items():
             if key in self._forbidden_directives:
                 msg = "Directive '%s' invalid for scheduler '%s'"
-                raise UWConfigError(msg % (key, self._props["scheduler"]))
+                raise UWConfigError(msg % (key, self._scheduler))
             if key in self._managed_directives:
                 switch = self._managed_directives[key]
                 if callable(switch) and (x := switch(value)) is not None:
@@ -58,7 +60,7 @@ class JobScheduler(ABC):
         :raises: UWConfigError if 'scheduler' is un- or mis-defined.
         """
         schedulers = {"slurm": Slurm, "pbs": PBS, "lsf": LSF}
-        if name := props.get("scheduler"):
+        if name := props.get(STR.scheduler):
             log.debug("Getting '%s' scheduler", name)
             if scheduler_class := schedulers.get(name):
                 return scheduler_class(props)  # type: ignore

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -37,11 +37,10 @@ class JobScheduler(ABC):
         for key, value in self._processed_props.items():
             if key in self._managed_directives:
                 switch = self._managed_directives[key]
-                ds.append(
-                    "%s %s" % (pre, switch(value))
-                    if callable(switch)
-                    else "%s %s%s%s" % (pre, switch, sep, value)
-                )
+                if callable(switch) and (x := switch(value)) is not None:
+                    ds.append("%s %s" % (pre, x))
+                else:
+                    ds.append("%s %s%s%s" % (pre, switch, sep, value))
             else:
                 ds.append("%s %s%s%s" % (pre, key, sep, value))
         return sorted(ds)
@@ -291,7 +290,8 @@ class Slurm(JobScheduler):
         """
         return {
             _DirectivesOptional.CORES: "--ntasks",
-            _DirectivesOptional.EXCLUSIVE: lambda _: "--exclusive",
+            _DirectivesOptional.DEBUG: lambda b: "--verbose" if b else None,
+            _DirectivesOptional.EXCLUSIVE: lambda b: "--exclusive" if b else None,
             _DirectivesOptional.EXPORT: "--export",
             _DirectivesOptional.JOB_NAME: "--job-name",
             _DirectivesOptional.MEMORY: "--mem",

--- a/src/uwtools/tests/drivers/test_chgres_cube.py
+++ b/src/uwtools/tests/drivers/test_chgres_cube.py
@@ -151,5 +151,5 @@ def test_ChgresCube__driver_name(driverobj):
     assert driverobj._driver_name == "chgres_cube"
 
 
-def test_ChgresCube__taskname(driverobj):
-    assert driverobj._taskname("foo") == "20240201 18Z chgres_cube foo"
+def test_ChgresCube_taskname(driverobj):
+    assert driverobj.taskname("foo") == "20240201 18Z chgres_cube foo"

--- a/src/uwtools/tests/drivers/test_esg_grid.py
+++ b/src/uwtools/tests/drivers/test_esg_grid.py
@@ -73,11 +73,11 @@ def driverobj(config):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
+        "taskname",
     ],
 )
 def test_ESGGrid(method):

--- a/src/uwtools/tests/drivers/test_filter_topo.py
+++ b/src/uwtools/tests/drivers/test_filter_topo.py
@@ -68,11 +68,11 @@ def driverobj(config):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
+        "taskname",
     ],
 )
 def test_FilterTopo(method):

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -247,8 +247,8 @@ def test_FV3_runscript(driverobj):
         assert [type(runscript.call_args.kwargs[x]) for x in args] == types
 
 
-def test_FV3__taskname(driverobj):
-    assert driverobj._taskname("foo") == "20240201 18Z fv3 foo"
+def test_FV3_taskname(driverobj):
+    assert driverobj.taskname("foo") == "20240201 18Z fv3 foo"
 
 
 def test_FV3__driver_name(driverobj):

--- a/src/uwtools/tests/drivers/test_global_equiv_resol.py
+++ b/src/uwtools/tests/drivers/test_global_equiv_resol.py
@@ -53,11 +53,11 @@ def driverobj(config):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
+        "taskname",
     ],
 )
 def test_GlobalEquivResol(method):

--- a/src/uwtools/tests/drivers/test_ioda.py
+++ b/src/uwtools/tests/drivers/test_ioda.py
@@ -113,5 +113,5 @@ def test_IODA__runcmd(driverobj):
     assert driverobj._runcmd == f"/path/to/bufr2ioda.x {config}"
 
 
-def test_IODA__taskname(driverobj):
-    assert driverobj._taskname("foo") == "20240501 06Z ioda foo"
+def test_IODA_taskname(driverobj):
+    assert driverobj.taskname("foo") == "20240501 06Z ioda foo"

--- a/src/uwtools/tests/drivers/test_jedi.py
+++ b/src/uwtools/tests/drivers/test_jedi.py
@@ -204,5 +204,5 @@ def test_JEDI__runcmd(driverobj):
     )
 
 
-def test_JEDI__taskname(driverobj):
-    assert driverobj._taskname("foo") == "20240201 18Z jedi foo"
+def test_JEDI_taskname(driverobj):
+    assert driverobj.taskname("foo") == "20240201 18Z jedi foo"

--- a/src/uwtools/tests/drivers/test_make_hgrid.py
+++ b/src/uwtools/tests/drivers/test_make_hgrid.py
@@ -58,11 +58,11 @@ def driverobj(config):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
+        "taskname",
     ],
 )
 def test_MakeHgrid(method):

--- a/src/uwtools/tests/drivers/test_make_solo_mosaic.py
+++ b/src/uwtools/tests/drivers/test_make_solo_mosaic.py
@@ -80,8 +80,8 @@ def test_MakeSoloMosaic__runcmd(driverobj):
     assert cmd == f"/path/to/make_solo_mosaic.exe --dir {dir_path} --num_tiles 1"
 
 
-def test_MakeSoloMosaic__taskname(driverobj):
-    assert driverobj._taskname("foo") == "make_solo_mosaic foo"
+def test_MakeSoloMosaic_taskname(driverobj):
+    assert driverobj.taskname("foo") == "make_solo_mosaic foo"
 
 
 def test_MakeSoloMosaic__validate(driverobj):

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -128,12 +128,12 @@ def driverobj(config, cycle):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
         "streams_file",
+        "taskname",
     ],
 )
 def test_MPAS(method):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -110,12 +110,12 @@ def driverobj(config, cycle):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
         "streams_file",
+        "taskname",
     ],
 )
 def test_MPASInit(method):

--- a/src/uwtools/tests/drivers/test_orog_gsl.py
+++ b/src/uwtools/tests/drivers/test_orog_gsl.py
@@ -61,11 +61,11 @@ def driverobj(config):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
+        "taskname",
     ],
 )
 def test_OrogGSL(method):

--- a/src/uwtools/tests/drivers/test_schism.py
+++ b/src/uwtools/tests/drivers/test_schism.py
@@ -45,7 +45,7 @@ def driverobj(config, cycle):
 
 @mark.parametrize(
     "method",
-    ["_taskname", "_validate"],
+    ["taskname", "_validate"],
 )
 def test_SCHISM(method):
     assert getattr(SCHISM, method) is getattr(AssetsCycleBased, method)

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -95,11 +95,11 @@ def driverobj(config):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
+        "taskname",
     ],
 )
 def test_SfcClimoGen(method):

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -59,11 +59,11 @@ def driverobj(config):
         "_runscript_done_file",
         "_runscript_path",
         "_scheduler",
-        "_taskname",
         "_validate",
         "_write_runscript",
         "run",
         "runscript",
+        "taskname",
     ],
 )
 def test_Shave(method):

--- a/src/uwtools/tests/drivers/test_support.py
+++ b/src/uwtools/tests/drivers/test_support.py
@@ -44,6 +44,9 @@ def test_tasks():
         def provisioned_rundir(self):
             pass
 
+        def taskname(self, suffix):
+            pass
+
         @external
         def t1(self):
             "@external t1"
@@ -62,9 +65,6 @@ def test_tasks():
 
         @property
         def _resources(self):
-            pass
-
-        def _taskname(self, suffix):
             pass
 
         def _validate(self, schema_file: Optional[Path] = None):

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -138,8 +138,8 @@ def test_Ungrib__gribfile(driverobj):
     assert dst.is_symlink()
 
 
-def test_Ungrib__taskname(driverobj):
-    assert driverobj._taskname("foo") == "20240201 18Z ungrib foo"
+def test_Ungrib_taskname(driverobj):
+    assert driverobj.taskname("foo") == "20240201 18Z ungrib foo"
 
 
 def test__ext():

--- a/src/uwtools/tests/drivers/test_upp.py
+++ b/src/uwtools/tests/drivers/test_upp.py
@@ -179,5 +179,5 @@ def test_UPP__runcmd(driverobj):
     assert driverobj._runcmd == "%s < itag" % driverobj.config["execution"]["executable"]
 
 
-def test_UPP__taskname(driverobj):
-    assert driverobj._taskname("foo") == "20240507 12:00:00 upp foo"
+def test_UPP_taskname(driverobj):
+    assert driverobj.taskname("foo") == "20240507 12:00:00 upp foo"

--- a/src/uwtools/tests/drivers/test_ww3.py
+++ b/src/uwtools/tests/drivers/test_ww3.py
@@ -45,7 +45,7 @@ def driverobj(config, cycle):
 
 @mark.parametrize(
     "method",
-    ["_taskname", "_validate"],
+    ["taskname", "_validate"],
 )
 def test_WaveWatchIII(method):
     assert getattr(WaveWatchIII, method) is getattr(AssetsCycleBased, method)

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -228,7 +228,10 @@ def test_Slurm__directive_separator(slurm):
 def test_Slurm__managed_directives(slurm):
     mds = slurm._managed_directives
     assert mds["cores"] == "--ntasks"
-    assert mds["exclusive"](None) == "--exclusive"
+    assert mds["debug"](True) == "--verbose"
+    assert mds["debug"](False) is None
+    assert mds["exclusive"](True) == "--exclusive"
+    assert mds["exclusive"](False) is None
     assert mds["export"] == "--export"
     assert mds["jobname"] == "--job-name"
     assert mds["memory"] == "--mem"

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -152,6 +152,10 @@ def test_LSF__directive_separator(lsf):
     assert lsf._directive_separator == " "
 
 
+def test_LSF__forbidden_directives(lsf):
+    assert lsf._forbidden_directives == []
+
+
 def test_LSF__managed_directives(lsf):
     mds = lsf._managed_directives
     assert mds["account"] == "-P"
@@ -184,6 +188,10 @@ def test_PBS(pbs):
 
 def test_PBS__directive_separator(pbs):
     assert pbs._directive_separator == " "
+
+
+def test_PBS__forbidden_directives(pbs):
+    assert pbs._forbidden_directives == []
 
 
 def test_PBS__managed_directives(pbs):
@@ -234,6 +242,10 @@ def test_Slurm(slurm):
 
 def test_Slurm__directive_separator(slurm):
     assert slurm._directive_separator == "="
+
+
+def test_Slurm__forbidden_directives(slurm):
+    assert slurm._forbidden_directives == ["shell"]
 
 
 def test_Slurm__managed_directives(slurm):

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -78,19 +78,26 @@ def test_JobScheduler_directives(schedulerobj):
     assert schedulerobj.directives == ["#DIR --a=foo", "#DIR --pi=3.14", "#DIR --t=01:10:00"]
 
 
-def test_JobScheduler_get_scheduler_bad_scheduler_specified():
+def test_JobScheduler_get_scheduler_fail_bad_directive_specified(props):
+    scheduler = ConcreteScheduler.get_scheduler(props={**props, "shell": "csh"})
+    with raises(UWConfigError) as e:
+        assert scheduler.directives
+    assert str(e.value).startswith("Directive 'shell' invalid for scheduler 'slurm'")
+
+
+def test_JobScheduler_get_scheduler_fail_bad_scheduler_specified():
     with raises(UWConfigError) as e:
         ConcreteScheduler.get_scheduler(props={"scheduler": "foo"})
     assert str(e.value).startswith("Scheduler 'foo' should be one of:")
 
 
-def test_JobScheduler_get_scheduler_no_scheduler_specified():
+def test_JobScheduler_get_scheduler_fail_no_scheduler_specified():
     with raises(UWConfigError) as e:
         ConcreteScheduler.get_scheduler(props={})
     assert str(e.value).startswith("No 'scheduler' defined in")
 
 
-def test_JobScheduler_get_scheduler_ok(props):
+def test_JobScheduler_get_scheduler_pass(props):
     assert isinstance(ConcreteScheduler.get_scheduler(props=props), scheduler.Slurm)
 
 

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -54,6 +54,10 @@ class ConcreteScheduler(scheduler.JobScheduler):
         return directive_separator
 
     @property
+    def _forbidden_directives(self) -> list[str]:
+        return ["shell"]
+
+    @property
     def _managed_directives(self) -> dict[str, Any]:
         return managed_directives
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -327,11 +327,11 @@ def test_schema_cdeps_atm_in(cdeps_config):
         "skip_restart_read",
     ]
     for k in ks_boolean:
-        assert "is not of type 'boolean'" in nmlerr(k, None)
+        assert "is not of type 'boolean'\n" in nmlerr(k, None)
     # integer:
     ks_integer = ["iradsw", "nx_global", "ny_global"]
     for k in ks_integer:
-        assert "is not of type 'integer'" in nmlerr(k, None)
+        assert "is not of type 'integer'\n" in nmlerr(k, None)
     # enum:
     ks_enum = ["datamode"]
     assert "is not one of" in nmlerr("datamode", None)
@@ -346,7 +346,7 @@ def test_schema_cdeps_atm_in(cdeps_config):
         "restfilm",
     ]
     for k in ks_string:
-        assert "is not of type 'string'" in nmlerr(k, None)
+        assert "is not of type 'string'\n" in nmlerr(k, None)
     # All namelist keys are optional:
     for k in ks_boolean + ks_integer + ks_enum + ks_string:
         assert not errors(with_del(block, "update_values", "datm_nml", k))
@@ -362,7 +362,7 @@ def test_schema_cdeps_nml_common(cdeps_config, section):
     # At least one is required:
     assert "is not valid" in errors(with_del(with_del(block, "base_file"), "update_values"))
     # The base_file value must be a string:
-    assert "is not of type 'string'" in errors(with_set(block, 1, "base_file"))
+    assert "is not of type 'string'\n" in errors(with_set(block, 1, "base_file"))
     # The update_values.datm_nml value is required:
     assert f"'d{section}_nml' is a required property" in errors(
         with_del(block, "update_values", f"d{section}_nml")
@@ -379,15 +379,15 @@ def test_schema_cdeps_ocn_in(cdeps_config):
     # boolean:
     ks_boolean = ["skip_restart_read"]
     for k in ks_boolean:
-        assert "is not of type 'boolean'" in nmlerr(k, None)
+        assert "is not of type 'boolean'\n" in nmlerr(k, None)
     # integer:
     ks_integer = ["nx_global", "ny_global"]
     for k in ks_integer:
-        assert "is not of type 'integer'" in nmlerr(k, None)
+        assert "is not of type 'integer'\n" in nmlerr(k, None)
     # number:
     ks_number = ["sst_constant_value"]
     for k in ks_number:
-        assert "is not of type 'number'" in nmlerr(k, None)
+        assert "is not of type 'number'\n" in nmlerr(k, None)
     # string:
     ks_string = [
         "datamode",
@@ -397,7 +397,7 @@ def test_schema_cdeps_ocn_in(cdeps_config):
         "restfilm",
     ]
     for k in ks_string:
-        assert "is not of type 'string'" in nmlerr(k, None)
+        assert "is not of type 'string'\n" in nmlerr(k, None)
     # All namelist keys are optional:
     for k in ks_boolean + ks_integer + ks_number + ks_string:
         assert not errors(with_del(block, "update_values", "docn_nml", k))
@@ -416,7 +416,7 @@ def test_schema_cdeps_streams(cdeps_config, section):
     # Arbitrarily-named stream blocks are not allowed:
     assert "does not match any of the regexes" in errors(with_set(block, {}, "streams", "foo"))
     # template_file must be a string:
-    assert "is not of type 'string'" in errors(with_set(block, 1, "template_file"))
+    assert "is not of type 'string'\n" in errors(with_set(block, 1, "template_file"))
     # Values must be of the correct types:
     valerr = lambda k, v: errors(with_set(block, v, "streams", "stream01", k))
     # enum:
@@ -425,20 +425,25 @@ def test_schema_cdeps_streams(cdeps_config, section):
     # integer:
     ks_integer = ["stream_offset", "yearAlign", "yearFirst", "yearLast"]
     for k in ks_integer:
-        assert "is not of type 'integer'" in valerr(k, None)
+        assert "is not of type 'integer'\n" in valerr(k, None)
     # number:
     ks_number = ["dtlimit"]
     for k in ks_number:
-        assert "is not of type 'number'" in valerr(k, None)
+        assert "is not of type 'number'\n" in valerr(k, None)
     # string:
     ks_string = ["mapalgo", "stream_lev_dimname", "stream_mesh_file", "taxmode", "tinterpalgo"]
     for k in ks_string:
-        assert "is not of type 'string'" in valerr(k, None)
+        assert "is not of type 'string'\n" in valerr(k, None)
     # string arrays:
-    ks_string_array = ["stream_data_files", "stream_data_variables", "stream_vectors"]
+    ks_string_array = ["stream_data_files", "stream_data_variables"]
     for k in ks_string_array:
-        assert "is not of type 'array'" in valerr(k, None)
-        assert "is not of type 'string'" in valerr(k, [1])
+        assert "is not of type 'array'\n" in valerr(k, None)
+        assert "is not of type 'string'\n" in valerr(k, [1])
+    # string or string array:
+    ks_string_or_string_array = ["stream_vectors"]
+    for k in ks_string_or_string_array:
+        assert "is not of type 'array', 'string'\n" in valerr(k, None)
+        assert "is not of type 'string'\n" in valerr(k, [1])
     # All keys are required:
     for k in ks_enum + ks_integer + ks_number + ks_string + ks_string_array:
         assert "is a required property" in errors(with_del(block, "streams", "stream01", k))
@@ -458,7 +463,7 @@ def test_schema_chgres_cube(chgres_cube_config):
     assert "Additional properties are not allowed" in errors({**chgres_cube_config, "foo": "bar"})
     # "rundir" must be present, and must be a string:
     assert "'rundir' is a required property" in errors(with_del(chgres_cube_config, "rundir"))
-    assert "is not of type 'string'" in errors(with_set(chgres_cube_config, None, "rundir"))
+    assert "is not of type 'string'\n" in errors(with_set(chgres_cube_config, None, "rundir"))
 
 
 def test_schema_chgres_cube_namelist(chgres_cube_config, chgres_cube_prop):
@@ -467,7 +472,7 @@ def test_schema_chgres_cube_namelist(chgres_cube_config, chgres_cube_prop):
     # Just base_file is ok:
     assert not errors(with_del(namelist, "update_values"))
     # base_file must be a string:
-    assert "88 is not of type 'string'" in errors(with_set(namelist, 88, "base_file"))
+    assert "88 is not of type 'string'\n" in errors(with_set(namelist, 88, "base_file"))
     # Just update_values is ok:
     assert not errors(with_del(namelist, "base_file"))
     # config is required with update_values:
@@ -545,8 +550,8 @@ def test_schema_chgres_cube_namelist_update_values(chgres_cube_config, chgres_cu
         "orog_files_target_grid",
         "sfc_files_input_grid",
     ]:
-        assert "is not of type 'array', 'string'" in errors(with_set(config, None, key))
-        assert "is not of type 'string'" in errors(with_set(config, [1, 2, 3], key))
+        assert "is not of type 'array', 'string'\n" in errors(with_set(config, None, key))
+        assert "is not of type 'string'\n" in errors(with_set(config, [1, 2, 3], key))
 
 
 # esg-grid
@@ -621,7 +626,7 @@ def test_schema_esg_grid_rundir(esg_grid_prop):
     errors = esg_grid_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # execution
@@ -659,15 +664,15 @@ def test_execution_batchargs():
     # But so are unknown ones:
     assert not errors({"--foo": 88, "walltime": "00:05:00"})
     # It just has to be a map:
-    assert "[] is not of type 'object'" in errors([])
+    assert "[] is not of type 'object'\n" in errors([])
     # The "threads" argument is not allowed: It will be propagated, if set, from execution.threads.
     assert "should not be valid" in errors({"threads": 4, "walltime": "00:05:00"})
     # Some keys require boolean values:
     for key in ["debug", "exclusive"]:
-        assert "is not of type 'boolean'" in errors({key: None})
+        assert "is not of type 'boolean'\n" in errors({key: None})
     # Some keys require integer values:
     for key in ["cores", "nodes"]:
-        assert "is not of type 'integer'" in errors({key: None})
+        assert "is not of type 'integer'\n" in errors({key: None})
     # Some keys require string values:
     for key in [
         "export",
@@ -681,7 +686,7 @@ def test_execution_batchargs():
         "stdout",
         "walltime",
     ]:
-        assert "is not of type 'string'" in errors({key: None})
+        assert "is not of type 'string'\n" in errors({key: None})
 
 
 def test_execution_executable():
@@ -689,7 +694,7 @@ def test_execution_executable():
     # String value is ok:
     assert not errors("fv3.exe")
     # Anything else is not:
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 def test_execution_mpiargs():
@@ -699,7 +704,7 @@ def test_execution_mpiargs():
     # mpiargs may be empty:
     assert not errors([])
     # String values are expected:
-    assert "88 is not of type 'string'" in errors(["string1", 88])
+    assert "88 is not of type 'string'\n" in errors(["string1", 88])
 
 
 def test_execution_threads():
@@ -708,7 +713,7 @@ def test_execution_threads():
     assert not errors(1)
     assert not errors(4)
     assert "0 is less than the minimum of 1" in errors(0)
-    assert "3.14 is not of type 'integer'" in errors(3.14)
+    assert "3.14 is not of type 'integer'\n" in errors(3.14)
 
 
 # execution-serial
@@ -742,13 +747,13 @@ def test_execution_serial_executable():
 def test_schema_files_to_stage():
     errors = schema_validator("files-to-stage")
     # The input must be an dict:
-    assert "is not of type 'object'" in errors([])
+    assert "is not of type 'object'\n" in errors([])
     # A str -> str dict is ok:
     assert not errors({"file1": "/path/to/file1", "file2": "/path/to/file2"})
     # An empty dict is not allowed:
     assert "{} should be non-empty" in errors({})
     # Non-string values are not allowed:
-    assert "True is not of type 'string'" in errors({"file1": True})
+    assert "True is not of type 'string'\n" in errors({"file1": True})
 
 
 # filter-topo
@@ -789,7 +794,7 @@ def test_schema_filter_topo():
     # Other top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors(with_set(config, "bar", "foo"))
     # Top-level rundir key requires a string value:
-    assert "is not of type 'string'" in errors(with_set(config, None, "rundir"))
+    assert "is not of type 'string'\n" in errors(with_set(config, None, "rundir"))
     # All config keys are requried:
     for key in ["input_grid_file"]:
         assert f"'{key}' is a required property" in errors(with_del(config, "config", key))
@@ -799,7 +804,7 @@ def test_schema_filter_topo():
     )
     # Some config keys require string values:
     for key in ["input_grid_file"]:
-        assert "is not of type 'string'" in errors(with_set(config, None, "config", key))
+        assert "is not of type 'string'\n" in errors(with_set(config, None, "config", key))
     # Namelist filter_topo_nml is required:
     assert "is a required property" in errors(with_del(config, *nmlkeys))
     # Additional namelists are not allowed:
@@ -823,16 +828,16 @@ def test_schema_filter_topo():
     assert not errors(with_set(config, "val", *nmlkeys, "key"))
     # Some filter_topo_nml keys require boolean values:
     for key in ["regional", "zero_ocean"]:
-        assert "is not of type 'boolean'" in errors(with_set(config, None, *nmlkeys, key))
+        assert "is not of type 'boolean'\n" in errors(with_set(config, None, *nmlkeys, key))
     # Some filter_topo_nml keys require integer values:
     for key in ["grid_type", "res"]:
-        assert "is not of type 'integer'" in errors(with_set(config, None, *nmlkeys, key))
+        assert "is not of type 'integer'\n" in errors(with_set(config, None, *nmlkeys, key))
     # Some filter_topo_nml keys require number values:
     for key in ["stretch_fac"]:
-        assert "is not of type 'number'" in errors(with_set(config, None, *nmlkeys, key))
+        assert "is not of type 'number'\n" in errors(with_set(config, None, *nmlkeys, key))
     # Some filter_topo_nml keys require string values:
     for key in ["grid_file", "mask_field", "topo_field", "topo_file"]:
-        assert "is not of type 'string'" in errors(with_set(config, None, *nmlkeys, key))
+        assert "is not of type 'string'\n" in errors(with_set(config, None, *nmlkeys, key))
 
 
 # fv3
@@ -883,7 +888,7 @@ def test_schema_fv3_diag_table(fv3_prop):
     # String value is ok:
     assert not errors("/path/to/file")
     # Anything else is not:
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 def test_schema_fv3_domain(fv3_prop):
@@ -907,12 +912,12 @@ def test_schema_fv3_lateral_boundary_conditions(fv3_prop):
     assert "'path' is a required property" in errors(with_del(config, "path"))
     # interval_hours must be an integer of at least 1:
     assert "0 is less than the minimum of 1" in errors(with_set(config, 0, "interval_hours"))
-    assert "'s' is not of type 'integer'" in errors(with_set(config, "s", "interval_hours"))
+    assert "'s' is not of type 'integer'\n" in errors(with_set(config, "s", "interval_hours"))
     # offset must be an integer of at least 0:
     assert "-1 is less than the minimum of 0" in errors(with_set(config, -1, "offset"))
-    assert "'s' is not of type 'integer'" in errors(with_set(config, "s", "offset"))
+    assert "'s' is not of type 'integer'\n" in errors(with_set(config, "s", "offset"))
     # path must be a string:
-    assert "88 is not of type 'string'" in errors(with_set(config, 88, "path"))
+    assert "88 is not of type 'string'\n" in errors(with_set(config, 88, "path"))
 
 
 def test_schema_fv3_length(fv3_prop):
@@ -924,7 +929,7 @@ def test_schema_fv3_length(fv3_prop):
     # A negative number is not ok:
     assert "-1 is less than the minimum of 1" in errors(-1)
     # Something other than an int is not ok:
-    assert "'a string' is not of type 'integer'" in errors("a string")
+    assert "'a string' is not of type 'integer'\n" in errors("a string")
 
 
 def test_schema_fv3_model_configure(fv3_prop):
@@ -934,7 +939,7 @@ def test_schema_fv3_model_configure(fv3_prop):
     # Just base_file is ok:
     assert not errors(base_file)
     # But base_file must be a string:
-    assert "88 is not of type 'string'" in errors({"base_file": 88})
+    assert "88 is not of type 'string'\n" in errors({"base_file": 88})
     # Just update_values is ok:
     assert not errors(update_values)
     # A combination of base_file and update_values is ok:
@@ -948,7 +953,7 @@ def test_schema_fv3_model_configure_update_values(fv3_prop):
     # boolean, number, and string values are ok:
     assert not errors({"bool": True, "int": 88, "float": 3.14, "string": "foo"})
     # Other types are not, e.g.:
-    assert "None is not of type 'boolean', 'number', 'string'" in errors({"null": None})
+    assert "None is not of type 'boolean', 'number', 'string'\n" in errors({"null": None})
     # At least one entry is required:
     assert "{} should be non-empty" in errors({})
 
@@ -960,7 +965,7 @@ def test_schema_fv3_namelist(fv3_prop):
     # Just base_file is ok:
     assert not errors(base_file)
     # base_file must be a string:
-    assert "88 is not of type 'string'" in errors({"base_file": 88})
+    assert "88 is not of type 'string'\n" in errors({"base_file": 88})
     # Just update_values is ok:
     assert not errors(update_values)
     # A combination of base_file and update_values is ok:
@@ -976,7 +981,7 @@ def test_schema_fv3_namelist_update_values(fv3_prop):
         {"nml": {"array": [1, 2, 3], "bool": True, "int": 88, "float": 3.14, "string": "foo"}}
     )
     # Other types are not, e.g.:
-    assert "None is not of type 'array', 'boolean', 'number', 'string'" in errors(
+    assert "None is not of type 'array', 'boolean', 'number', 'string'\n" in errors(
         {"nml": {"null": None}}
     )
     # At least one namelist entry is required:
@@ -989,7 +994,7 @@ def test_schema_fv3_rundir(fv3_prop):
     errors = fv3_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # global-equiv-resol
@@ -1016,7 +1021,7 @@ def test_schema_global_equiv_resol_paths(global_equiv_resol_prop, schema_entry):
     errors = global_equiv_resol_prop(schema_entry)
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # ioda
@@ -1060,7 +1065,7 @@ def test_schema_ioda_rundir(ioda_prop):
     errors = ioda_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # jedi
@@ -1104,7 +1109,7 @@ def test_schema_jedi_rundir(jedi_prop):
     errors = jedi_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # make-hgrid
@@ -1166,7 +1171,7 @@ def test_schema_make_hgrid_rundir(make_hgrid_prop):
     errors = make_hgrid_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # make-solo-mosaic
@@ -1209,7 +1214,7 @@ def test_schema_make_solo_mosaic_rundir(make_solo_mosaic_prop):
     errors = make_solo_mosaic_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # mpas
@@ -1247,12 +1252,12 @@ def test_schema_mpas_lateral_boundary_conditions(mpas_prop):
     assert "'path' is a required property" in errors(with_del(config, "path"))
     # interval_hours must be an integer of at least 1:
     assert "0 is less than the minimum of 1" in errors(with_set(config, 0, "interval_hours"))
-    assert "'s' is not of type 'integer'" in errors(with_set(config, "s", "interval_hours"))
+    assert "'s' is not of type 'integer'\n" in errors(with_set(config, "s", "interval_hours"))
     # offset must be an integer of at least 0:
     assert "-1 is less than the minimum of 0" in errors(with_set(config, -1, "offset"))
-    assert "'s' is not of type 'integer'" in errors(with_set(config, "s", "offset"))
+    assert "'s' is not of type 'integer'\n" in errors(with_set(config, "s", "offset"))
     # path must be a string:
-    assert "88 is not of type 'string'" in errors(with_set(config, 88, "path"))
+    assert "88 is not of type 'string'\n" in errors(with_set(config, 88, "path"))
 
 
 def test_schema_mpas_length(mpas_prop):
@@ -1264,7 +1269,7 @@ def test_schema_mpas_length(mpas_prop):
     # A negative number is not ok:
     assert "-1 is less than the minimum of 1" in errors(-1)
     # Something other than an int is not ok:
-    assert "'a string' is not of type 'integer'" in errors("a string")
+    assert "'a string' is not of type 'integer'\n" in errors("a string")
 
 
 def test_schema_mpas_namelist(mpas_prop):
@@ -1274,7 +1279,7 @@ def test_schema_mpas_namelist(mpas_prop):
     # Just base_file is ok:
     assert not errors(base_file)
     # base_file must be a string:
-    assert "88 is not of type 'string'" in errors({"base_file": 88})
+    assert "88 is not of type 'string'\n" in errors({"base_file": 88})
     # Just update_values is ok:
     assert not errors(update_values)
     # A combination of base_file and update_values is ok:
@@ -1290,7 +1295,7 @@ def test_schema_mpas_namelist_update_values(mpas_prop):
         {"nml": {"array": [1, 2, 3], "bool": True, "int": 88, "float": 3.14, "string": "foo"}}
     )
     # Other types are not, e.g.:
-    assert "None is not of type 'array', 'boolean', 'number', 'string'" in errors(
+    assert "None is not of type 'array', 'boolean', 'number', 'string'\n" in errors(
         {"nml": {"null": None}}
     )
     # At least one namelist entry is required:
@@ -1303,7 +1308,7 @@ def test_schema_mpas_rundir(mpas_prop):
     errors = mpas_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # mpas-init
@@ -1343,16 +1348,16 @@ def test_schema_mpas_init_boundary_conditions(mpas_init_prop):
     assert "'path' is a required property" in errors(with_del(config, "path"))
     # interval_hours must be an integer of at least 1:
     assert "0 is less than the minimum of 1" in errors(with_set(config, 0, "interval_hours"))
-    assert "'s' is not of type 'integer'" in errors(with_set(config, "s", "interval_hours"))
+    assert "'s' is not of type 'integer'\n" in errors(with_set(config, "s", "interval_hours"))
     # offset must be an integer of at least 0:
     assert "-1 is less than the minimum of 0" in errors(with_set(config, -1, "offset"))
-    assert "'s' is not of type 'integer'" in errors(with_set(config, "s", "offset"))
+    assert "'s' is not of type 'integer'\n" in errors(with_set(config, "s", "offset"))
     # path must be a string:
-    assert "88 is not of type 'string'" in errors(with_set(config, 88, "path"))
+    assert "88 is not of type 'string'\n" in errors(with_set(config, 88, "path"))
     # length must be a positive int
     assert "0 is less than the minimum of 1" in errors(with_set(config, 0, "length"))
     assert "-1 is less than the minimum of 1" in errors(with_set(config, -1, "length"))
-    assert "'s' is not of type 'integer'" in errors(with_set(config, "s", "length"))
+    assert "'s' is not of type 'integer'\n" in errors(with_set(config, "s", "length"))
 
 
 def test_schema_mpas_init_namelist(mpas_init_prop):
@@ -1362,7 +1367,7 @@ def test_schema_mpas_init_namelist(mpas_init_prop):
     # Just base_file is ok:
     assert not errors(base_file)
     # base_file must be a string:
-    assert "88 is not of type 'string'" in errors({"base_file": 88})
+    assert "88 is not of type 'string'\n" in errors({"base_file": 88})
     # Just update_values is ok:
     assert not errors(update_values)
     # A combination of base_file and update_values is ok:
@@ -1378,7 +1383,7 @@ def test_schema_mpas_init_namelist_update_values(mpas_init_prop):
         {"nml": {"array": [1, 2, 3], "bool": True, "int": 88, "float": 3.14, "string": "foo"}}
     )
     # Other types are not, e.g.:
-    assert "None is not of type 'array', 'boolean', 'number', 'string'" in errors(
+    assert "None is not of type 'array', 'boolean', 'number', 'string'\n" in errors(
         {"nml": {"null": None}}
     )
     # At least one namelist entry is required:
@@ -1391,7 +1396,7 @@ def test_schema_mpas_init_rundir(mpas_init_prop):
     errors = mpas_init_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # mpas-streams
@@ -1461,8 +1466,8 @@ def test_schema_mpas_streams_properties_values_array(mpas_streams):
     errors = schema_validator("mpas-streams")
     for k, v in mpas_streams.items():
         for prop in ["files", "streams", "vars", "var_arrays", "var_structs"]:
-            assert "is not of type 'array'" in errors({k: {**v, prop: None}})
-            assert "is not of type 'string'" in errors({k: {**v, prop: [None]}})
+            assert "is not of type 'array'\n" in errors({k: {**v, prop: None}})
+            assert "is not of type 'string'\n" in errors({k: {**v, prop: [None]}})
             assert "should be non-empty" in errors({k: {**v, prop: []}})
 
 
@@ -1470,7 +1475,7 @@ def test_schema_mpas_streams_properties_boolean(mpas_streams):
     errors = schema_validator("mpas-streams")
     for k, v in mpas_streams.items():
         for prop in ["mutable"]:
-            assert "is not of type 'boolean'" in errors({k: {**v, prop: None}})
+            assert "is not of type 'boolean'\n" in errors({k: {**v, prop: None}})
 
 
 def test_schema_mpas_streams_properties_enum(mpas_streams):
@@ -1502,7 +1507,7 @@ def test_schema_mpas_streams_properties_string(mpas_streams):
             "packages",
             "reference_time",
         ]:
-            assert "is not of type 'string'" in errors({k: {**v, prop: None}})
+            assert "is not of type 'string'\n" in errors({k: {**v, prop: None}})
 
 
 # namelist
@@ -1523,7 +1528,7 @@ def test_schema_namelist():
         }
     )
     # Other types at the name-value level are not allowed:
-    errormsg = "%s is not of type 'array', 'boolean', 'number', 'string'"
+    errormsg = "%s is not of type 'array', 'boolean', 'number', 'string'\n"
     assert errormsg % "None" in errors({"namelist": {"nonetype": None}})
     assert errormsg % "{}" in errors({"namelist": {"dict": {}}})
     # Needs at least one namelist value:
@@ -1531,9 +1536,9 @@ def test_schema_namelist():
     # Needs at least one name-value value:
     assert "{} should be non-empty" in errors({"namelist": {}})
     # Namelist level must be a mapping:
-    assert "[] is not of type 'object'" in errors([])
+    assert "[] is not of type 'object'\n" in errors([])
     # Name-value level level must be a mapping:
-    assert "[] is not of type 'object'" in errors({"namelist": []})
+    assert "[] is not of type 'object'\n" in errors({"namelist": []})
 
 
 # orog-gsl
@@ -1566,17 +1571,17 @@ def test_schema_orog_gsl():
     )
     # Some config keys require integer values:
     for key in ["halo", "resolution", "tile"]:
-        assert "is not of type 'integer'" in errors(with_set(config, None, "config", key))
+        assert "is not of type 'integer'\n" in errors(with_set(config, None, "config", key))
     # Some config keys require string values:
     for key in ["input_grid_file", "topo_data_2p5m", "topo_data_30s"]:
-        assert "is not of type 'string'" in errors(with_set(config, None, "config", key))
+        assert "is not of type 'string'\n" in errors(with_set(config, None, "config", key))
     # Some top level keys are required:
     for key in ["config", "execution", "rundir"]:
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Other top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors(with_set(config, "bar", "foo"))
     # Top-level rundir key requires a string value:
-    assert "is not of type 'string'" in errors(with_set(config, None, "rundir"))
+    assert "is not of type 'string'\n" in errors(with_set(config, None, "rundir"))
 
 
 # platform
@@ -1652,7 +1657,7 @@ def test_schema_rocoto_metatask_attrs():
     assert not errors({"throttle": 88})
     assert not errors({"throttle": 0})
     assert "-1 is less than the minimum of 0" in errors({"throttle": -1})
-    assert "'foo' is not of type 'integer'" in errors({"throttle": "foo"})
+    assert "'foo' is not of type 'integer'\n" in errors({"throttle": "foo"})
 
 
 def test_schema_rocoto_workflow_cycledef():
@@ -1738,7 +1743,7 @@ def test_schema_schism_rundir(schism_prop):
     errors = schism_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # sfc-climo-gen
@@ -1767,7 +1772,7 @@ def test_schema_sfc_climo_gen_namelist(sfc_climo_gen_prop):
     # Just base_file is ok:
     assert not errors(base_file)
     # base_file must be a string:
-    assert "88 is not of type 'string'" in errors({"base_file": 88})
+    assert "88 is not of type 'string'\n" in errors({"base_file": 88})
     # Just update_values is ok:
     assert not errors(update_values)
     # config is required with update_values:
@@ -1783,7 +1788,7 @@ def test_schema_sfc_climo_gen_namelist_update_values(sfc_climo_gen_prop):
     # array, boolean, number, and string values are ok:
     assert not errors({"array": [1, 2, 3], "bool": True, "int": 88, "float": 3.14, "string": "foo"})
     # Other types are not, e.g.:
-    assert "None is not of type 'array', 'boolean', 'number', 'string'" in errors({"null": None})
+    assert "None is not of type 'array', 'boolean', 'number', 'string'\n" in errors({"null": None})
     # No minimum number of entries is required:
     assert not errors({})
 
@@ -1792,7 +1797,7 @@ def test_schema_sfc_climo_gen_rundir(sfc_climo_gen_prop):
     errors = sfc_climo_gen_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # shave
@@ -1842,7 +1847,7 @@ def test_schema_shave_rundir(shave_prop):
     errors = shave_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # ungrib
@@ -1874,7 +1879,7 @@ def test_schema_ungrib_rundir(ungrib_prop):
     errors = ungrib_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # upp
@@ -2006,7 +2011,7 @@ def test_schema_upp_rundir(upp_prop):
     errors = upp_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)
 
 
 # ww3
@@ -2051,4 +2056,4 @@ def test_schema_ww3_rundir(ww3_prop):
     errors = ww3_prop("rundir")
     # Must be a string:
     assert not errors("/some/path")
-    assert "88 is not of type 'string'" in errors(88)
+    assert "88 is not of type 'string'\n" in errors(88)

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -662,6 +662,26 @@ def test_execution_batchargs():
     assert "[] is not of type 'object'" in errors([])
     # The "threads" argument is not allowed: It will be propagated, if set, from execution.threads.
     assert "should not be valid" in errors({"threads": 4, "walltime": "00:05:00"})
+    # Some keys require boolean values:
+    for key in ["debug", "exclusive"]:
+        assert "is not of type 'boolean'" in errors({key: None})
+    # Some keys require integer values:
+    for key in ["cores", "nodes"]:
+        assert "is not of type 'integer'" in errors({key: None})
+    # Some keys require string values:
+    for key in [
+        "export",
+        "jobname",
+        "memory",
+        "partition",
+        "queue",
+        "rundir",
+        "shell",
+        "stderr",
+        "stdout",
+        "walltime",
+    ]:
+        assert "is not of type 'string'" in errors({key: None})
 
 
 def test_execution_executable():


### PR DESCRIPTION
**Synopsis**

A set of updates to help in the development of the Coastal App coupled executable:

- In `uwtools.api` driver modules, use literal strings in the `__all__` array to avoid linter warnings in apps that import items (e.g. the `CDEPS` class from the `uwtools.api.cdeps` module) from these modules. While `pylint` on the command line does not complain, `pyright` in emacs flags these as potentially erroneous since it cannot determine what the dynamically-generated strings will be. I think it's better to avoid any suggestion of errors to users if possible.
- Make the `_taskname()` driver method public by renaming it to `taskname()`. This is handy to call in an external driver, and I can't see a reason to keep it private and require the awkward underscore. This accounts for the bulk of the diffs.
- In `cdeps.jsonschema`, let the CDEPS `stream_vectors` key take either a string or a string-array value. Update tests accordingly.
- Factor `batchargs` out of `execution.jsonschema` and `execution-serial.jsonschema` to `batchargs.jsonschema` and reference it. Also, extend the checks on types of known values.
- In `scheduler.py`, add logic to forbid the use of certain directives with certain schedulers. Immediate use case: Forbid use of the `shell` directive, which has no corresponding support in Slurm.
- Turn the `debug` directive into `--verbose` when specified for Slurm.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
