### PR TITLE
Use .get() lookups for optional schism, ww3 template_value items

### DIFF
--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -34,7 +34,7 @@ class SCHISM(AssetsCycleBased):
         render(
             input_file=template_file,
             output_file=path,
-            overrides=self.config[STR.namelist]["template_values"],
+            overrides=self.config[STR.namelist].get("template_values", {}),
         )
 
     @tasks

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -34,7 +34,7 @@ class WaveWatchIII(AssetsCycleBased):
         render(
             input_file=template_file,
             output_file=path,
-            overrides=self.config[STR.namelist]["template_values"],
+            overrides=self.config[STR.namelist].get("template_values", {}),
         )
 
     @tasks


### PR DESCRIPTION
**Synopsis**

The `template_values` item under `namelist` for `schism` and `ww3` is optional per those drivers' schemas (and based on user feedback, this is a good thing, in that they might like to provide a complete, ready-to-use file via the `template_file` value and not apply any Jinja2 evaluation to it), but access in the driver code is via `[]` lookup, making them de facto required. Change `[]` lookups to `.get()` with a `{}` default value.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
