### PR TITLE
Simplify unknown-extension error message

### DIFF
--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import IO, Any, Generator, Optional, Union
 
 from uwtools.exceptions import UWError
-from uwtools.logging import log
 from uwtools.strings import FORMAT
 
 
@@ -52,10 +51,9 @@ def get_file_format(path: Path) -> str:
     suffix = Path(path).suffix.replace(".", "")
     try:
         return FORMAT.formats()[suffix]
-    except KeyError as e:
+    except KeyError:
         msg = f"Cannot deduce format of '{path}' from unknown extension '{suffix}'"
-        log.critical(msg)
-        raise UWError(msg) from e
+        raise UWError(msg) from None
 
 
 def path_if_it_exists(path: str) -> str:


### PR DESCRIPTION
**Synopsis**

When a file with an unrecognized extension is specified, `uwtools` provides information on the underlying `KeyError` that is not useful to users. This PR simplifies the information presented to the user.

Old behavior:
```
>>> template.render(input_file="template.jinja2", values_src="values.txt")
Cannot deduce format of 'values.txt' from unknown extension 'txt'
Traceback (most recent call last):
  File "/home/maddenp/git/uwtools/src/uwtools/utils/file.py", line 54, in get_file_format
    return FORMAT.formats()[suffix]
           ~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'txt'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/maddenp/git/uwtools/src/uwtools/api/template.py", line 50, in render
    result = _render(
             ^^^^^^^^
  File "/home/maddenp/git/uwtools/src/uwtools/config/jinja2.py", line 176, in render
    values = _supplement_values(
             ^^^^^^^^^^^^^^^^^^^
  File "/home/maddenp/git/uwtools/src/uwtools/config/jinja2.py", line 349, in _supplement_values
    values_format = values_format or get_file_format(values_src)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maddenp/git/uwtools/src/uwtools/utils/file.py", line 58, in get_file_format
    raise UWError(msg) from e
uwtools.exceptions.UWError: Cannot deduce format of 'values.txt' from unknown extension 'txt'
```

New behavior:
```
>>> template.render(input_file="template.jinja2", values_src="values.txt")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/maddenp/git/uwtools/src/uwtools/api/template.py", line 50, in render
    result = _render(
             ^^^^^^^^
  File "/home/maddenp/git/uwtools/src/uwtools/config/jinja2.py", line 176, in render
    values = _supplement_values(
             ^^^^^^^^^^^^^^^^^^^
  File "/home/maddenp/git/uwtools/src/uwtools/config/jinja2.py", line 349, in _supplement_values
    values_format = values_format or get_file_format(values_src)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maddenp/git/uwtools/src/uwtools/utils/file.py", line 56, in get_file_format
    raise UWError(msg) from None
uwtools.exceptions.UWError: Cannot deduce format of 'values.txt' from unknown extension 'txt'
```

CLI behavior remains:
```
$ echo "{{ x }}" | uw template render --values-file values.txt
Cannot deduce format of 'values.txt' from unknown extension 'txt'
```

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
