### PR TITLE
Rocoto Docs Typo Fix

### DIFF
--- a/docs/sections/user_guide/yaml/rocoto.rst
+++ b/docs/sections/user_guide/yaml/rocoto.rst
@@ -131,7 +131,7 @@ Let's dissect the following task example:
      walltime: 00:01:00
      envars:
        person: siri
-     dependencies:
+     dependency:
 
 Each task is named by its UW YAML key. Blocks under ``tasks:`` prefixed with ``task_`` will be named with what follows the prefix. In the example above the task will be named ``hello`` and will appear in the XML like this:
 
@@ -157,7 +157,7 @@ The name of the task can be any string accepted by Rocoto as a task name (includ
      <value>siri</value>
    </envar>
 
-``dependencies:`` -- [Optional] Any number of dependencies accepted by Rocoto. This section is described in more detail below.
+``dependency:`` -- [Optional] Any number of dependencies accepted by Rocoto. This section is described in more detail below.
 
 The other keys not specifically mentioned here follow the same conventions as described in the :rocoto:`Rocoto<>` documentation.
 
@@ -180,7 +180,7 @@ Each of the dependencies that requires attributes (the ``key="value"`` parts ins
      ...
    task_goodbye:
      command: "goodbye"
-     dependencies:
+     dependency:
         taskdep:
           attrs:
             task: hello
@@ -209,7 +209,7 @@ Because UW YAML represents a hash table (a dictionary in Python), each key at th
    task_hello:
      command: "hello world"
      ...
-     dependencies:
+     dependency:
        and:
          datadep_foo:
            value: "foo.txt"


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->
Fixes a typo on the [Defining a Rocoto Workflow](https://uwtools.readthedocs.io/en/main/sections/user_guide/yaml/rocoto.html) Read the Docs page where `dependencies` is used as a key in the UW YAML rather than `dependency`.

**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
