### PR TITLE
UW-653 controller key path

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -49,7 +49,7 @@ class Assets(ABC):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ) -> None:
         config_input = config if isinstance(config, YAMLConfig) else YAMLConfig(config=config)
         config_input.dereference(
@@ -66,7 +66,10 @@ class Assets(ABC):
         except KeyError as e:
             raise UWConfigError("Required '%s' block missing in config" % self.driver_name()) from e
         if controller:
-            self._config[STR.rundir] = self._config_intermediate[controller][STR.rundir]
+            rundir = self._config_intermediate[controller[0]][STR.rundir]
+            for key in controller[1:]:
+                rundir = rundir[key]
+            self._config[STR.rundir] = rundir
         self.schema_file = schema_file
         self._validate()
         dryrun(enable=dry_run)
@@ -241,7 +244,7 @@ class AssetsCycleBased(Assets):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -274,7 +277,7 @@ class AssetsCycleLeadtimeBased(Assets):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -314,7 +317,7 @@ class AssetsTimeInvariant(Assets):
         dry_run: bool = False,
         key_path: Optional[list[str]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ):
         super().__init__(
             config=config,
@@ -339,7 +342,7 @@ class Driver(Assets):
         key_path: Optional[list[str]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -352,7 +355,10 @@ class Driver(Assets):
         )
         self._batch = batch
         if controller:
-            self._config[STR.execution] = self.config_full[controller][STR.execution]
+            execution = self._config_intermediate[controller[0]][STR.execution]
+            for key in controller[1:]:
+                execution = execution[key]
+            self._config[STR.execution] = execution
 
     # Workflow tasks
 
@@ -541,7 +547,7 @@ class DriverCycleBased(Driver):
         key_path: Optional[list[str]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -576,7 +582,7 @@ class DriverCycleLeadtimeBased(Driver):
         key_path: Optional[list[str]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -618,7 +624,7 @@ class DriverTimeInvariant(Driver):
         key_path: Optional[list[str]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[str] = None,
+        controller: Optional[list[str]] = None,
     ):
         super().__init__(
             config=config,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -65,11 +65,7 @@ class Assets(ABC):
             self._config: dict = self._config_intermediate[self.driver_name()]
         except KeyError as e:
             raise UWConfigError("Required '%s' block missing in config" % self.driver_name()) from e
-        if controller:
-            rundir = self._config_intermediate[controller[0]][STR.rundir]
-            for key in controller[1:]:
-                rundir = rundir[key]
-            self._config[STR.rundir] = rundir
+        self._delegate(controller, STR.rundir)
         self.schema_file = schema_file
         self._validate()
         dryrun(enable=dry_run)
@@ -169,6 +165,16 @@ class Assets(ABC):
             log.debug(f"Wrote config to {path}")
         else:
             log.debug(f"Failed to validate {path}")
+
+    def _delegate(self, controller: Optional[list[str]], config_key: str) -> None:
+        """
+        ???
+        """
+        if controller:
+            val = self._config_intermediate[controller[0]][config_key]
+            for key in controller[1:]:
+                val = val[key]
+            self._config[config_key] = val
 
     # Public helper methods
 
@@ -354,11 +360,7 @@ class Driver(Assets):
             controller=controller,
         )
         self._batch = batch
-        if controller:
-            execution = self._config_intermediate[controller[0]][STR.execution]
-            for key in controller[1:]:
-                execution = execution[key]
-            self._config[STR.execution] = execution
+        self._delegate(controller, STR.execution)
 
     # Workflow tasks
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -174,10 +174,10 @@ class Assets(ABC):
         :param config_key: Name of config item to delegate to controller.
         """
         if controller:
-            val = self._config_intermediate[controller[0]][config_key]
+            val = self._config_intermediate[controller[0]]
             for key in controller[1:]:
                 val = val[key]
-            self._config[config_key] = val
+            self._config[config_key] = val[config_key]
 
     # Public helper methods
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -168,7 +168,10 @@ class Assets(ABC):
 
     def _delegate(self, controller: Optional[list[str]], config_key: str) -> None:
         """
-        ???
+        Selectively delegate config to controller.
+
+        :param controller: Key(s) leading to block in config controlling run-time values.
+        :param config_key: Name of config item to delegate to controller.
         """
         if controller:
             val = self._config_intermediate[controller[0]][config_key]
@@ -658,7 +661,7 @@ def _add_docstring(class_: type, omit: Optional[list[str]] = None) -> None:
     :param key_path: Keys leading through the config to the driver's configuration block.
     :param batch: Run component via the batch system?
     :param schema_file: Path to schema file to use to validate an external driver.
-    :param controller: Name of block in config controlling run-time values.
+    :param controller: Key(s) leading to block in config controlling run-time values.
     """
     setattr(
         class_,

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -285,6 +285,13 @@ def test_Assets__create_user_updated_config_base_file(
     assert updated == expected
 
 
+def test_Assets__delegate(driverobj):
+    assert "roses" not in driverobj.config
+    driverobj._config_intermediate["plants"] = {"flowers": {"roses": "red"}}
+    driverobj._delegate(["plants", "flowers"], "roses")
+    assert driverobj.config["roses"] == "red"
+
+
 def test_Assets__rundir(assetsobj):
     assert assetsobj.rundir == Path(assetsobj.config["rundir"])
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -195,7 +195,7 @@ def test_Assets_controller(config, controller_schema):
         with raises(UWConfigError):
             ConcreteAssetsTimeInvariant(config=config, schema_file=controller_schema)
         assert ConcreteAssetsTimeInvariant(
-            config=config, schema_file=controller_schema, controller="controller"
+            config=config, schema_file=controller_schema, controller=["controller"]
         )
 
 
@@ -342,7 +342,7 @@ def test_Driver_controller(config, controller_schema):
         with raises(UWConfigError):
             ConcreteDriverTimeInvariant(config=config, schema_file=controller_schema)
         assert ConcreteDriverTimeInvariant(
-            config=config, schema_file=controller_schema, controller="controller"
+            config=config, schema_file=controller_schema, controller=["controller"]
         )
 
 


### PR DESCRIPTION
**Synopsis**

To support coupled driver applications where subcomponents defer to a "controller" component's config block for their `execution` and/or `rundir` values, we initially implemented a single key identifying to identify the controller component's block at the top of the config. In UW YAML in general, however, config blocks can be nested arbitrarily deeply, and a key path provided to navigate to them. This PR adds the ability to locate the controller component's block via an arbitrary key path. This is a breaking change because the `controller` argument now requires ` list[str]` value; but we only have a single coupled component at the moment, so it should be an easy update when this change is released in a future v2.5.0.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
