### PR TITLE
Update jsonschema pin range and increment build number

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,7 @@ name: readthedocs
 channels:
   - conda-forge
 dependencies:
+  - python<3.13
   - sphinx_rtd_theme=2.0.*
   - sphinxcontrib-bibtex=2.6.*
   - tree

--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -1,6 +1,6 @@
 {
-  "build": "py_0",
-  "buildnum": "0",
+  "build": "py_1",
+  "buildnum": "1",
   "name": "uwtools",
   "packages": {
     "dev": [
@@ -11,7 +11,7 @@
       "isort =5.13.*",
       "jinja2 =3.1.*",
       "jq =1.7.*",
-      "jsonschema =4.23.*",
+      "jsonschema >=4.18,<4.24",
       "lxml =5.2.*",
       "make >=3.8",
       "mypy =1.10.*",
@@ -27,7 +27,7 @@
       "f90nml =1.4.*",
       "iotaa =0.8.*",
       "jinja2 =3.1.*",
-      "jsonschema =4.23.*",
+      "jsonschema >=4.18,<4.24",
       "lxml =5.2.*",
       "python >=3.9,<3.13",
       "pyyaml =6.0.*"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - f90nml 1.4.*
     - iotaa 0.8.*
     - jinja2 3.1.*
-    - jsonschema 4.23.*
+    - jsonschema >=4.18,<4.24
     - lxml 5.2.*
     - python >=3.9,<3.13
     - pyyaml 6.0.*

--- a/src/uwtools/resources/info.json
+++ b/src/uwtools/resources/info.json
@@ -1,4 +1,4 @@
 {
   "version": "2.4.2",
-  "buildnum": "0"
+  "buildnum": "1"
 }


### PR DESCRIPTION
**Synopsis**

Update build number to 1 for version 2.4.2, with a relaxed pin range for `jsonschema`.

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
