### PR TITLE
DRY out Driver._validate()

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -479,12 +479,7 @@ class Driver(Assets):
         :param schema_file: The JSON Schema file to use for validation.
         :raises: UWConfigError if config fails validation.
         """
-        if schema_file:
-            validate_external(schema_file=schema_file, config=self._config_intermediate)
-        else:
-            validate_internal(
-                schema_name=self.driver_name.replace("_", "-"), config=self._config_intermediate
-            )
+        Assets._validate(self, schema_file)
         validate_internal(schema_name=STR.platform, config=self._config_intermediate)
 
     def _write_runscript(self, path: Path, envvars: Optional[dict[str, str]] = None) -> None:


### PR DESCRIPTION
**Synopsis**

DRY out code duplicated between `Assets._validate()` and `Driver._validate()`. This might not have prevented the bug addressed by #574 but might help prevent future need-updates-in-multiple-places bugs.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
