### PR TITLE
Update package versions

### DIFF
--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -4,7 +4,7 @@
   "name": "uwtools",
   "packages": {
     "dev": [
-      "black =24.4.*",
+      "black =24.8.*",
       "docformatter =1.7.*",
       "f90nml =1.4.*",
       "iotaa =0.8.*",
@@ -12,12 +12,12 @@
       "jinja2 =3.1.*",
       "jq =1.7.*",
       "jsonschema =4.23.*",
-      "lxml =5.2.*",
-      "make >=3.8",
-      "mypy =1.10.*",
+      "lxml =5.3.*",
+      "make =4.4.*",
+      "mypy =1.11.*",
       "pip",
       "pylint =3.2.*",
-      "pytest =8.2.*",
+      "pytest =8.3.*",
       "pytest-cov =5.0.*",
       "pytest-xdist =3.6.*",
       "python >=3.9,<3.13",
@@ -28,7 +28,7 @@
       "iotaa =0.8.*",
       "jinja2 =3.1.*",
       "jsonschema =4.23.*",
-      "lxml =5.2.*",
+      "lxml =5.3.*",
       "python >=3.9,<3.13",
       "pyyaml =6.0.*"
     ]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,19 +17,19 @@ requirements:
     - iotaa 0.8.*
     - jinja2 3.1.*
     - jsonschema 4.23.*
-    - lxml 5.2.*
+    - lxml 5.3.*
     - python >=3.9,<3.13
     - pyyaml 6.0.*
 test:
   requires:
-    - black 24.4.*
+    - black 24.8.*
     - docformatter 1.7.*
     - isort 5.13.*
     - jq 1.7.*
-    - make >=3.8
-    - mypy 1.10.*
+    - make 4.4.*
+    - mypy 1.11.*
     - pylint 3.2.*
-    - pytest 8.2.*
+    - pytest 8.3.*
     - pytest-cov 5.0.*
     - pytest-xdist 3.6.*
 about:


### PR DESCRIPTION
**Synopsis**

While testing a new `iotaa` release meant to address an issue we discovered while reviewing #598, I took the opportunity to re-pin some `uwtools` dependencies at the latest versions. The new `iotaa` release saw only the patch component of its version number increment, so no change is visible in this PR's diffs, but a new `uwtools` development shell or installation into a conda environment should pull in its newest `0.8.3` package.

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
