### PR TITLE
Make driver_name() public

### DIFF
--- a/src/uwtools/drivers/cdeps.py
+++ b/src/uwtools/drivers/cdeps.py
@@ -93,14 +93,16 @@ class CDEPS(AssetsCycleBased):
         yield file(path=Path(template_file))
         self._model_stream_file("ocn_streams", path, template_file)
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.cdeps
+
+    # Private helper methods
 
     def _model_namelist_file(self, group: str, path: Path) -> None:
         """

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -89,10 +89,10 @@ class ChgresCube(DriverCycleBased):
         }
         self._write_runscript(path=path, envvars=envvars)
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """

--- a/src/uwtools/drivers/esg_grid.py
+++ b/src/uwtools/drivers/esg_grid.py
@@ -49,10 +49,10 @@ class ESGGrid(DriverTimeInvariant):
             self.runscript(),
         ]
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -60,10 +60,10 @@ class FilterTopo(DriverTimeInvariant):
             self.runscript(),
         ]
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -176,10 +176,10 @@ class FV3(DriverCycleBased):
         }
         self._write_runscript(path=path, envvars=envvars)
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """

--- a/src/uwtools/drivers/global_equiv_resol.py
+++ b/src/uwtools/drivers/global_equiv_resol.py
@@ -38,14 +38,16 @@ class GlobalEquivResol(DriverTimeInvariant):
             self.runscript(),
         ]
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.globalequivresol
+
+    # Private helper methods
 
     @property
     def _runcmd(self):

--- a/src/uwtools/drivers/ioda.py
+++ b/src/uwtools/drivers/ioda.py
@@ -29,6 +29,15 @@ class IODA(JEDIBase):
             self.runscript(),
         ]
 
+    # Public helper methods
+
+    @property
+    def driver_name(self) -> str:
+        """
+        Returns the name of this driver.
+        """
+        return STR.ioda
+
     # Private helper methods
 
     @property
@@ -37,13 +46,6 @@ class IODA(JEDIBase):
         Returns the name of the config file used in execution.
         """
         return "ioda.yaml"
-
-    @property
-    def _driver_name(self) -> str:
-        """
-        Returns the name of this driver.
-        """
-        return STR.ioda
 
     @property
     def _runcmd(self) -> str:

--- a/src/uwtools/drivers/jedi.py
+++ b/src/uwtools/drivers/jedi.py
@@ -54,6 +54,15 @@ class JEDI(JEDIBase):
             logging.info("%s: Config is valid", taskname)
             a.ready = lambda: True
 
+    # Public helper methods
+
+    @property
+    def driver_name(self) -> str:
+        """
+        Returns the name of this driver.
+        """
+        return STR.jedi
+
     # Private helper methods
 
     @property
@@ -62,13 +71,6 @@ class JEDI(JEDIBase):
         Returns the name of the config file used in execution.
         """
         return "jedi.yaml"
-
-    @property
-    def _driver_name(self) -> str:
-        """
-        Returns the name of this driver.
-        """
-        return STR.jedi
 
     @property
     def _runcmd(self) -> str:

--- a/src/uwtools/drivers/make_hgrid.py
+++ b/src/uwtools/drivers/make_hgrid.py
@@ -24,14 +24,16 @@ class MakeHgrid(DriverTimeInvariant):
         yield self.taskname("provisioned run directory")
         yield self.runscript()
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.makehgrid
+
+    # Private helper methods
 
     @property
     def _runcmd(self):

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -32,16 +32,18 @@ class MakeSoloMosaic(DriverTimeInvariant):
 
         :param suffix: Log-string suffix.
         """
