### PR TITLE
Bug Fix for the template render tool

### DIFF
--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -170,7 +170,7 @@ def render(
     :param searchpath: Paths to search for extra templates.
     :param values_needed: Just report variables needed to render the template?
     :param dry_run: Run in dry-run mode?
-    :return: The rendered template, or None.
+    :return: The unrendered template if values_needed is True, the rendered template, or None.
     """
     _report(locals())
     values = _supplement_values(
@@ -180,11 +180,11 @@ def render(
     undeclared_variables = template.undeclared_variables
 
     # If a report of variables required to render the template was requested, make that report and
-    # then return.
+    # then return the unrendered template.
 
     if values_needed:
         _values_needed(undeclared_variables)
-        return None
+        return str(template)
 
     # Render the template. If there are missing values, report them and return an error to the
     # caller.

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -52,18 +52,17 @@ def test_render_fail(kwargs):
         with raises(UWTemplateRenderError):
             template.render(**kwargs)
 
-def test_render_values_needed(caplog, template_file):
-    log.setLevel(logging.INFO)
-    template.render(input_file=template_file, values_needed=True)
-    for var in ("roses_color", "violets_color"):
-            assert logged(caplog, f"  {var}")
-
 def test_render_to_str(kwargs):
     del kwargs["output_file"]
     with patch.object(template, "render") as render:
         template.render_to_str(**kwargs)
         render.assert_called_once_with(**{**kwargs, "output_file": Path(os.devnull)})
 
+def test_render_values_needed(caplog, template_file):
+    log.setLevel(logging.INFO)
+    template.render(input_file=template_file, values_needed=True)
+    for var in ("roses_color", "violets_color"):
+            assert logged(caplog, f"  {var}")
 
 def test_translate():
     kwargs: dict = {

--- a/src/uwtools/tests/api/test_template.py
+++ b/src/uwtools/tests/api/test_template.py
@@ -9,8 +9,9 @@ from pytest import fixture, raises
 
 from uwtools.api import template
 from uwtools.exceptions import UWTemplateRenderError
-from uwtools.tests.support import logged
 from uwtools.logging import log
+from uwtools.tests.support import logged
+
 
 @fixture
 def kwargs():
@@ -25,6 +26,7 @@ def kwargs():
         "values_needed": True,
         "dry_run": True,
     }
+
 
 @fixture
 def template_file(tmp_path):
@@ -52,17 +54,20 @@ def test_render_fail(kwargs):
         with raises(UWTemplateRenderError):
             template.render(**kwargs)
 
+
 def test_render_to_str(kwargs):
     del kwargs["output_file"]
     with patch.object(template, "render") as render:
         template.render_to_str(**kwargs)
         render.assert_called_once_with(**{**kwargs, "output_file": Path(os.devnull)})
 
+
 def test_render_values_needed(caplog, template_file):
     log.setLevel(logging.INFO)
     template.render(input_file=template_file, values_needed=True)
     for var in ("roses_color", "violets_color"):
-            assert logged(caplog, f"  {var}")
+        assert logged(caplog, f"  {var}")
+
 
 def test_translate():
     kwargs: dict = {


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->
`template.render` and `template.render_to_str` currently return `None` when the `values_needed` parameter is set to `True`, which leads to an error being raised. This fix has the functions return the unrendered template instead. A unit test is added that fails for the old behavior and passes for the new behavior.

**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [ ] I have added myself and any co-authors to the PR's _Assignees_ list.
- [ ] I have reviewed the documentation and have made any updates necessitated by this change.
