### PR TITLE
Typos in doc strings

### DIFF
--- a/docs/sections/contributor_guide/documentation.rst
+++ b/docs/sections/contributor_guide/documentation.rst
@@ -44,7 +44,7 @@ Please follow these guidelines when contributing to the documentation:
 * In [[sub]sub]section titles, capitalize all "principal" words. In practice this usually means all words but articles (a, an, the), logicals (and, etc.), and prepositions (for, of, etc.). Always fully capitalize acronyms (e.g., YAML).
 * Never capitalize proper names when their owners do not (e.g., write `"pandas" <https://pandas.pydata.org/>`_, not "Pandas", even at the start of a sentence) or when referring to a software artifact (e.g., write ``numpy`` when referring to the library, and "NumPy" when referring to the project).
 * When referring to YAML constructs, `block` refers to an entry whose value is a nested collection of key/value pairs, while `entry` refers to a single key/value pair.
-* When using the ``.. code-block::`` directive, align the actual code with the word ``code``. Also, when ``.. code-block::`` directives appear in bulleted or numberd lists, align them with the text following the space to the right of the bullet/number. For example:
+* When using the ``.. code-block::`` directive, align the actual code with the word ``code``. Also, when ``.. code-block::`` directives appear in bulleted or numbered lists, align them with the text following the space to the right of the bullet/number. For example:
 
   .. code-block:: text
 

--- a/src/uwtools/api/rocoto.py
+++ b/src/uwtools/api/rocoto.py
@@ -22,7 +22,7 @@ def realize(
 
     If no input file is specified, ``stdin`` is read. A ``YAMLConfig`` object may also be provided
     as input. If no output file is specified, ``stdout`` is written to. Both the input config and
-    output Rocoto XML will be validated against appropriate schcemas.
+    output Rocoto XML will be validated against appropriate schemas.
 
     :param config: YAML input file or ``YAMLConfig`` object (``None`` => read ``stdin``).
     :param output_file: XML output file path (``None`` => write to ``stdout``).

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -110,7 +110,7 @@ def dereference(
     values; render strings; convert values tagged with explicit types; and return objects of other
     types unmodified. Rendering may fail for valid reasons -- notably a replacement value not being
     available in the given context object. In such cases, return the original value: Any unrendered
-    Jinja2 syntax it contains may may be rendered by later processing with better context.
+    Jinja2 syntax it contains may be rendered by later processing with better context.
 
     When rendering dict values, replacement values will be taken from, in priority order
       1. The full context dict
@@ -335,7 +335,7 @@ def _supplement_values(
     env: bool = False,
 ) -> dict:
     """
-    Optionally supplement values from given source with overrides and/or environment vairables.
+    Optionally supplement values from given source with overrides and/or environment variables.
 
     :param values_src: Source of values to render the template.
     :param values_format: Format of values when sourced from file.


### PR DESCRIPTION
**Synopsis**
A small collection of typos that I've found recently. 

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
