### PR TITLE
Fix for Rocoto streq dependencies.

### DIFF
--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -261,7 +261,9 @@ class _RocotoXML:
         :param config: Configuration data for the tag.
         :param tag: Name of new element to add.
         """
-        self._set_attrs(SubElement(e, tag), config)
+        e = SubElement(e, tag)
+        for k, v in config.items():
+            self._add_compound_time_string(e, v, k)
 
     def _add_task_dependency_taskdep(self, e: _Element, config: dict) -> None:
         """

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -165,15 +165,15 @@ class Test__RocotoXML:
             },
         }
         errors = schema_validator("rocoto", "$defs")
-        taskname = "metatask_test"
-        assert not errors({taskname: config})
+        metataskname = "metatask_test"
+        assert not errors({metataskname: config})
         orig = instance._add_metatask
         with patch.multiple(instance, _add_metatask=D, _add_task=D) as mocks:
-            orig(e=root, config=config, name_attr=taskname)
+            orig(e=root, config=config, name_attr=metataskname)
         metatask = root[0]
         assert metatask.tag == "metatask"
         assert metatask.get("mode") == "parallel"
-        assert metatask.get("name") == taskname
+        assert metatask.get("name") == metataskname
         assert metatask.get("throttle") == "42"
         assert {e.get("name"): e.text for e in metatask.xpath("var")} == {"baz": "3", "qux": "4"}
         mocks["_add_metatask"].assert_called_once_with(
@@ -195,9 +195,9 @@ class Test__RocotoXML:
             "command": "echo hello",
             "cores": 2,
         }
-        errors = schema_validator("rocoto", "$defs", "task")
-        taskname = "test-task"
-        assert not errors(config)
+        taskname = "task_test"
+        errors = schema_validator("rocoto", "$defs")
+        assert not errors({taskname: config})
         with patch.multiple(instance, _add_task_dependency=D, _add_task_envar=D) as mocks:
             instance._add_task(e=root, config=config, name_attr=taskname)
         task = root[0]


### PR DESCRIPTION
**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

Fixes a bug associated with using the Rocoto `streq` dependency. When specifying the schema-approved YAML option for the dependency as in this very abbreviated example:

```
rocoto:
  task:
    dependency:
      streq:
        left: foo
        right: bar
```

The resulting XML is invalid against the Rocoto RelaxNG schema:

```
<streq/>
```
And should appear as:

```
<streq/>
  <left>foo</left>
  <right>bar</right>
<streq/>
```


To fix future instances of similar failures, I added validation checks to each config object used to test the rocoto mechanics.


**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
