### PR TITLE
Docstring cleanup

### DIFF
--- a/docs/sections/user_guide/cli/drivers/cdeps/help.out
+++ b/docs/sections/user_guide/cli/drivers/cdeps/help.out
@@ -11,16 +11,16 @@ Optional arguments:
 Positional arguments:
   TASK
     atm
-      Create data atmosphere configuration with all required content
+      The data atmosphere configuration with all required content
     atm_nml
-      Create data atmosphere Fortran namelist file (datm_in)
+      The data atmosphere Fortran namelist file (datm_in)
     atm_stream
-      Create data atmosphere stream config file (datm.streams)
+      The data atmosphere stream config file (datm.streams)
     ocn
-      Create data ocean configuration with all required content
+      The data ocean configuration with all required content
     ocn_nml
-      Create data ocean Fortran namelist file (docn_in)
+      The data ocean Fortran namelist file (docn_in)
     ocn_stream
-      Create data ocean stream config file (docn.streams)
+      The data ocean stream config file (docn.streams)
     validate
       Validate the UW driver config

--- a/docs/sections/user_guide/cli/drivers/cdeps/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/cdeps/run-help.out
@@ -2,7 +2,7 @@ usage: uw cdeps atm --cycle CYCLE [-h] [--version] [--config-file PATH]
                     [--dry-run] [--graph-file PATH] [--key-path KEY[.KEY...]]
                     [--quiet] [--verbose]
 
-Create data atmosphere configuration with all required content
+The data atmosphere configuration with all required content
 
 Required arguments:
   --cycle CYCLE

