### PR TITLE
Add formatting to Copier/Linker/MakeDirs class docstrings for better API docs

### DIFF
--- a/docs/sections/user_guide/api/index.rst
+++ b/docs/sections/user_guide/api/index.rst
@@ -2,6 +2,8 @@ API
 ===
 
 .. toctree::
+   :maxdepth: 1
+
    cdeps
    chgres_cube
    config

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -35,13 +35,13 @@ class Stager(ABC):
         """
         Stage files and directories.
 
-        :param config: YAML-file path, or dict (read stdin if missing or None).
+        :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).
         :param target_dir: Path to target directory.
-        :param cycle: A datetime object to make available for use in the config.
-        :param leadtime: A timedelta object to make available for use in the config.
+        :param cycle: A ``datetime`` object to make available for use in the config.
+        :param leadtime: A ``timedelta`` object to make available for use in the config.
         :param keys: YAML keys leading to file dst/src block.
         :param dry_run: Do not copy files.
-        :raises: UWConfigError if config fails validation.
+        :raises: ``UWConfigError`` if config fails validation.
         """
         dryrun(enable=dry_run)
         self._keys = keys or []


### PR DESCRIPTION
**Synopsis**

We previously exposed the `Copier`, `Linker`, and `MakeDirs` classes from `uwtools.fs` via the API, but the docstrings for those classes didn't get RST formatting added. This corrects that: Compare the [current version](https://uwtools.readthedocs.io/en/main/sections/user_guide/api/fs.html#uwtools.api.fs.Copier) (as of this writing) `Copier` docs to the [PR version](https://uwtools--601.org.readthedocs.build/en/601/sections/user_guide/api/fs.html#uwtools.api.fs.Copier).

I also thought that the [current API page](https://uwtools.readthedocs.io/en/main/sections/user_guide/api/index.html) is too long, so [reduced its depth](https://uwtools--601.org.readthedocs.build/en/601/sections/user_guide/api/index.html).

**Type**

- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
