### PR TITLE
UW-656 Run-time checks for bad uw execute arguments

### DIFF
--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -67,6 +67,7 @@ def test__get_driver_module_implicit():
 
 def test_execute_fail_stdin_not_ok(kwargs):
     kwargs["config"] = None
+    kwargs["cycle"] = dt.datetime.now()
     kwargs["stdin_ok"] = False
     with raises(UWError) as e:
         driver_api.execute(**kwargs)

--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -65,6 +65,13 @@ def test__get_driver_module_implicit():
     pass
 
 
+@mark.parametrize("key,val", [("batch", True), ("leadtime", 6)])
+def test_execute_fail_bad_args(caplog, key, kwargs, val):
+    kwargs.update({"cycle": dt.datetime.now(), key: val})
+    assert driver_api.execute(**kwargs) is False
+    assert logged(caplog, f"TestDriver does not accept argument '{key}'")
+
+
 def test_execute_fail_stdin_not_ok(kwargs):
     kwargs["config"] = None
     kwargs["cycle"] = dt.datetime.now()


### PR DESCRIPTION
**Synopsis**

Old behavior:
```
$ uw execute --module /home/maddenp/execute/rand.py --classname Rand --task randfile --config-file /home/maddenp/execute/rand.yaml --cycle 2024-08-05T12 --leadtime 6 --batch
[2024-08-08T21:16:52]     INFO 0 UW schema-validation errors found
[2024-08-08T21:16:52]     INFO rand Random-integer file: Initial state: Not Ready
[2024-08-08T21:16:52]     INFO rand Random-integer file: Checking requirements
[2024-08-08T21:16:52]     INFO rand Random-integer file: Requirement(s) ready
[2024-08-08T21:16:52]     INFO rand Random-integer file: Executing
[2024-08-08T21:16:52]     INFO rand Random-integer file: Final state: Ready
```
This despite the fact that the `Rand` driver class (an minimal example class I'm working with for the [UW-649](https://jira.epic.oarcloud.noaa.gov/browse/UW-649) documentation task) inherits from `AssetsTimeInvariant` and so does not accept the `cycle`, `leadtime`, or `batch` arguments. This could confuse users who supply these arguments expecting them to have some effect.

New behavior:
```
$ uw execute --module /home/maddenp/execute/rand.py --classname Rand --task randfile --config-file /home/maddenp/execute/rand.yaml --cycle 2024-08-05T12
[2024-08-08T21:18:42]    ERROR Rand does not accept argument 'cycle'
$ uw execute --module /home/maddenp/execute/rand.py --classname Rand --task randfile --config-file /home/maddenp/execute/rand.yaml --leadtime 6
[2024-08-08T21:18:54]    ERROR Rand does not accept argument 'leadtime'
$ uw execute --module /home/maddenp/execute/rand.py --classname Rand --task randfile --config-file /home/maddenp/execute/rand.yaml --batch
[2024-08-08T21:19:03]    ERROR Rand does not accept argument 'batch'
```

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
