### PR TITLE
UW-639 Mixed cyclestr / text support

### DIFF
--- a/docs/sections/user_guide/yaml/rocoto.rst
+++ b/docs/sections/user_guide/yaml/rocoto.rst
@@ -90,7 +90,7 @@ In the example, the resulting log would appear in the XML file as:
 
 The ``attrs:`` block is optional within the ``cyclestr:`` block and can be used to specify the cycle offset.
 
-Wherever a `cyclestr:` block is accepted, a YAML sequence mixing text and `cyclestr:` items may also be provided. For example,
+Wherever a ``cyclestr:`` block is accepted, a YAML sequence mixing text and ``cyclestr:`` blocks may also be provided. For example,
 
 .. code-block:: yaml
 

--- a/docs/sections/user_guide/yaml/rocoto.rst
+++ b/docs/sections/user_guide/yaml/rocoto.rst
@@ -86,11 +86,29 @@ In the example, the resulting log would appear in the XML file as:
 
 .. code-block:: xml
 
-   <log>
-     <cyclestr>/some/path/to/&FOO;</cyclestr>
-   </log>
+   <log><cyclestr>/some/path/to/&FOO;</cyclestr></log>
 
 The ``attrs:`` block is optional within the ``cyclestr:`` block and can be used to specify the cycle offset.
+
+Wherever a `cyclestr:` block is accepted, a YAML sequence mixing text and `cyclestr:` items may also be provided. For example,
+
+.. code-block:: yaml
+
+   log:
+     - cyclestr:
+         value: "%Y%m%d%H"
+     - -through-
+     - cyclestr:
+         attrs:
+           offset: "06:00:00"
+         value: "%Y%m%d%H"
+     - .log
+
+would be rendered as
+
+.. code-block:: xml
+
+   <log><cyclestr>%Y%m%d%H</cyclestr>-through-<cyclestr offset="06:00:00">%Y%m%d%H</cyclestr>.log</log>
 
 Tasks Section
 -------------