--- a/src/uwtools/api/execute.py
+++ b/src/uwtools/api/execute.py
@@ -88,7 +88,7 @@ def execute(
 
 def tasks(module: Union[Path, str], classname: str) -> dict[str, str]:
     """
-    Returns a mapping from driver task names to their one-line descriptions.
+    Return a mapping from driver task names to their one-line descriptions.
 
     :param module: Name of driver module.
     :param classname: Name of driver class to instantiate.
@@ -104,7 +104,7 @@ def _get_driver_class(
     module: Union[Path, str], classname: str
 ) -> tuple[Optional[Type], Optional[Path]]:
     """
-    Returns the driver class.
+    Return the driver class.
 
     :param module: Name of driver module to load.
     :param classname: Name of driver class to instantiate.
@@ -124,7 +124,7 @@ def _get_driver_class(
 
 def _get_driver_module_explicit(module: Path) -> Optional[ModuleType]:
     """
-    Returns the named module found via explicit lookup of given path.
+    Return the named module found via explicit lookup of given path.
 
     :param module: Name of driver module to load.
     """
@@ -143,7 +143,7 @@ def _get_driver_module_explicit(module: Path) -> Optional[ModuleType]:
 
 def _get_driver_module_implicit(module: str) -> Optional[ModuleType]:
     """
-    Returns the named module found via implicit (sys.path-based) lookup.
+    Return the named module found via implicit (sys.path-based) lookup.
 
     :param module: Name of driver module to load.
     """

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -100,7 +100,7 @@ def main() -> None:
 
 def _add_subparser_config(subparsers: Subparsers) -> ModeChecks:
     """
-    Subparser for mode: config
+    Add subparser for mode: config
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -116,7 +116,7 @@ def _add_subparser_config(subparsers: Subparsers) -> ModeChecks:
 
 def _add_subparser_config_compare(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: config compare
+    Add subparser for mode: config compare
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -146,7 +146,7 @@ def _add_subparser_config_compare(subparsers: Subparsers) -> ActionChecks:
 
 def _add_subparser_config_realize(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: config realize
+    Add subparser for mode: config realize
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -172,7 +172,7 @@ def _add_subparser_config_realize(subparsers: Subparsers) -> ActionChecks:
 
 def _add_subparser_config_validate(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: config validate
+    Add subparser for mode: config validate
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -186,7 +186,7 @@ def _add_subparser_config_validate(subparsers: Subparsers) -> ActionChecks:
 
 def _dispatch_config(args: Args) -> bool:
     """
-    Dispatch logic for config mode.
+    Define dispatch logic for config mode.
 
     :param args: Parsed command-line args.
     """
@@ -200,7 +200,7 @@ def _dispatch_config(args: Args) -> bool:
 
 def _dispatch_config_compare(args: Args) -> bool:
     """
-    Dispatch logic for config compare action.
+    Define dispatch logic for config compare action.
 
     :param args: Parsed command-line args.
     """
@@ -214,7 +214,7 @@ def _dispatch_config_compare(args: Args) -> bool:
 
 def _dispatch_config_realize(args: Args) -> bool:
     """
-    Dispatch logic for config realize action.
+    Define dispatch logic for config realize action.
 
     :param args: Parsed command-line args.
     """
@@ -242,7 +242,7 @@ def _dispatch_config_realize(args: Args) -> bool:
 
 def _dispatch_config_validate(args: Args) -> bool:
     """
-    Dispatch logic for config validate action.
+    Define dispatch logic for config validate action.
 
     :param args: Parsed command-line args.
     """
@@ -258,7 +258,7 @@ def _dispatch_config_validate(args: Args) -> bool:
 
 def _add_subparser_execute(subparsers: Subparsers) -> ModeChecks:
     """
-    Subparser for mode: execute
+    Add subparser for mode: execute
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -285,7 +285,7 @@ def _add_subparser_execute(subparsers: Subparsers) -> ModeChecks:
 
 def _dispatch_execute(args: Args) -> bool:
     """
-    Dispatch logic for execute mode.
+    Define dispatch logic for execute mode.
 
     :param args: Parsed command-line args.
     """
@@ -310,7 +310,7 @@ def _dispatch_execute(args: Args) -> bool:
 
 def _add_subparser_fs(subparsers: Subparsers) -> ModeChecks:
     """
-    Subparser for mode: fs
+    Add subparser for mode: fs
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -326,7 +326,7 @@ def _add_subparser_fs(subparsers: Subparsers) -> ModeChecks:
 
 def _add_subparser_fs_common(parser: Parser) -> ActionChecks:
     """
-    Common subparser code for mode: fs {copy link makedirs}
+    Perform common subparser setup for mode: fs {copy link makedirs}
 
     :param parser: The parser to configure.
     """
@@ -343,7 +343,7 @@ def _add_subparser_fs_common(parser: Parser) -> ActionChecks:
 
 def _add_subparser_fs_copy(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: fs copy
+    Add subparser for mode: fs copy
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -353,7 +353,7 @@ def _add_subparser_fs_copy(subparsers: Subparsers) -> ActionChecks:
 
 def _add_subparser_fs_link(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: fs link
+    Add subparser for mode: fs link
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -363,7 +363,7 @@ def _add_subparser_fs_link(subparsers: Subparsers) -> ActionChecks:
 
 def _add_subparser_fs_makedirs(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: fs makedirs
+    Add subparser for mode: fs makedirs
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -373,7 +373,7 @@ def _add_subparser_fs_makedirs(subparsers: Subparsers) -> ActionChecks:
 
 def _dispatch_fs(args: Args) -> bool:
     """
-    Dispatch logic for fs mode.
+    Define dispatch logic for fs mode.
 
     :param args: Parsed command-line args.
     """
@@ -387,7 +387,7 @@ def _dispatch_fs(args: Args) -> bool:
 
 def _dispatch_fs_copy(args: Args) -> bool:
     """
-    Dispatch logic for fs copy action.
+    Define dispatch logic for fs copy action.
 
     :param args: Parsed command-line args.
     """
@@ -404,7 +404,7 @@ def _dispatch_fs_copy(args: Args) -> bool:
 
 def _dispatch_fs_link(args: Args) -> bool:
     """
-    Dispatch logic for fs link action.
+    Define dispatch logic for fs link action.
 
     :param args: Parsed command-line args.
     """
@@ -421,7 +421,7 @@ def _dispatch_fs_link(args: Args) -> bool:
 
 def _dispatch_fs_makedirs(args: Args) -> bool:
     """
-    Dispatch logic for fs makedirs action.
+    Define dispatch logic for fs makedirs action.
 
     :param args: Parsed command-line args.
     """
@@ -441,7 +441,7 @@ def _dispatch_fs_makedirs(args: Args) -> bool:
 
 def _add_subparser_rocoto(subparsers: Subparsers) -> ModeChecks:
     """
-    Subparser for mode: rocoto
+    Add subparser for mode: rocoto
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -456,7 +456,7 @@ def _add_subparser_rocoto(subparsers: Subparsers) -> ModeChecks:
 
 def _add_subparser_rocoto_realize(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: rocoto realize
+    Add subparser for mode: rocoto realize
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -470,7 +470,7 @@ def _add_subparser_rocoto_realize(subparsers: Subparsers) -> ActionChecks:
 
 def _add_subparser_rocoto_validate(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: rocoto validate
+    Add subparser for mode: rocoto validate
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -483,7 +483,7 @@ def _add_subparser_rocoto_validate(subparsers: Subparsers) -> ActionChecks:
 
 def _dispatch_rocoto(args: Args) -> bool:
     """
-    Dispatch logic for rocoto mode.
+    Define dispatch logic for rocoto mode.
 
     :param args: Parsed command-line args.
     """
@@ -496,7 +496,7 @@ def _dispatch_rocoto(args: Args) -> bool:
 
 def _dispatch_rocoto_realize(args: Args) -> bool:
     """
-    Dispatch logic for rocoto realize action. Validate input and output.
+    Define dispatch logic for rocoto realize action. Validate input and output.
 
     :param args: Parsed command-line args.
     """
@@ -509,7 +509,7 @@ def _dispatch_rocoto_realize(args: Args) -> bool:
 
 def _dispatch_rocoto_validate(args: Args) -> bool:
     """
-    Dispatch logic for rocoto validate action.
+    Define dispatch logic for rocoto validate action.
 
     :param args: Parsed command-line args.
     """
@@ -521,7 +521,7 @@ def _dispatch_rocoto_validate(args: Args) -> bool:
 
 def _add_subparser_template(subparsers: Subparsers) -> ModeChecks:
     """
-    Subparser for mode: template
+    Add subparser for mode: template
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -536,7 +536,7 @@ def _add_subparser_template(subparsers: Subparsers) -> ModeChecks:
 
 def _add_subparser_template_translate(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: template translate
+    Add subparser for mode: template translate
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -550,7 +550,7 @@ def _add_subparser_template_translate(subparsers: Subparsers) -> ActionChecks:
 
 def _add_subparser_template_render(subparsers: Subparsers) -> ActionChecks:
     """
-    Subparser for mode: template render
+    Add subparser for mode: template render
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
@@ -571,7 +571,7 @@ def _add_subparser_template_render(subparsers: Subparsers) -> ActionChecks:
 
 def _dispatch_template(args: Args) -> bool:
     """
-    Dispatch logic for template mode.
+    Define dispatch logic for template mode.
 
     :param args: Parsed command-line args.
     """
@@ -584,7 +584,7 @@ def _dispatch_template(args: Args) -> bool:
 
 def _dispatch_template_render(args: Args) -> bool:
     """
-    Dispatch logic for template render action.
+    Define dispatch logic for template render action.
 
     :param args: Parsed command-line args.
     """
@@ -611,7 +611,7 @@ def _dispatch_template_render(args: Args) -> bool:
 
 def _dispatch_template_translate(args: Args) -> bool:
     """
-    Dispatch logic for template translate action.
+    Define dispatch logic for template translate action.
 
     :param args: Parsed command-line args.
     """
@@ -968,7 +968,7 @@ def _add_subparser_for_driver(
     with_leadtime: Optional[bool] = False,
 ) -> ModeChecks:
     """
-    Subparser for a standalone-driver mode.
+    Add subparser for a standalone-driver mode.
 
     :param name: Name of the driver whose subparser to configure.
     :param subparsers: Parent parser's subparsers, to add this subparser to.
@@ -996,7 +996,7 @@ def _add_subparser_for_driver_task(
     with_leadtime: Optional[bool] = False,
 ) -> ActionChecks:
     """
-    Subparser for a driver action.
+    Add subparser for a driver action.
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     :param task: The task to add a subparser for.
@@ -1101,7 +1101,7 @@ def _dict_from_key_eq_val_strings(config_items: list[str]) -> dict[str, str]:
 
 def _dispatch_to_driver(name: str, args: Args) -> bool:
     """
-    Dispatch logic for a driver mode.
+    Define dispatch logic for a driver mode.
 
     :param name: Name of the driver to dispatch to.
     :param args: Parsed command-line args.
@@ -1123,7 +1123,7 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
 
 def _formatter(prog: str) -> HelpFormatter:
     """
-    A standard formatter for help messages.
+    Return a standard formatter for help messages.
     """
     # max_help_positions sets the maximum starting column for option help text.
     return HelpFormatter(prog, max_help_position=6)

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -14,7 +14,7 @@ def convert(
     input_file: Optional[Path] = None, output_file: Optional[Path] = None, dry_run: bool = False
 ) -> None:
     """
-    Replaces atparse @[] tokens with Jinja2 {{}} equivalents.
+    Replace atparse @[] tokens with Jinja2 {{}} equivalents.
 
     If no input file is given, stdin is used. If no output file is given, stdout is used. In dry-run
     mode, output is written to stderr.

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -40,7 +40,7 @@ class Config(ABC, UserDict):
 
     def __repr__(self) -> str:
         """
-        Returns the string representation of a Config object.
+        Return the string representation of a Config object.
         """
         return self._dict_to_str(self.data)
 
@@ -79,7 +79,7 @@ class Config(ABC, UserDict):
     @property
     def _depth(self) -> int:
         """
-        Returns the depth of this config's hierarchy.
+        Return the depth of this config's hierarchy.
         """
         return depth(self.data)
 
@@ -87,7 +87,7 @@ class Config(ABC, UserDict):
     @abstractmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
-        Returns the string representation of the given dict.
+        Return the string representation of the given dict.
 
         :param cfg: A dict object.
         """
@@ -96,14 +96,14 @@ class Config(ABC, UserDict):
     @abstractmethod
     def _get_depth_threshold() -> Optional[int]:
         """
-        Returns the config's depth threshold.
+        Return the config's depth threshold.
         """
 
     @staticmethod
     @abstractmethod
     def _get_format() -> str:
         """
-        Returns the config's format name.
+        Return the config's format name.
         """
 
     @abstractmethod
@@ -111,7 +111,7 @@ class Config(ABC, UserDict):
         """
         Reads and parses a config file.
 
-        Returns the result of loading and parsing the specified config file, or stdin if no file is
+        Return the result of loading and parsing the specified config file, or stdin if no file is
         given.
 
         :param config_file: Path to config file to load.

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -79,7 +79,7 @@ class Config(ABC, UserDict):
     @property
     def _depth(self) -> int:
         """
-        Return the depth of this config's hierarchy.
+        The depth of this config's hierarchy.
         """
         return depth(self.data)
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -109,7 +109,7 @@ class Config(ABC, UserDict):
     @abstractmethod
     def _load(self, config_file: Optional[Path]) -> dict:
         """
-        Reads and parses a config file.
+        Read and parse a config file.
 
         Return the result of loading and parsing the specified config file, or stdin if no file is
         given.
@@ -218,7 +218,7 @@ class Config(ABC, UserDict):
     @abstractmethod
     def dump(self, path: Optional[Path]) -> None:
         """
-        Dumps the config to stdout or a file.
+        Dump the config to stdout or a file.
 
         :param path: Path to dump config to (default: stdout).
         """
@@ -227,7 +227,7 @@ class Config(ABC, UserDict):
     @abstractmethod
     def dump_dict(cfg: dict, path: Optional[Path] = None) -> None:
         """
-        Dumps a provided config dictionary to stdout or a file.
+        Dump a provided config dictionary to stdout or a file.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to (default: stdout).
@@ -235,7 +235,7 @@ class Config(ABC, UserDict):
 
     def update_from(self, src: Union[dict, UserDict]) -> None:
         """
-        Updates a config.
+        Update a config.
 
         :param src: The dictionary with new data to use.
         """

--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -16,7 +16,7 @@ class FieldTableConfig(YAMLConfig):
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
-        Returns the field-table representation of the given dict.
+        Return the field-table representation of the given dict.
 
         :param cfg: A dict object.
         """
@@ -39,14 +39,14 @@ class FieldTableConfig(YAMLConfig):
     @staticmethod
     def _get_depth_threshold() -> Optional[int]:
         """
-        Returns the config's depth threshold.
+        Return the config's depth threshold.
         """
         return None
 
     @staticmethod
     def _get_format() -> str:
         """
-        Returns the config's format name.
+        Return the config's format name.
         """
         return FORMAT.fieldtable
 

--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -54,7 +54,7 @@ class FieldTableConfig(YAMLConfig):
 
     def dump(self, path: Optional[Path] = None) -> None:
         """
-        Dumps the config in Field Table format.
+        Dump the config in Field Table format.
 
         :param path: Path to dump config to (default: stdout).
         """
@@ -63,7 +63,7 @@ class FieldTableConfig(YAMLConfig):
     @classmethod
     def dump_dict(cls, cfg: dict, path: Optional[Path] = None) -> None:
         """
-        Dumps a provided config dictionary in Field Table format.
+        Dump a provided config dictionary in Field Table format.
 
         FMS field and tracer managers must be registered in an ASCII table called ``field_table``.
         This table lists field type, target model and methods the querying model will ask for. See

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -59,7 +59,7 @@ class INIConfig(Config):
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """
-        Reads and parses an INI file.
+        Read and parse an INI file.
 
         See docs for Config._load().
 
@@ -74,7 +74,7 @@ class INIConfig(Config):
 
     def dump(self, path: Optional[Path] = None) -> None:
         """
-        Dumps the config in INI format.
+        Dump the config in INI format.
 
         :param path: Path to dump config to (default: stdout).
         """
@@ -83,7 +83,7 @@ class INIConfig(Config):
     @classmethod
     def dump_dict(cls, cfg: dict, path: Optional[Path] = None) -> None:
         """
-        Dumps a provided config dictionary in INI format.
+        Dump a provided config dictionary in INI format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to (default: stdout).

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -26,7 +26,7 @@ class INIConfig(Config):
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
-        Returns the INI representation of the given dict.
+        Return the INI representation of the given dict.
 
         :param cfg: A dict object.
         """
@@ -46,14 +46,14 @@ class INIConfig(Config):
     @staticmethod
     def _get_depth_threshold() -> Optional[int]:
         """
-        Returns the config's depth threshold.
+        Return the config's depth threshold.
         """
         return 2
 
     @staticmethod
     def _get_format() -> str:
         """
-        Returns the config's format name.
+        Return the config's format name.
         """
         return FORMAT.ini
 

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -31,7 +31,7 @@ class NMLConfig(Config):
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
-        Returns the field-table representation of the given dict.
+        Return the field-table representation of the given dict.
 
         :param cfg: A dict object.
         """
@@ -50,14 +50,14 @@ class NMLConfig(Config):
     @staticmethod
     def _get_depth_threshold() -> Optional[int]:
         """
-        Returns the config's depth threshold.
+        Return the config's depth threshold.
         """
         return None
 
     @staticmethod
     def _get_format() -> str:
         """
-        Returns the config's format name.
+        Return the config's format name.
         """
         return FORMAT.nml
 

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -63,11 +63,12 @@ class NMLConfig(Config):
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """
-        Reads and parses a Fortran namelist file.
+        Read and parse a Fortran namelist file.
 
         See docs for Config._load().
 
         :param config_file: Path to config file to load.
+        :return: The parsed namelist data.
         """
         with readable(config_file) as f:
             config: dict = f90nml.read(f)
@@ -77,7 +78,7 @@ class NMLConfig(Config):
 
     def dump(self, path: Optional[Path]) -> None:
         """
-        Dumps the config in Fortran namelist format.
+        Dump the config in Fortran namelist format.
 
         :param path: Path to dump config to (default: stdout).
         """
@@ -86,7 +87,7 @@ class NMLConfig(Config):
     @classmethod
     def dump_dict(cls, cfg: Union[dict, Namelist], path: Optional[Path] = None) -> None:
         """
-        Dumps a provided config dictionary in Fortran namelist format.
+        Dump a provided config dictionary in Fortran namelist format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to (default: stdout).

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -53,7 +53,7 @@ class SHConfig(Config):
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """
-        Reads and parses key=value lines from shell code.
+        Read and parse key=value lines from shell code.
 
         See docs for Config._load().
 
@@ -75,7 +75,7 @@ class SHConfig(Config):
 
     def dump(self, path: Optional[Path]) -> None:
         """
-        Dumps the config as key=value lines.
+        Dump the config as key=value lines.
 
         :param path: Path to dump config to (default: stdout).
         """
@@ -85,7 +85,7 @@ class SHConfig(Config):
     @classmethod
     def dump_dict(cls, cfg: dict, path: Optional[Path] = None) -> None:
         """
-        Dumps a provided config dictionary in bash format.
+        Dump a provided config dictionary in bash format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to (default: stdout).

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -27,7 +27,7 @@ class SHConfig(Config):
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
-        Returns the field-table representation of the given dict.
+        Return the field-table representation of the given dict.
 
         :param cfg: A dict object.
         """
@@ -40,14 +40,14 @@ class SHConfig(Config):
     @staticmethod
     def _get_depth_threshold() -> Optional[int]:
         """
-        Returns the config's depth threshold.
+        Return the config's depth threshold.
         """
         return 1
 
     @staticmethod
     def _get_format() -> str:
         """
-        Returns the config's format name.
+        Return the config's format name.
         """
         return FORMAT.sh
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -88,7 +88,7 @@ class YAMLConfig(Config):
 
     def _load(self, config_file: Optional[Path]) -> dict:
         """
-        Reads and parses a YAML file.
+        Read and parse a YAML file.
 
         See docs for Config._load().
 
@@ -124,6 +124,7 @@ class YAMLConfig(Config):
 
         :param dumper: The YAML dumper.
         :param data: The f90nml Namelist to serialize.
+        :return: A YAML mapping.
         """
         namelist_dict = data.todict()
         return dumper.represent_mapping("tag:yaml.org,2002:map", namelist_dict)
@@ -137,6 +138,7 @@ class YAMLConfig(Config):
 
         :param dumper: The YAML dumper.
         :param data: The OrderedDict to serialize.
+        :return: A YAML mapping.
         """
 
         return dumper.represent_mapping("tag:yaml.org,2002:map", from_od(data))
@@ -167,7 +169,7 @@ class YAMLConfig(Config):
 
     def dump(self, path: Optional[Path] = None) -> None:
         """
-        Dumps the config in YAML format.
+        Dump the config in YAML format.
 
         :param path: Path to dump config to (default: stdout).
         """
@@ -176,7 +178,7 @@ class YAMLConfig(Config):
     @classmethod
     def dump_dict(cls, cfg: dict, path: Optional[Path] = None) -> None:
         """
-        Dumps a provided config dictionary in YAML format.
+        Dump a provided config dictionary in YAML format.
 
         :param cfg: The in-memory config object to dump.
         :param path: Path to dump config to (default: stdout).
@@ -187,9 +189,7 @@ class YAMLConfig(Config):
 
 def _write_plain_open_ended(self, *args, **kwargs) -> None:
     """
-    Write YAML without ...
-
-    end-of-stream marker.
+    Write YAML without the "..." end-of-stream marker.
     """
     self.write_plain_base(*args, **kwargs)
     self.open_ended = False

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -65,7 +65,7 @@ class YAMLConfig(Config):
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:
         """
-        Returns the YAML representation of the given dict.
+        Return the YAML representation of the given dict.
 
         :param cfg: The in-memory config object.
         """
@@ -75,14 +75,14 @@ class YAMLConfig(Config):
     @staticmethod
     def _get_depth_threshold() -> Optional[int]:
         """
-        Returns the config's depth threshold.
+        Return the config's depth threshold.
         """
         return None
 
     @staticmethod
     def _get_format() -> str:
         """
-        Returns the config's format name.
+        Return the config's format name.
         """
         return FORMAT.yaml
 
@@ -143,7 +143,7 @@ class YAMLConfig(Config):
 
     def _yaml_include(self, loader: yaml.Loader, node: yaml.SequenceNode) -> dict:
         """
-        Returns a dictionary with include tags processed.
+        Return a dictionary with include tags processed.
 
         :param loader: The YAML loader.
         :param node: A YAML node.

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -154,7 +154,7 @@ class YAMLConfig(Config):
     @property
     def _yaml_loader(self) -> type[yaml.SafeLoader]:
         """
-        Set up the loader with the appropriate constructors.
+        The loader, with appropriate constructors added.
         """
         loader = yaml.SafeLoader
         loader.add_constructor(INCLUDE_TAG, self._yaml_include)

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -90,7 +90,7 @@ class J2Template:
     @property
     def undeclared_variables(self) -> set[str]:
         """
-        Return the names of variables needed to render the template.
+        The names of variables needed to render the template.
 
         :return: Names of variables needed to render the template.
         """

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -19,7 +19,7 @@ _ConfigVal = Union[bool, dict, float, int, list, str, UWYAMLConvert, UWYAMLRemov
 
 class J2Template:
     """
-    Reads Jinja2 templates from files or strings, and renders them using the user-provided values.
+    Read Jinja2 templates from files or strings, and render them using the user-provided values.
     """
 
     def __init__(
@@ -91,8 +91,6 @@ class J2Template:
     def undeclared_variables(self) -> set[str]:
         """
         The names of variables needed to render the template.
-
-        :return: Names of variables needed to render the template.
         """
         j2_parsed = self._j2env.parse(self._template_str)
         return meta.find_undeclared_variables(j2_parsed)

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -90,7 +90,7 @@ class J2Template:
     @property
     def undeclared_variables(self) -> set[str]:
         """
-        Returns the names of variables needed to render the template.
+        Return the names of variables needed to render the template.
 
         :return: Names of variables needed to render the template.
         """

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -49,7 +49,7 @@ def format_to_config(fmt: str) -> Type:
 
 def from_od(d: Union[OrderedDict, dict]) -> dict:
     """
-    Returns a (nested) dict with content equivalent to the given (nested) OrderedDict.
+    Return a (nested) dict with content equivalent to the given (nested) OrderedDict.
 
     :param d: A (possibly nested) OrderedDict.
     """
@@ -69,7 +69,7 @@ def log_and_error(msg: str) -> Exception:
 
 def yaml_to_str(cfg: dict) -> str:
     """
-    Returns a uwtools-conventional YAML representation of the given dict.
+    Return a uwtools-conventional YAML representation of the given dict.
 
     :param cfg: A dict object.
     """

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -161,7 +161,7 @@ def _ensure_format(
 
 def _print_config_section(config: dict, key_path: list[str]) -> None:
     """
-    Prints the contents of the located subtree as key=value pairs, one per line.
+    Print the contents of the located subtree as key=value pairs, one per line.
 
     :param config: A config.
     :param key_path: Path of keys to subsection of config file.

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -21,7 +21,7 @@ from uwtools.utils.file import resource_path
 
 def get_schema_file(schema_name: str) -> Path:
     """
-    Returns the path to the JSON Schema file for a given name.
+    Return the path to the JSON Schema file for a given name.
 
     :param schema_name: Name of uwtools schema to validate the config against.
     """

--- a/src/uwtools/drivers/cdeps.py
+++ b/src/uwtools/drivers/cdeps.py
@@ -98,7 +98,7 @@ class CDEPS(AssetsCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.cdeps
 

--- a/src/uwtools/drivers/cdeps.py
+++ b/src/uwtools/drivers/cdeps.py
@@ -24,7 +24,7 @@ class CDEPS(AssetsCycleBased):
     @tasks
     def atm(self):
         """
-        Create data atmosphere configuration with all required content.
+        The data atmosphere configuration with all required content.
         """
         yield self.taskname("data atmosphere configuration")
         yield [
@@ -35,7 +35,7 @@ class CDEPS(AssetsCycleBased):
     @task
     def atm_nml(self):
         """
-        Create data atmosphere Fortran namelist file (datm_in).
+        The data atmosphere Fortran namelist file (datm_in).
         """
         fn = "datm_in"
         yield self.taskname(f"namelist file {fn}")
@@ -47,7 +47,7 @@ class CDEPS(AssetsCycleBased):
     @task
     def atm_stream(self):
         """
-        Create data atmosphere stream config file (datm.streams).
+        The data atmosphere stream config file (datm.streams).
         """
         fn = "datm.streams"
         yield self.taskname(f"stream file {fn}")
@@ -60,7 +60,7 @@ class CDEPS(AssetsCycleBased):
     @tasks
     def ocn(self):
         """
-        Create data ocean configuration with all required content.
+        The data ocean configuration with all required content.
         """
         yield self.taskname("data atmosphere configuration")
         yield [
@@ -71,7 +71,7 @@ class CDEPS(AssetsCycleBased):
     @task
     def ocn_nml(self):
         """
-        Create data ocean Fortran namelist file (docn_in).
+        The data ocean Fortran namelist file (docn_in).
         """
         fn = "docn_in"
         yield self.taskname(f"namelist file {fn}")
@@ -83,7 +83,7 @@ class CDEPS(AssetsCycleBased):
     @task
     def ocn_stream(self):
         """
-        Create data ocean stream config file (docn.streams).
+        The data ocean stream config file (docn.streams).
         """
         fn = "docn.streams"
         yield self.taskname(f"stream file {fn}")

--- a/src/uwtools/drivers/cdeps.py
+++ b/src/uwtools/drivers/cdeps.py
@@ -98,7 +98,7 @@ class CDEPS(AssetsCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.cdeps
 

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -94,7 +94,7 @@ class ChgresCube(DriverCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.chgrescube
 

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -94,7 +94,7 @@ class ChgresCube(DriverCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.chgrescube
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -158,7 +158,7 @@ class Assets(ABC):
     @abstractmethod
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
 
     # Private helper methods
@@ -387,7 +387,7 @@ class Driver(Assets):
     @property
     def _run_resources(self) -> dict[str, Any]:
         """
-        Return platform configuration data.
+        The platform configuration data.
         """
         if not (platform := self._config_intermediate.get("platform")):
             raise UWConfigError("Required 'platform' block missing in config")
@@ -404,7 +404,7 @@ class Driver(Assets):
     @property
     def _runcmd(self) -> str:
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         execution = self.config.get(STR.execution, {})
         mpiargs = execution.get(STR.mpiargs, [])
@@ -461,14 +461,14 @@ class Driver(Assets):
     @property
     def _runscript_path(self) -> Path:
         """
-        Return the path to the runscript.
+        The path to the runscript.
         """
         return self.rundir / f"runscript.{self.driver_name}"
 
     @property
     def _scheduler(self) -> JobScheduler:
         """
-        Return the job scheduler specified by the platform information.
+        The job scheduler specified by the platform information.
         """
         return JobScheduler.get_scheduler(self._run_resources)
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -99,7 +99,7 @@ class Assets(ABC):
 
     def taskname(self, suffix: str) -> str:
         """
-        Returns a common tag for graph-task log messages.
+        Return a common tag for graph-task log messages.
 
         :param suffix: Log-string suffix.
         """
@@ -158,7 +158,7 @@ class Assets(ABC):
     @abstractmethod
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
 
     # Private helper methods
@@ -167,7 +167,7 @@ class Assets(ABC):
         self, config_keys: Optional[list[str]] = None, schema_keys: Optional[list[str]] = None
     ) -> dict:
         """
-        Returns the (sub)schema for validating the driver's namelist content.
+        Return the (sub)schema for validating the driver's namelist content.
 
         :param config_keys: Keys leading to the namelist block in the driver config.
         :param schema_keys: Keys leading to the namelist-validating (sub)schema.
@@ -387,7 +387,7 @@ class Driver(Assets):
     @property
     def _run_resources(self) -> dict[str, Any]:
         """
-        Returns platform configuration data.
+        Return platform configuration data.
         """
         if not (platform := self._config_intermediate.get("platform")):
             raise UWConfigError("Required 'platform' block missing in config")
@@ -404,7 +404,7 @@ class Driver(Assets):
     @property
     def _runcmd(self) -> str:
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         execution = self.config.get(STR.execution, {})
         mpiargs = execution.get(STR.mpiargs, [])
@@ -423,7 +423,7 @@ class Driver(Assets):
         scheduler: Optional[JobScheduler] = None,
     ) -> str:
         """
-        Returns a driver runscript.
+        Return a driver runscript.
 
         :param execution: Statements to execute.
         :param envcmds: Shell commands to set up runtime environment.
@@ -461,14 +461,14 @@ class Driver(Assets):
     @property
     def _runscript_path(self) -> Path:
         """
-        Returns the path to the runscript.
+        Return the path to the runscript.
         """
         return self.rundir / f"runscript.{self.driver_name}"
 
     @property
     def _scheduler(self) -> JobScheduler:
         """
-        Returns the job scheduler specified by the platform information.
+        Return the job scheduler specified by the platform information.
         """
         return JobScheduler.get_scheduler(self._run_resources)
 

--- a/src/uwtools/drivers/esg_grid.py
+++ b/src/uwtools/drivers/esg_grid.py
@@ -54,7 +54,7 @@ class ESGGrid(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.esggrid
 

--- a/src/uwtools/drivers/esg_grid.py
+++ b/src/uwtools/drivers/esg_grid.py
@@ -54,7 +54,7 @@ class ESGGrid(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.esggrid
 

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -65,7 +65,7 @@ class FilterTopo(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.filtertopo
 

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -65,7 +65,7 @@ class FilterTopo(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.filtertopo
 

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -181,7 +181,7 @@ class FV3(DriverCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.fv3
 

--- a/src/uwtools/drivers/fv3.py
+++ b/src/uwtools/drivers/fv3.py
@@ -181,7 +181,7 @@ class FV3(DriverCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.fv3
 

--- a/src/uwtools/drivers/global_equiv_resol.py
+++ b/src/uwtools/drivers/global_equiv_resol.py
@@ -43,7 +43,7 @@ class GlobalEquivResol(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.globalequivresol
 
@@ -52,7 +52,7 @@ class GlobalEquivResol(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         input_file_path = self.config["input_grid_file"]

--- a/src/uwtools/drivers/global_equiv_resol.py
+++ b/src/uwtools/drivers/global_equiv_resol.py
@@ -43,7 +43,7 @@ class GlobalEquivResol(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.globalequivresol
 
@@ -52,7 +52,7 @@ class GlobalEquivResol(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         input_file_path = self.config["input_grid_file"]

--- a/src/uwtools/drivers/ioda.py
+++ b/src/uwtools/drivers/ioda.py
@@ -34,7 +34,7 @@ class IODA(JEDIBase):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.ioda
 
@@ -43,14 +43,14 @@ class IODA(JEDIBase):
     @property
     def _config_fn(self) -> str:
         """
-        Returns the name of the config file used in execution.
+        Return the name of the config file used in execution.
         """
         return "ioda.yaml"
 
     @property
     def _runcmd(self) -> str:
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         jedi_config = str(self.rundir / self._config_fn)

--- a/src/uwtools/drivers/ioda.py
+++ b/src/uwtools/drivers/ioda.py
@@ -34,7 +34,7 @@ class IODA(JEDIBase):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.ioda
 
@@ -43,14 +43,14 @@ class IODA(JEDIBase):
     @property
     def _config_fn(self) -> str:
         """
-        Return the name of the config file used in execution.
+        The name of the config file used in execution.
         """
         return "ioda.yaml"
 
     @property
     def _runcmd(self) -> str:
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         jedi_config = str(self.rundir / self._config_fn)

--- a/src/uwtools/drivers/jedi.py
+++ b/src/uwtools/drivers/jedi.py
@@ -59,7 +59,7 @@ class JEDI(JEDIBase):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.jedi
 
@@ -68,14 +68,14 @@ class JEDI(JEDIBase):
     @property
     def _config_fn(self) -> str:
         """
-        Returns the name of the config file used in execution.
+        Return the name of the config file used in execution.
         """
         return "jedi.yaml"
 
     @property
     def _runcmd(self) -> str:
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         execution = self.config[STR.execution]
         jedi_config = self.rundir / self._config_fn

--- a/src/uwtools/drivers/jedi.py
+++ b/src/uwtools/drivers/jedi.py
@@ -59,7 +59,7 @@ class JEDI(JEDIBase):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.jedi
 
@@ -68,14 +68,14 @@ class JEDI(JEDIBase):
     @property
     def _config_fn(self) -> str:
         """
-        Return the name of the config file used in execution.
+        The name of the config file used in execution.
         """
         return "jedi.yaml"
 
     @property
     def _runcmd(self) -> str:
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         execution = self.config[STR.execution]
         jedi_config = self.rundir / self._config_fn

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -72,5 +72,5 @@ class JEDIBase(DriverCycleBased):
     @abstractmethod
     def _config_fn(self) -> str:
         """
-        Returns the name of the config file used in execution.
+        Return the name of the config file used in execution.
         """

--- a/src/uwtools/drivers/jedi_base.py
+++ b/src/uwtools/drivers/jedi_base.py
@@ -72,5 +72,5 @@ class JEDIBase(DriverCycleBased):
     @abstractmethod
     def _config_fn(self) -> str:
         """
-        Return the name of the config file used in execution.
+        The name of the config file used in execution.
         """

--- a/src/uwtools/drivers/make_hgrid.py
+++ b/src/uwtools/drivers/make_hgrid.py
@@ -29,7 +29,7 @@ class MakeHgrid(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.makehgrid
 
@@ -38,7 +38,7 @@ class MakeHgrid(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         config = self.config["config"]

--- a/src/uwtools/drivers/make_hgrid.py
+++ b/src/uwtools/drivers/make_hgrid.py
@@ -29,7 +29,7 @@ class MakeHgrid(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.makehgrid
 
@@ -38,7 +38,7 @@ class MakeHgrid(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         config = self.config["config"]

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -28,7 +28,7 @@ class MakeSoloMosaic(DriverTimeInvariant):
 
     def taskname(self, suffix: str) -> str:
         """
-        Returns a common tag for graph-task log messages.
+        Return a common tag for graph-task log messages.
 
         :param suffix: Log-string suffix.
         """
@@ -39,7 +39,7 @@ class MakeSoloMosaic(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.makesolomosaic
 
@@ -48,7 +48,7 @@ class MakeSoloMosaic(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         flags = " ".join(f"--{k} {v}" for k, v in self.config["config"].items())

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -39,7 +39,7 @@ class MakeSoloMosaic(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.makesolomosaic
 
@@ -48,7 +48,7 @@ class MakeSoloMosaic(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         flags = " ".join(f"--{k} {v}" for k, v in self.config["config"].items())

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -71,7 +71,7 @@ class MPAS(MPASBase):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.mpas
 

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -71,7 +71,7 @@ class MPAS(MPASBase):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.mpas
 

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -73,7 +73,7 @@ class MPASInit(MPASBase):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.mpasinit
 

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -73,7 +73,7 @@ class MPASInit(MPASBase):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.mpasinit
 

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -75,7 +75,7 @@ class OrogGSL(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.oroggsl
 
@@ -84,7 +84,7 @@ class OrogGSL(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         inputs = [str(self.config["config"][k]) for k in ("tile", "resolution", "halo")]
         executable = self.config[STR.execution][STR.executable]

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -75,7 +75,7 @@ class OrogGSL(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.oroggsl
 
@@ -84,7 +84,7 @@ class OrogGSL(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         inputs = [str(self.config["config"][k]) for k in ("tile", "resolution", "halo")]
         executable = self.config[STR.execution][STR.executable]

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -50,7 +50,7 @@ class SCHISM(AssetsCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.schism
 

--- a/src/uwtools/drivers/schism.py
+++ b/src/uwtools/drivers/schism.py
@@ -50,7 +50,7 @@ class SCHISM(AssetsCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.schism
 

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -57,7 +57,7 @@ class SfcClimoGen(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.sfcclimogen
 

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -57,7 +57,7 @@ class SfcClimoGen(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.sfcclimogen
 

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -29,7 +29,7 @@ class Shave(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.shave
 
@@ -38,7 +38,7 @@ class Shave(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         config = self.config["config"]

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -29,7 +29,7 @@ class Shave(DriverTimeInvariant):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.shave
 
@@ -38,7 +38,7 @@ class Shave(DriverTimeInvariant):
     @property
     def _runcmd(self):
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         executable = self.config[STR.execution][STR.executable]
         config = self.config["config"]

--- a/src/uwtools/drivers/support.py
+++ b/src/uwtools/drivers/support.py
@@ -19,7 +19,7 @@ def graph() -> str:
 
 def set_driver_docstring(driver_class: Type) -> None:
     """
-    Appends inherited parameter descriptions to the driver's own docstring.
+    Append inherited parameter descriptions to the driver's own docstring.
 
     :param driver_class: The class whose docstring to update.
     """

--- a/src/uwtools/drivers/support.py
+++ b/src/uwtools/drivers/support.py
@@ -12,7 +12,7 @@ from uwtools.drivers.driver import DriverT
 
 def graph() -> str:
     """
-    Returns Graphviz DOT code for the most recently executed task.
+    Return Graphviz DOT code for the most recently executed task.
     """
     return _iotaa.graph()
 
@@ -36,7 +36,7 @@ def set_driver_docstring(driver_class: Type) -> None:
 
 def tasks(driver_class: DriverT) -> dict[str, str]:
     """
-    Returns a mapping from task names to their one-line descriptions.
+    Return a mapping from task names to their one-line descriptions.
 
     :param driver_class: Class of driver object to instantiate.
     """

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -107,7 +107,7 @@ class Ungrib(DriverCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.ungrib
 

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -130,7 +130,9 @@ class Ungrib(DriverCycleBased):
 
 def _ext(n):
     """
-    Maps integers to 3-letter string.
+    Return a 3-letter representation of the given integer.
+
+    :param n: The integer to convert to a string representation.
     """
     b = 26
     return "{:A>3}".format(("" if n < b else _ext(n // b)) + chr(65 + n % b))[-3:]

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -107,7 +107,7 @@ class Ungrib(DriverCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.ungrib
 

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -77,7 +77,7 @@ class UPP(DriverCycleLeadtimeBased):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.upp
 
@@ -86,14 +86,14 @@ class UPP(DriverCycleLeadtimeBased):
     @property
     def _namelist_path(self) -> Path:
         """
-        Path to the namelist file.
+        The path to the namelist file.
         """
         return self.rundir / "itag"
 
     @property
     def _runcmd(self) -> str:
         """
-        Return the full command-line component invocation.
+        The full command-line component invocation.
         """
         execution = self.config.get(STR.execution, {})
         mpiargs = execution.get(STR.mpiargs, [])

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -77,7 +77,7 @@ class UPP(DriverCycleLeadtimeBased):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.upp
 
@@ -93,7 +93,7 @@ class UPP(DriverCycleLeadtimeBased):
     @property
     def _runcmd(self) -> str:
         """
-        Returns the full command-line component invocation.
+        Return the full command-line component invocation.
         """
         execution = self.config.get(STR.execution, {})
         mpiargs = execution.get(STR.mpiargs, [])

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -64,7 +64,7 @@ class WaveWatchIII(AssetsCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Returns the name of this driver.
+        Return the name of this driver.
         """
         return STR.ww3
 

--- a/src/uwtools/drivers/ww3.py
+++ b/src/uwtools/drivers/ww3.py
@@ -64,7 +64,7 @@ class WaveWatchIII(AssetsCycleBased):
     @property
     def driver_name(self) -> str:
         """
-        Return the name of this driver.
+        The name of this driver.
         """
         return STR.ww3
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -95,14 +95,14 @@ class Stager(ABC):
     @abstractmethod
     def _dst_paths(self) -> list[str]:
         """
-        Return the paths to files or directories to create.
+        The paths to files or directories to create.
         """
 
     @property
     @abstractmethod
     def _schema(self) -> str:
         """
-        Return the name of the schema to use for config validation.
+        The name of the schema to use for config validation.
         """
 
     def _validate(self) -> None:
@@ -122,14 +122,14 @@ class FileStager(Stager):
     @property
     def _dst_paths(self) -> list[str]:
         """
-        Return the paths to files to create.
+        The paths to files to create.
         """
         return list(self._config.keys())
 
     @property
     def _schema(self) -> str:
         """
-        Return the name of the schema to use for config validation.
+        The name of the schema to use for config validation.
         """
         return "files-to-stage"
 
@@ -183,7 +183,7 @@ class MakeDirs(Stager):
     @property
     def _dst_paths(self) -> list[str]:
         """
-        Return the paths to directories to create.
+        The paths to directories to create.
         """
         paths: list[str] = self._config[STR.makedirs]
         return paths
@@ -191,6 +191,6 @@ class MakeDirs(Stager):
     @property
     def _schema(self) -> str:
         """
-        Return the name of the schema to use for config validation.
+        The name of the schema to use for config validation.
         """
         return "makedirs"

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -95,14 +95,14 @@ class Stager(ABC):
     @abstractmethod
     def _dst_paths(self) -> list[str]:
         """
-        Returns the paths to files or directories to create.
+        Return the paths to files or directories to create.
         """
 
     @property
     @abstractmethod
     def _schema(self) -> str:
         """
-        Returns the name of the schema to use for config validation.
+        Return the name of the schema to use for config validation.
         """
 
     def _validate(self) -> None:
@@ -122,14 +122,14 @@ class FileStager(Stager):
     @property
     def _dst_paths(self) -> list[str]:
         """
-        Returns the paths to files to create.
+        Return the paths to files to create.
         """
         return list(self._config.keys())
 
     @property
     def _schema(self) -> str:
         """
-        Returns the name of the schema to use for config validation.
+        Return the name of the schema to use for config validation.
         """
         return "files-to-stage"
 
@@ -183,7 +183,7 @@ class MakeDirs(Stager):
     @property
     def _dst_paths(self) -> list[str]:
         """
-        Returns the paths to directories to create.
+        Return the paths to directories to create.
         """
         paths: list[str] = self._config[STR.makedirs]
         return paths
@@ -191,6 +191,6 @@ class MakeDirs(Stager):
     @property
     def _schema(self) -> str:
         """
-        Returns the name of the schema to use for config validation.
+        Return the name of the schema to use for config validation.
         """
         return "makedirs"

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -353,7 +353,7 @@ class _RocotoXML:
     @property
     def _doctype(self) -> Optional[str]:
         """
-        Generate the <!DOCTYPE> block with <!ENTITY> definitions.
+        The <!DOCTYPE> block with <!ENTITY> definitions.
 
         :return: The <!DOCTYPE> block if entities are defined, otherwise None.
         """

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -71,7 +71,7 @@ class JobScheduler(ABC):
 
     def submit_job(self, runscript: Path, submit_file: Optional[Path] = None) -> bool:
         """
-        Submits a job to the scheduler.
+        Submit a job to the scheduler.
 
         :param runscript: Path to the runscript.
         :param submit_file: Path to file to write output of submit command to.
@@ -243,7 +243,7 @@ class PBS(JobScheduler):
     @staticmethod
     def _placement(items: dict[str, Any]) -> dict[str, Any]:
         """
-        Placement logic.
+        Return provided items with scheduler-specific replacements.
         """
         exclusive = items.get(_DirectivesOptional.EXCLUSIVE)
         placement = items.get(_DirectivesOptional.PLACEMENT)
@@ -284,7 +284,7 @@ class PBS(JobScheduler):
 
     def _select(self, items: dict[str, Any]) -> dict[str, Any]:
         """
-        Select logic.
+        Return provided items with scheduler-specific selections.
         """
         select = []
         if nodes := items.get(_DirectivesOptional.NODES):

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -32,7 +32,7 @@ class JobScheduler(ABC):
     @property
     def directives(self) -> list[str]:
         """
-        Returns resource-request scheduler directives.
+        Return resource-request scheduler directives.
         """
         pre, sep = self._prefix, self._directive_separator
         ds = []
@@ -53,7 +53,7 @@ class JobScheduler(ABC):
     @staticmethod
     def get_scheduler(props: Mapping) -> JobScheduler:
         """
-        Returns a configured job scheduler.
+        Return a configured job scheduler.
 
         :param props: Configuration settings for job scheduler.
         :return: A configured job scheduler.
@@ -89,28 +89,28 @@ class JobScheduler(ABC):
     @abstractmethod
     def _directive_separator(self) -> str:
         """
-        Returns the character used to separate directive keys and values.
+        Return the character used to separate directive keys and values.
         """
 
     @property
     @abstractmethod
     def _forbidden_directives(self) -> list[str]:
         """
-        Returns directives that this scheduler does not support.
+        Return directives that this scheduler does not support.
         """
 
     @property
     @abstractmethod
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Returns a mapping from canonical names to scheduler-specific CLI switches.
+        Return a mapping from canonical names to scheduler-specific CLI switches.
         """
 
     @property
     @abstractmethod
     def _prefix(self) -> str:
         """
-        Returns the scheduler's resource-request prefix.
+        Return the scheduler's resource-request prefix.
         """
 
     @property
@@ -124,7 +124,7 @@ class JobScheduler(ABC):
     @abstractmethod
     def _submit_cmd(self) -> str:
         """
-        Returns the scheduler's job-submit executable name.
+        Return the scheduler's job-submit executable name.
         """
 
     def _validate_props(self) -> None:
@@ -149,21 +149,21 @@ class LSF(JobScheduler):
     @property
     def _directive_separator(self) -> str:
         """
-        Returns the character used to separate directive keys and values.
+        Return the character used to separate directive keys and values.
         """
         return " "
 
     @property
     def _forbidden_directives(self) -> list[str]:
         """
-        Returns directives that this scheduler does not support.
+        Return directives that this scheduler does not support.
         """
         return []
 
     @property
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Returns a mapping from canonical names to scheduler-specific CLI switches.
+        Return a mapping from canonical names to scheduler-specific CLI switches.
         """
         return {
             _DirectivesOptional.JOB_NAME: "-J",
@@ -181,7 +181,7 @@ class LSF(JobScheduler):
     @property
     def _prefix(self) -> str:
         """
-        Returns the scheduler's resource-request prefix.
+        Return the scheduler's resource-request prefix.
         """
         return "#BSUB"
 
@@ -194,7 +194,7 @@ class LSF(JobScheduler):
     @property
     def _submit_cmd(self) -> str:
         """
-        Returns the scheduler's job-submit executable name.
+        Return the scheduler's job-submit executable name.
         """
         return "bsub"
 
@@ -207,21 +207,21 @@ class PBS(JobScheduler):
     @property
     def _directive_separator(self) -> str:
         """
-        Returns the character used to separate directive keys and values.
+        Return the character used to separate directive keys and values.
         """
         return " "
 
     @property
     def _forbidden_directives(self) -> list[str]:
         """
-        Returns directives that this scheduler does not support.
+        Return directives that this scheduler does not support.
         """
         return []
 
     @property
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Returns a mapping from canonical names to scheduler-specific CLI switches.
+        Return a mapping from canonical names to scheduler-specific CLI switches.
         """
         return {
             _DirectivesOptional.DEBUG: lambda x: f"-l debug={str(x).lower()}",
@@ -258,7 +258,7 @@ class PBS(JobScheduler):
     @property
     def _prefix(self) -> str:
         """
-        Returns the scheduler's resource-request prefix.
+        Return the scheduler's resource-request prefix.
         """
         return "#PBS"
 
@@ -299,7 +299,7 @@ class PBS(JobScheduler):
     @property
     def _submit_cmd(self) -> str:
         """
-        Returns the scheduler's job-submit executable name.
+        Return the scheduler's job-submit executable name.
         """
         return "qsub"
 
@@ -312,14 +312,14 @@ class Slurm(JobScheduler):
     @property
     def _forbidden_directives(self) -> list[str]:
         """
-        Returns directives that this scheduler does not support.
+        Return directives that this scheduler does not support.
         """
         return [_DirectivesOptional.SHELL]
 
     @property
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Returns a mapping from canonical names to scheduler-specific CLI switches.
+        Return a mapping from canonical names to scheduler-specific CLI switches.
         """
         return {
             _DirectivesOptional.CORES: "--ntasks",
@@ -343,21 +343,21 @@ class Slurm(JobScheduler):
     @property
     def _directive_separator(self) -> str:
         """
-        Returns the character used to separate directive keys and values.
+        Return the character used to separate directive keys and values.
         """
         return "="
 
     @property
     def _prefix(self) -> str:
         """
-        Returns the scheduler's resource-request prefix.
+        Return the scheduler's resource-request prefix.
         """
         return "#SBATCH"
 
     @property
     def _submit_cmd(self) -> str:
         """
-        Returns the scheduler's job-submit executable name.
+        Return the scheduler's job-submit executable name.
         """
         return "sbatch"
 

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -116,7 +116,7 @@ class JobScheduler(ABC):
     @property
     def _processed_props(self) -> dict[str, Any]:
         """
-        Pre-processed runscript directives,
+        Pre-processed runscript directives.
         """
         return self._props
 
@@ -188,7 +188,7 @@ class LSF(JobScheduler):
     @property
     def _processed_props(self) -> dict[str, Any]:
         """
-        Pre-processed runscript directives,
+        Pre-processed runscript directives.
         """
         props = deepcopy(self._props)
         props[_DirectivesOptional.THREADS] = props.get(_DirectivesOptional.THREADS, 1)
@@ -268,7 +268,7 @@ class PBS(JobScheduler):
     @property
     def _processed_props(self) -> dict[str, Any]:
         """
-        Pre-processed runscript directives,
+        Pre-processed runscript directives.
         """
         props = self._props
         props.update(self._select(props))

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -32,7 +32,7 @@ class JobScheduler(ABC):
     @property
     def directives(self) -> list[str]:
         """
-        Return resource-request scheduler directives.
+        The resource-request scheduler directives.
         """
         pre, sep = self._prefix, self._directive_separator
         ds = []
@@ -89,34 +89,34 @@ class JobScheduler(ABC):
     @abstractmethod
     def _directive_separator(self) -> str:
         """
-        Return the character used to separate directive keys and values.
+        The character used to separate directive keys and values.
         """
 
     @property
     @abstractmethod
     def _forbidden_directives(self) -> list[str]:
         """
-        Return directives that this scheduler does not support.
+        The directives that this scheduler does not support.
         """
 
     @property
     @abstractmethod
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Return a mapping from canonical names to scheduler-specific CLI switches.
+        A mapping from canonical names to scheduler-specific CLI switches.
         """
 
     @property
     @abstractmethod
     def _prefix(self) -> str:
         """
-        Return the scheduler's resource-request prefix.
+        The scheduler's resource-request prefix.
         """
 
     @property
     def _processed_props(self) -> dict[str, Any]:
         """
-        Pre-process directives before converting to runscript.
+        Pre-processed runscript directives,
         """
         return self._props
 
@@ -124,7 +124,7 @@ class JobScheduler(ABC):
     @abstractmethod
     def _submit_cmd(self) -> str:
         """
-        Return the scheduler's job-submit executable name.
+        The scheduler's job-submit executable name.
         """
 
     def _validate_props(self) -> None:
@@ -149,21 +149,21 @@ class LSF(JobScheduler):
     @property
     def _directive_separator(self) -> str:
         """
-        Return the character used to separate directive keys and values.
+        The character used to separate directive keys and values.
         """
         return " "
 
     @property
     def _forbidden_directives(self) -> list[str]:
         """
-        Return directives that this scheduler does not support.
+        Directives that this scheduler does not support.
         """
         return []
 
     @property
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Return a mapping from canonical names to scheduler-specific CLI switches.
+        A mapping from canonical names to scheduler-specific CLI switches.
         """
         return {
             _DirectivesOptional.JOB_NAME: "-J",
@@ -181,12 +181,15 @@ class LSF(JobScheduler):
     @property
     def _prefix(self) -> str:
         """
-        Return the scheduler's resource-request prefix.
+        The scheduler's resource-request prefix.
         """
         return "#BSUB"
 
     @property
     def _processed_props(self) -> dict[str, Any]:
+        """
+        Pre-processed runscript directives,
+        """
         props = deepcopy(self._props)
         props[_DirectivesOptional.THREADS] = props.get(_DirectivesOptional.THREADS, 1)
         return props
@@ -194,7 +197,7 @@ class LSF(JobScheduler):
     @property
     def _submit_cmd(self) -> str:
         """
-        Return the scheduler's job-submit executable name.
+        The scheduler's job-submit executable name.
         """
         return "bsub"
 
@@ -207,21 +210,21 @@ class PBS(JobScheduler):
     @property
     def _directive_separator(self) -> str:
         """
-        Return the character used to separate directive keys and values.
+        The character used to separate directive keys and values.
         """
         return " "
 
     @property
     def _forbidden_directives(self) -> list[str]:
         """
-        Return directives that this scheduler does not support.
+        Directives that this scheduler does not support.
         """
         return []
 
     @property
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Return a mapping from canonical names to scheduler-specific CLI switches.
+        A mapping from canonical names to scheduler-specific CLI switches.
         """
         return {
             _DirectivesOptional.DEBUG: lambda x: f"-l debug={str(x).lower()}",
@@ -258,12 +261,15 @@ class PBS(JobScheduler):
     @property
     def _prefix(self) -> str:
         """
-        Return the scheduler's resource-request prefix.
+        The scheduler's resource-request prefix.
         """
         return "#PBS"
 
     @property
     def _processed_props(self) -> dict[str, Any]:
+        """
+        Pre-processed runscript directives,
+        """
         props = self._props
         props.update(self._select(props))
         props.update(self._placement(props))
@@ -299,7 +305,7 @@ class PBS(JobScheduler):
     @property
     def _submit_cmd(self) -> str:
         """
-        Return the scheduler's job-submit executable name.
+        The scheduler's job-submit executable name.
         """
         return "qsub"
 
@@ -312,14 +318,14 @@ class Slurm(JobScheduler):
     @property
     def _forbidden_directives(self) -> list[str]:
         """
-        Return directives that this scheduler does not support.
+        Directives that this scheduler does not support.
         """
         return [_DirectivesOptional.SHELL]
 
     @property
     def _managed_directives(self) -> dict[str, Any]:
         """
-        Return a mapping from canonical names to scheduler-specific CLI switches.
+        A mapping from canonical names to scheduler-specific CLI switches.
         """
         return {
             _DirectivesOptional.CORES: "--ntasks",
@@ -343,21 +349,21 @@ class Slurm(JobScheduler):
     @property
     def _directive_separator(self) -> str:
         """
-        Return the character used to separate directive keys and values.
+        The character used to separate directive keys and values.
         """
         return "="
 
     @property
     def _prefix(self) -> str:
         """
-        Return the scheduler's resource-request prefix.
+        The scheduler's resource-request prefix.
         """
         return "#SBATCH"
 
     @property
     def _submit_cmd(self) -> str:
         """
-        Return the scheduler's job-submit executable name.
+        The scheduler's job-submit executable name.
         """
         return "sbatch"
 

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -38,14 +38,14 @@ class FORMAT:
     @staticmethod
     def extensions() -> list[str]:
         """
-        Returns recognized filename extensions.
+        Return recognized filename extensions.
         """
         return [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml]
 
     @staticmethod
     def formats() -> dict[str, str]:
         """
-        Returns the recognized format names.
+        Return the recognized format names.
         """
         return {
             field.name: str(getattr(FORMAT, field.name))

--- a/src/uwtools/tests/support.py
+++ b/src/uwtools/tests/support.py
@@ -36,7 +36,7 @@ def compare_files(path1: Union[Path, str], path2: Union[Path, str]) -> bool:
 
 def fixture_pathobj(suffix: str = "") -> Path:
     """
-    Returns a pathlib Path object to a test-fixture resource file.
+    Return a pathlib Path object to a test-fixture resource file.
 
     :param suffix: A subpath relative to the location of the unit-test fixture resource files. The
         prefix path to the resources files is known to Python and varies based on installation
@@ -49,7 +49,7 @@ def fixture_pathobj(suffix: str = "") -> Path:
 
 def fixture_path(suffix: str = "") -> Path:
     """
-    Returns a POSIX path to a test-fixture resource file.
+    Return a POSIX path to a test-fixture resource file.
 
     :param suffix: A subpath relative to the location of the unit-test fixture resource files. The
         prefix path to the resources files is known to Python and varies based on installation

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -38,7 +38,7 @@ def make_execute(
     with_leadtime: Optional[bool] = False,
 ) -> Callable[..., bool]:
     """
-    Returns a function that executes tasks for the given driver.
+    Return a function that executes tasks for the given driver.
 
     :param driver_class: The driver class whose tasks to execute.
     :param with_cycle: Does the driver's constructor take a 'cycle' parameter?

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -42,7 +42,7 @@ def _stdinproxy():
 
 def get_file_format(path: Path) -> str:
     """
-    Returns a standardized file format name given a path/filename.
+    Return a standardized file format name given a path/filename.
 
     :param path: A path or filename.
     :return: One of a set of supported file-format names.
@@ -58,7 +58,7 @@ def get_file_format(path: Path) -> str:
 
 def path_if_it_exists(path: str) -> str:
     """
-    Returns the given path as an absolute path if it exists, and raises an exception otherwise.
+    Return the given path as an absolute path if it exists, and raises an exception otherwise.
 
     :param path: The filesystem path to test.
     :return: The same filesystem path as an absolute path.
@@ -91,7 +91,7 @@ def readable(
 
 def resource_path(suffix: str = "") -> Path:
     """
-    Returns a pathlib Path object to a uwtools resource file.
+    Return a pathlib Path object to a uwtools resource file.
 
     :param suffix: A subpath relative to the location of the uwtools resource files. The prefix path
         to the resources files is known to Python and varies based on installation location.

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -16,7 +16,7 @@ from uwtools.strings import FORMAT
 
 class StdinProxy:
     """
-    Reads stdin once but permits multiple reads of its data.
+    Read stdin once and return its cached data.
     """
 
     def __init__(self) -> None:

--- a/src/uwtools/utils/memory.py
+++ b/src/uwtools/utils/memory.py
@@ -25,7 +25,7 @@ class Memory:
     @property
     def measurement(self):
         """
-        Return the measurement (MB, KB, etc.)
+        The measurement (MB, KB, etc.)
         """
         if self._measurement is None:
             self._measurement = self._value[-2:]
@@ -34,7 +34,7 @@ class Memory:
     @property
     def quantity(self):
         """
-        Return the quantity.
+        The quantity.
         """
         if self._quantity is None:
             self._quantity = float(self._value[0:-2])
@@ -42,7 +42,7 @@ class Memory:
 
     def convert(self, measurement: str):
         """
-        Converts the current representation to another measurement.
+        Convert the current representation to another measurement.
         """
         quantity = (MAP[self.measurement] / MAP[measurement.upper()]) * self.quantity
 

--- a/src/uwtools/utils/memory.py
+++ b/src/uwtools/utils/memory.py
@@ -25,7 +25,7 @@ class Memory:
     @property
     def measurement(self):
         """
-        Returns the measurement (MB, KB, etc.)
+        Return the measurement (MB, KB, etc.)
         """
         if self._measurement is None:
             self._measurement = self._value[-2:]
@@ -34,7 +34,7 @@ class Memory:
     @property
     def quantity(self):
         """
-        Returns the quantity.
+        Return the quantity.
         """
         if self._quantity is None:
             self._quantity = float(self._value[0:-2])


### PR DESCRIPTION
**Synopsis**

While working on something else, I became distracted by divergences from conventions in our docstrings. I've tried to harmonize those in this PR, though I'm sure I've missed some stragglers that, if we agree on the conventions described below, we can chip away at in future work as we find them.

The conventions I've tried to adhere to -- which are the case in most of our docstrings already:

- For action-oriented functions/methods (most of them), use active language: "Do a thing", not "Does a thing", "Return a value", not "Returns a value", etc.
- For language objects that _are_ rather than _do_ -- classes, `@property` methods, driver workflow tasks, etc. -- simply state what the thing is: "The valid names", not "Return the valid names".
- For functions/methods that exist mainly to produce and return a value, it's ok to omit the `:return:` docstring item if the docstring's first line starts with "Return ...". In some places, having both is useful, but see the previous bullet for cases when neither is necessary.

**Type**

- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
