### PR TITLE
Make driver rundir an absolute path

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -96,7 +96,7 @@ class Assets(ABC):
         """
         The path to the component's run directory.
         """
-        return Path(self.config[STR.rundir])
+        return Path(self.config[STR.rundir]).absolute()
 
     def taskname(self, suffix: str) -> str:
         """


### PR DESCRIPTION
**Synopsis**

Forgotten in last PR: Make driver rundir an absolute path.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