--- a/src/uwtools/resources/jsonschema/rocoto.jsonschema
+++ b/src/uwtools/resources/jsonschema/rocoto.jsonschema
@@ -1,44 +1,60 @@
 {
   "$defs": {
     "compoundTimeString": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "$ref": "#/$defs/compoundTimeStringElement"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/compoundTimeStringElement"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "compoundTimeStringElement": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/cycleString"
+        },
         {
           "type": "integer"
         },
         {
           "type": "string"
-        },
-        {
+        }
+      ]
+    },
+    "cycleString": {
+      "additionalProperties": false,
+      "properties": {
+        "cyclestr": {
           "additionalProperties": false,
           "properties": {
-            "cyclestr": {
+            "attrs": {
               "additionalProperties": false,
               "properties": {
-                "attrs": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "offset": {
-                      "$ref": "#/$defs/time"
-                    }
-                  },
-                  "type": "object"
-                },
-                "value": {
-                  "type": "string"
+                "offset": {
+                  "$ref": "#/$defs/time"
                 }
               },
-              "required": [
-                "value"
-              ],
               "type": "object"
+            },
+            "value": {
+              "type": "string"
             }
           },
           "required": [
-            "cyclestr"
+            "value"
           ],
           "type": "object"
         }
-      ]
+      },
+      "required": [
+        "cyclestr"
+      ],
+      "type": "object"
     },
     "dependency": {
       "additionalProperties": false,

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -115,10 +115,10 @@ class _RocotoXML:
         """
         e = SubElement(e, tag)
         if isinstance(config, dict):
-            if subconfig := config.get(STR.cyclestr):
-                cyclestr = SubElement(e, STR.cyclestr)
-                cyclestr.text = subconfig[STR.value]
-                self._set_attrs(cyclestr, subconfig)
+            subconfig = config[STR.cyclestr]
+            cyclestr = SubElement(e, STR.cyclestr)
+            cyclestr.text = subconfig[STR.value]
+            self._set_attrs(cyclestr, subconfig)
         else:
             e.text = str(config)
         return e

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -115,7 +115,6 @@ class _RocotoXML:
         """
         e = SubElement(e, tag)
         if isinstance(config, dict):
-            self._set_attrs(e, config)
             if subconfig := config.get(STR.cyclestr):
                 cyclestr = SubElement(e, STR.cyclestr)
                 cyclestr.text = subconfig[STR.value]

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -116,7 +116,7 @@ class _RocotoXML:
         e = SubElement(e, tag)
         if isinstance(config, dict):
             self._set_attrs(e, config)
-            if subconfig := config.get(STR.cyclestr, {}):
+            if subconfig := config.get(STR.cyclestr):
                 cyclestr = SubElement(e, STR.cyclestr)
                 cyclestr.text = subconfig[STR.value]
                 self._set_attrs(cyclestr, subconfig)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -6,6 +6,7 @@ Tests for uwtools.rocoto module.
 from unittest.mock import DEFAULT as D
 from unittest.mock import PropertyMock, patch
 
+from lxml import etree
 from pytest import fixture, mark, raises
 
 from uwtools import rocoto
@@ -110,12 +111,12 @@ class Test__RocotoXML:
         cfgfile, _ = assets
         assert rocoto._RocotoXML(config=YAMLConfig(cfgfile))._root.tag == "workflow"
 
-    def test__add_compound_time_string_basic(self, instance, root):
-        config = "bar"
+    @mark.parametrize("config", ["bar", 42])
+    def test__add_compound_time_string_basic(self, config, instance, root):
         instance._add_compound_time_string(e=root, config=config, tag="foo")
         child = root[0]
         assert child.tag == "foo"
-        assert child.text == "bar"
+        assert child.text == str(config)
 
     def test__add_compound_time_string_cyclestr(self, instance, root):
         config = {"cyclestr": {"attrs": {"baz": "42"}, "value": "qux"}}
@@ -123,6 +124,28 @@ class Test__RocotoXML:
         cyclestr = root[0][0]
         assert cyclestr.get("baz") == "42"
         assert cyclestr.text == "qux"
+
+    def test__add_compound_time_string_list(self, instance, root):
+        config = [
+            "cycle-",
+            {"cyclestr": {"value": "%s"}},
+            "-valid-",
+            {"cyclestr": {"value": "%s", "attrs": {"offset": "00:06:00"}}},
+            ".log",
+        ]
+        instance._add_compound_time_string(e=root, config=config, tag="a")
+        expected = "<a>{}</a>".format(
+            "".join(
+                [
+                    "cycle-",
+                    "<cyclestr>%s</cyclestr>",
+                    "-valid-",
+                    '<cyclestr offset="00:06:00">%s</cyclestr>',
+                    ".log",
+                ]
+            )
+        )
+        assert etree.tostring(root[0]).decode("utf-8") == expected
 
     def test__add_metatask(self, instance, root):
         config = {

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -133,8 +133,7 @@ class Test__RocotoXML:
             {"cyclestr": {"value": "%s", "attrs": {"offset": "00:06:00"}}},
             ".log",
         ]
-        instance._add_compound_time_string(e=root, config=config, tag="a")
-        expected = "<a>{}</a>".format(
+        xml = "<a>{}</a>".format(
             "".join(
                 [
                     "cycle-",
@@ -145,7 +144,8 @@ class Test__RocotoXML:
                 ]
             )
         )
-        assert etree.tostring(root[0]).decode("utf-8") == expected
+        instance._add_compound_time_string(e=root, config=config, tag="a")
+        assert etree.tostring(root[0]).decode("utf-8") == xml
 
     def test__add_metatask(self, instance, root):
         config = {

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -118,12 +118,10 @@ class Test__RocotoXML:
         assert child.text == "bar"
 
     def test__add_compound_time_string_cyclestr(self, instance, root):
-        config = {"attrs": {"bar": "42"}, "cyclestr": {"attrs": {"baz": "43"}, "value": "qux"}}
+        config = {"cyclestr": {"attrs": {"baz": "42"}, "value": "qux"}}
         instance._add_compound_time_string(e=root, config=config, tag="foo")
-        child = root[0]
-        assert child.get("bar") == "42"
-        cyclestr = child[0]
-        assert cyclestr.get("baz") == "43"
+        cyclestr = root[0][0]
+        assert cyclestr.get("baz") == "42"
         assert cyclestr.text == "qux"
 
     def test__add_metatask(self, instance, root):


### PR DESCRIPTION
**Synopsis**

Add UW YAML for Rocoto support for mixed `<cyclestr>` and text content by extending the definition of `compoundTimeString`. Where, previously, only a single string, integer, or `cyclestr:` block was allowed, now a sequence of these values is accepted, which is rendered as a mix of text and element XML children.

For example, we can now realize `rocoto.yaml`
```
workflow:
  attrs:
    realtime: false
    scheduler: slurm
  cycledef:
    - spec: 202409100000 202409110000 06:00:00
  log:
    - rocoto-
    - cyclestr:
        value: "@Y@m@d"
    - -through-
    - cyclestr:
        value: "@Y@m@d"
        attrs:
          offset: "06:00:00"
    - .log
  tasks:
    task_foo:
      command: /bin/true
      cores: 1
      walltime: 00:01:00
```

as Rocoto XML

```
$ uw rocoto realize --config-file rocoto.yaml
[2024-09-10T20:17:38]     INFO 0 UW schema-validation errors found in Rocoto config
[2024-09-10T20:17:38]     INFO 0 Rocoto XML validation errors found
<?xml version='1.0' encoding='utf-8'?>
<workflow realtime="False" scheduler="slurm">
  <cycledef>202409100000 202409110000 06:00:00</cycledef>
  <log>rocoto-<cyclestr>@Y@m@d</cyclestr>-through-<cyclestr offset="06:00:00">@Y@m@d</cyclestr>.log</log>
  <task name="foo">
    <cores>1</cores>
    <walltime>00:01:00</walltime>
    <command>/bin/true</command>
    <jobname>foo</jobname>
  </task>
</workflow>
```

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
