### PR TITLE
UW-655 Get program name from sys.argv

### DIFF
--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -1022,7 +1022,7 @@ def _basic_setup(parser: Parser) -> Group:
         _switch(STR.version),
         action=STR.version,
         help="Show version info and exit",
-        version=f"%(prog)s {_version()}",
+        version=f"{Path(sys.argv[0]).name} {_version()}",
     )
     return optional
 


### PR DESCRIPTION
**Synopsis**

Old behavior:
```
$ uw config --version
uw config version 2.3.1 build 0
$ uw template --version
uw template version 2.3.1 build 0
```
`config` and `template` should not appear, as the version number belongs to `uw`, not to a mode.

New behavior:
```
$ uw config --version
uw version 2.3.1 build 0
$ uw template --version
uw version 2.3.1 build 0
```

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
