### PR TITLE
Rocoto XML regex fix

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -33,8 +33,6 @@ from uwtools.strings import STR
 from uwtools.utils.file import writable
 from uwtools.utils.processing import run_shell_cmd
 
-OutputT = dict[str, Union[str, list[str]]]
-
 # NB: Class docstrings are programmatically defined.
 
 
@@ -433,7 +431,7 @@ class Driver(Assets):
     # Public methods
 
     @property
-    def output(self) -> OutputT:
+    def output(self) -> Union[dict[str, str], dict[str, list[str]]]:
         """
         Returns a description of the file(s) created when this component runs.
         """

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.drivers.driver import DriverCycleLeadtimeBased, OutputT
+from uwtools.drivers.driver import DriverCycleLeadtimeBased
 from uwtools.drivers.support import set_driver_docstring
 from uwtools.exceptions import UWConfigError
 from uwtools.strings import STR
@@ -100,7 +100,7 @@ class UPP(DriverCycleLeadtimeBased):
         return STR.upp
 
     @property
-    def output(self) -> OutputT:
+    def output(self) -> dict[str, list[str]]:
         """
         Returns a description of the file(s) created when this component runs.
         """

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -92,7 +92,7 @@ class _RocotoXML:
         xml = etree.tostring(
             self._root, pretty_print=True, encoding="utf-8", xml_declaration=True
         ).decode()
-        xml = re.sub(r"&amp;([^;]+);", r"&\1;", xml)
+        xml = re.sub(r"&amp;([^&]+;)", r"&\1", xml)
         xml = self._insert_doctype(xml)
         return xml
 

--- a/src/uwtools/tests/fixtures/hello_workflow.yaml
+++ b/src/uwtools/tests/fixtures/hello_workflow.yaml
@@ -15,9 +15,9 @@ workflow:
     task_hello:
       attrs:
         cycledefs: howdy
-        maxtries: "2"
+        maxtries: 2
       account: "&ACCOUNT;"
-      command: "echo hello $person"
+      command: "echo account for $person is &ACCOUNT; && true"
       jobname:
         cyclestr:
           attrs:
@@ -34,7 +34,7 @@ workflow:
       task_hello_#member#:
         attrs:
           cycledefs: howdy
-          maxtries: "1"
+          maxtries: 1
         account: "&ACCOUNT;"
         command: "echo hello #member#"
         nodes: 1:ppn=1


### PR DESCRIPTION
**Synopsis**

Given `rocoto.yaml`:
```
workflow:
  entities:
    GREETING: hello
  attrs:
    realtime: false
    scheduler: slurm
  cycledef:
    - spec: 202410290000 202410300000 06:00:00
  log: logs/test.log
  tasks:
    task_greet:
      command: true && echo &GREETING;
      cores: 1
      walltime: 00:00:10
```
Current behavior:
```
$ uw rocoto realize --config-file rocoto.yaml 
[2024-11-01T23:10:42]     INFO 0 UW schema-validation errors found in Rocoto config
...
lxml.etree.XMLSyntaxError: xmlParseEntityRef: no name, line 11, column 20
```
The problematic line in the XML is:
```
<command>true &&amp; echo &GREETING;</command>
```
due to the regex corrected in this PR, which changed a correct `&amp;&amp;` into `&&amp;`. The regex is meant to correct mangled entities like `&amp;FOO;`, which should appear as `&FOO;` in the XML.

With the change in this PR:
```
$ uw rocoto realize --config-file rocoto.yaml 
[2024-11-01T23:13:57]     INFO 0 UW schema-validation errors found in Rocoto config
[2024-11-01T23:13:57]     INFO 0 Rocoto XML validation errors found
<?xml version='1.0' encoding='utf-8'?>
<!DOCTYPE workflow [
  <!ENTITY GREETING "hello">
]>
<workflow realtime="False" scheduler="slurm">
  <cycledef>202410290000 202410300000 06:00:00</cycledef>
  <log>logs/test.log</log>
  <task name="greet">
    <cores>1</cores>
    <walltime>00:00:10</walltime>
    <command>true &amp;&amp; echo &GREETING;</command>
    <jobname>greet</jobname>
  </task>
</workflow>
```
I think this this command should be interpreted as `true && echo hello` at run time, but maybe someone with a Rocoto workflow could confirm by e.g. adding `true &amp;&amp; ` to the start of a `<command>` tag's text, which should have no effect (and, specifically, should cause no error).

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