-        return "%s %s" % (self._driver_name, suffix)
+        return "%s %s" % (self.driver_name, suffix)
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.makesolomosaic
+
+    # Private helper methods
 
     @property
     def _runcmd(self):

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -66,14 +66,16 @@ class MPAS(MPASBase):
             schema=self._namelist_schema(),
         )
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.mpas
+
+    # Private helper methods
 
     @property
     def _streams_fn(self) -> str:

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -68,14 +68,16 @@ class MPASInit(MPASBase):
             schema=self._namelist_schema(),
         )
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.mpasinit
+
+    # Private helper methods
 
     @property
     def _streams_fn(self) -> str:

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -70,14 +70,16 @@ class OrogGSL(DriverTimeInvariant):
         yield asset(dst, dst.is_file)
         yield symlink(target=src, linkname=dst)
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.oroggsl
+
+    # Private helper methods
 
     @property
     def _runcmd(self):

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -45,10 +45,10 @@ class SCHISM(AssetsCycleBased):
         yield self.taskname("provisioned run directory")
         yield self.namelist_file()
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -52,10 +52,10 @@ class SfcClimoGen(DriverTimeInvariant):
             self.runscript(),
         ]
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -24,14 +24,16 @@ class Shave(DriverTimeInvariant):
         yield self.taskname("provisioned run directory")
         yield self.runscript()
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.shave
+
+    # Private helper methods
 
     @property
     def _runcmd(self):

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -102,14 +102,16 @@ class Ungrib(DriverCycleBased):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.symlink_to(Path(self.config["vtable"]))
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.ungrib
+
+    # Private helper methods
 
     @task
     def _gribfile(self, infile: Path, link: Path):

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -72,14 +72,16 @@ class UPP(DriverCycleLeadtimeBased):
             self.runscript(),
         ]
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """
         return STR.upp
+
+    # Private helper methods
 
     @property
     def _namelist_path(self) -> Path:

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -59,10 +59,10 @@ class WaveWatchIII(AssetsCycleBased):
         yield None
         path.mkdir(parents=True)
 
-    # Private helper methods
+    # Public helper methods
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         """
         Returns the name of this driver.
         """

--- a/src/uwtools/tests/drivers/test_cdeps.py
+++ b/src/uwtools/tests/drivers/test_cdeps.py
@@ -111,8 +111,8 @@ def test_CDEPS_streams(driverobj, group):
         assert f.read().strip() == dedent(expected).strip()
 
 
-def test_CDEPS__driver_name(driverobj):
-    assert driverobj._driver_name == "cdeps"
+def test_CDEPS_driver_name(driverobj):
+    assert driverobj.driver_name == "cdeps"
 
 
 def test_CDEPS__model_namelist_file(driverobj):

--- a/src/uwtools/tests/drivers/test_chgres_cube.py
+++ b/src/uwtools/tests/drivers/test_chgres_cube.py
@@ -147,8 +147,8 @@ def test_ChgresCube_runscript(driverobj):
         assert [type(runscript.call_args.kwargs[x]) for x in args] == types
 
 
-def test_ChgresCube__driver_name(driverobj):
-    assert driverobj._driver_name == "chgres_cube"
+def test_ChgresCube_driver_name(driverobj):
+    assert driverobj.driver_name == "chgres_cube"
 
 
 def test_ChgresCube_taskname(driverobj):

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -40,7 +40,7 @@ class Common:
         pass
 
     @property
-    def _driver_name(self) -> str:
+    def driver_name(self) -> str:
         return "concrete"
 
     def _validate(self, schema_file: Optional[Path] = None) -> None:
@@ -218,7 +218,7 @@ def test_Assets_key_path(config, tmp_path):
     assetsobj = ConcreteAssetsTimeInvariant(
         config=config_file, dry_run=False, key_path=["foo", "bar"]
     )
-    assert assetsobj.config == config[assetsobj._driver_name]
+    assert assetsobj.config == config[assetsobj.driver_name]
     assert assetsobj._platform == config["platform"]
 
 

--- a/src/uwtools/tests/drivers/test_esg_grid.py
+++ b/src/uwtools/tests/drivers/test_esg_grid.py
@@ -123,5 +123,5 @@ def test_ESGGrid_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_FilterTopo__driver_name(driverobj):
-    assert driverobj._driver_name == "esg_grid"
+def test_FilterTopo_driver_name(driverobj):
+    assert driverobj.driver_name == "esg_grid"

--- a/src/uwtools/tests/drivers/test_filter_topo.py
+++ b/src/uwtools/tests/drivers/test_filter_topo.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
+# pylint: disable=missing-function-docstring,redefined-outer-name
 """
 filter_topo driver tests.
 """
@@ -100,5 +100,5 @@ def test_FilterTopo_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_FilterTopo__driver_name(driverobj):
-    assert driverobj._driver_name == "filter_topo"
+def test_FilterTopo_driver_name(driverobj):
+    assert driverobj.driver_name == "filter_topo"

--- a/src/uwtools/tests/drivers/test_fv3.py
+++ b/src/uwtools/tests/drivers/test_fv3.py
@@ -247,9 +247,9 @@ def test_FV3_runscript(driverobj):
         assert [type(runscript.call_args.kwargs[x]) for x in args] == types
 
 
+def test_FV3_driver_name(driverobj):
+    assert driverobj.driver_name == "fv3"
+
+
 def test_FV3_taskname(driverobj):
     assert driverobj.taskname("foo") == "20240201 18Z fv3 foo"
-
-
-def test_FV3__driver_name(driverobj):
-    assert driverobj._driver_name == "fv3"

--- a/src/uwtools/tests/drivers/test_global_equiv_resol.py
+++ b/src/uwtools/tests/drivers/test_global_equiv_resol.py
@@ -83,11 +83,11 @@ def test_GlobalEquivResol_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
+def test_FilterTopo_driver_name(driverobj):
+    assert driverobj.driver_name == "global_equiv_resol"
+
+
 def test_GlobalEquivResol__runcmd(driverobj):
     cmd = driverobj._runcmd
     input_file_path = driverobj.config["input_grid_file"]
     assert cmd == f"/path/to/global_equiv_resol.exe {input_file_path}"
-
-
-def test_FilterTopo__driver_name(driverobj):
-    assert driverobj._driver_name == "global_equiv_resol"

--- a/src/uwtools/tests/drivers/test_ioda.py
+++ b/src/uwtools/tests/drivers/test_ioda.py
@@ -100,12 +100,12 @@ def test_IODA_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
+def test_IODA_driver_name(driverobj):
+    assert driverobj.driver_name == "ioda"
+
+
 def test_IODA__config_fn(driverobj):
     assert driverobj._config_fn == "ioda.yaml"
-
-
-def test_IODA__driver_name(driverobj):
-    assert driverobj._driver_name == "ioda"
 
 
 def test_IODA__runcmd(driverobj):

--- a/src/uwtools/tests/drivers/test_jedi.py
+++ b/src/uwtools/tests/drivers/test_jedi.py
@@ -188,12 +188,12 @@ def test_JEDI_validate_only(caplog, driverobj):
     assert regex_logged(caplog, "Config is valid")
 
 
+def test_JEDI_driver_name(driverobj):
+    assert driverobj.driver_name == "jedi"
+
+
 def test_JEDI__config_fn(driverobj):
     assert driverobj._config_fn == "jedi.yaml"
-
-
-def test_JEDI__driver_name(driverobj):
-    assert driverobj._driver_name == "jedi"
 
 
 def test_JEDI__runcmd(driverobj):

--- a/src/uwtools/tests/drivers/test_make_hgrid.py
+++ b/src/uwtools/tests/drivers/test_make_hgrid.py
@@ -76,8 +76,8 @@ def test_MakeHgrid_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_MakeHgrid__driver_name(driverobj):
-    assert driverobj._driver_name == "make_hgrid"
+def test_MakeHgrid_driver_name(driverobj):
+    assert driverobj.driver_name == "make_hgrid"
 
 
 def test_MakeHgrid__runcmd(driverobj):

--- a/src/uwtools/tests/drivers/test_make_solo_mosaic.py
+++ b/src/uwtools/tests/drivers/test_make_solo_mosaic.py
@@ -70,8 +70,8 @@ def test_MakeSoloMosaic_provisioned_rundir(driverobj):
         runscript.assert_called_once_with()
 
 
-def test_MakeSoloMosiac__driver_name(driverobj):
-    assert driverobj._driver_name == "make_solo_mosaic"
+def test_MakeSoloMosiac_driver_name(driverobj):
+    assert driverobj.driver_name == "make_solo_mosaic"
 
 
 def test_MakeSoloMosaic__runcmd(driverobj):

--- a/src/uwtools/tests/drivers/test_make_solo_mosaic.py
+++ b/src/uwtools/tests/drivers/test_make_solo_mosaic.py
@@ -70,7 +70,7 @@ def test_MakeSoloMosaic_provisioned_rundir(driverobj):
         runscript.assert_called_once_with()
 
 
-def test_MakeSoloMosiac_driver_name(driverobj):
+def test_MakeSoloMosaic_driver_name(driverobj):
     assert driverobj.driver_name == "make_solo_mosaic"
 
 

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -236,8 +236,8 @@ def test_MPAS_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_MPAS__driver_name(driverobj):
-    assert driverobj._driver_name == "mpas"
+def test_MPAS_driver_name(driverobj):
+    assert driverobj.driver_name == "mpas"
 
 
 def test_MPAS_streams_file(config, driverobj):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -211,8 +211,8 @@ def test_MPASInit_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_MPASInit__driver_name(driverobj):
-    assert driverobj._driver_name == "mpas_init"
+def test_MPASInit_driver_name(driverobj):
+    assert driverobj.driver_name == "mpas_init"
 
 
 def test_MPASInit_streams_file(config, driverobj):

--- a/src/uwtools/tests/drivers/test_orog_gsl.py
+++ b/src/uwtools/tests/drivers/test_orog_gsl.py
@@ -102,8 +102,8 @@ def test_OrogGSL_topo_data_3os(driverobj):
     assert path.is_symlink()
 
 
-def test_OrogGSL__driver_name(driverobj):
-    assert driverobj._driver_name == "orog_gsl"
+def test_OrogGSL_driver_name(driverobj):
+    assert driverobj.driver_name == "orog_gsl"
 
 
 def test_OrogGSL__runcmd(driverobj):

--- a/src/uwtools/tests/drivers/test_schism.py
+++ b/src/uwtools/tests/drivers/test_schism.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
+# pylint: disable=missing-function-docstring,redefined-outer-name
 """
 SCHISM driver tests.
 """
@@ -71,5 +71,5 @@ def test_SCHISM_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_SCHISM__driver_name(driverobj):
-    assert driverobj._driver_name == "schism"
+def test_SCHISM_driver_name(driverobj):
+    assert driverobj.driver_name == "schism"

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -138,5 +138,5 @@ def test_SfcClimoGen_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_SfcClimoGen__driver_name(driverobj):
-    assert driverobj._driver_name == "sfc_climo_gen"
+def test_SfcClimoGen_driver_name(driverobj):
+    assert driverobj.driver_name == "sfc_climo_gen"

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -80,8 +80,8 @@ def test_Shave_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_Shave__driver_name(driverobj):
-    assert driverobj._driver_name == "shave"
+def test_Shave_driver_name(driverobj):
+    assert driverobj.driver_name == "shave"
 
 
 def test_Shave__runcmd(driverobj):

--- a/src/uwtools/tests/drivers/test_support.py
+++ b/src/uwtools/tests/drivers/test_support.py
@@ -60,7 +60,7 @@ def test_tasks():
             "@tasks t3"
 
         @property
-        def _driver_name(self):
+        def driver_name(self):
             pass
 
         @property

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -125,8 +125,8 @@ def test_Ungrib_vtable(driverobj):
     assert dst.is_symlink()
 
 
-def test_Ungrib__driver_name(driverobj):
-    assert driverobj._driver_name == "ungrib"
+def test_Ungrib_driver_name(driverobj):
+    assert driverobj.driver_name == "ungrib"
 
 
 def test_Ungrib__gribfile(driverobj):

--- a/src/uwtools/tests/drivers/test_upp.py
+++ b/src/uwtools/tests/drivers/test_upp.py
@@ -167,8 +167,8 @@ def test_UPP_provisioned_rundir(driverobj):
         mocks[m].assert_called_once_with()
 
 
-def test_UPP__driver_name(driverobj):
-    assert driverobj._driver_name == "upp"
+def test_UPP_driver_name(driverobj):
+    assert driverobj.driver_name == "upp"
 
 
 def test_UPP__namelist_path(driverobj):

--- a/src/uwtools/tests/drivers/test_ww3.py
+++ b/src/uwtools/tests/drivers/test_ww3.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
+# pylint: disable=missing-function-docstring,redefined-outer-name
 """
 WaveWatchIII driver tests.
 """
@@ -79,5 +79,5 @@ def test_WaveWatchIII_restart_directory(driverobj):
     assert path.is_dir()
 
 
-def test_WaveWatchIII__driver_name(driverobj):
-    assert driverobj._driver_name == "ww3"
+def test_WaveWatchIII_driver_name(driverobj):
+    assert driverobj.driver_name == "ww3"

--- a/src/uwtools/tests/fixtures/testdriver.py
+++ b/src/uwtools/tests/fixtures/testdriver.py
@@ -18,5 +18,5 @@ class TestDriver(AssetsCycleBased):
         yield None
 
     @property
-    def _driver_name(self):
+    def driver_name(self):
         return "testdriver"


### PR DESCRIPTION
**Synopsis**

Maybe the last one: Make the driver attribute `driver_name` public. It needs to be implemented in external drivers and strikes me as awkward to keep private. This is all just text-substitution of `_driver_name` -> `driver_name` and then repositioning some code in some files. Essentially trivial.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
