### PR TITLE
 Implement fs copy from HTTP

### DIFF
--- a/docs/sections/user_guide/cli/tools/fs.rst
+++ b/docs/sections/user_guide/cli/tools/fs.rst
@@ -25,7 +25,7 @@ Source paths prefixed with ``http://`` or ``https://`` will be copied from their
 Examples
 ^^^^^^^^
 
-Given ``copy-config.yaml`` containing a mapping from local-filesystem destination paths to source paths.
+Given ``copy-config.yaml`` containing a mapping from local-filesystem destination paths to source paths
 
 .. literalinclude:: fs/copy-config.yaml
    :language: yaml
@@ -34,7 +34,7 @@ Given ``copy-config.yaml`` containing a mapping from local-filesystem destinatio
 .. literalinclude:: fs/copy-exec.out
    :language: text
 
-Here, ``foo`` and ``bar`` are copies of their respective local-filesystem source files, and ``gpl`` is a copy of the upstream network source of the GNU General Public License.
+Here, ``foo`` and ``bar`` are copies of their respective local-filesystem source files, and ``gpl`` is a copy of the upstream network source.
 
 The ``--cycle`` and ``--leadtime`` options can be used to make Python ``datetime`` and ``timedelta`` objects, respectively, available for use in Jinja2 expression in the config. For example:
 

--- a/docs/sections/user_guide/cli/tools/fs.rst
+++ b/docs/sections/user_guide/cli/tools/fs.rst
@@ -15,6 +15,8 @@ The ``uw`` mode for handling filesystem items (files and directories).
 
 The ``copy`` action stages files in a target directory by copying files. Any ``KEY`` positional arguments are used to navigate, in the order given, from the top of the config to the :ref:`file block <files_yaml>`.
 
+Source paths prefixed with ``http://`` or ``https://`` will be copied from their upstream network locations to the local filesystem.
+
 .. literalinclude:: fs/copy-help.cmd
    :emphasize-lines: 1
 .. literalinclude:: fs/copy-help.out
@@ -23,7 +25,7 @@ The ``copy`` action stages files in a target directory by copying files. Any ``K
 Examples
 ^^^^^^^^
 
-Given ``copy-config.yaml`` containing
+Given ``copy-config.yaml`` containing a mapping from local-filesystem destination paths to source paths.
 
 .. literalinclude:: fs/copy-config.yaml
    :language: yaml
@@ -32,7 +34,7 @@ Given ``copy-config.yaml`` containing
 .. literalinclude:: fs/copy-exec.out
    :language: text
 
-Here, ``foo`` and ``bar`` are copies of their respective source files.
+Here, ``foo`` and ``bar`` are copies of their respective local-filesystem source files, and ``gpl`` is a copy of the upstream network source of the GNU General Public License.
 
 The ``--cycle`` and ``--leadtime`` options can be used to make Python ``datetime`` and ``timedelta`` objects, respectively, available for use in Jinja2 expression in the config. For example:
 

--- a/docs/sections/user_guide/cli/tools/fs/copy-config.yaml
+++ b/docs/sections/user_guide/cli/tools/fs/copy-config.yaml
@@ -1,4 +1,5 @@
 config:
   files:
     foo: src/foo
+    licenses/gpl: https://www.gnu.org/licenses/gpl-3.0.txt
     subdir/bar: src/bar

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec-no-target-dir-err.out
@@ -1,3 +1,3 @@
-[2024-08-26T23:03:40]     INFO Validating config against internal schema: files-to-stage
-[2024-08-26T23:03:40]     INFO 0 UW schema-validation errors found in fs config
-[2024-08-26T23:03:40]    ERROR Relative path 'foo' requires the target directory to be specified
+[2024-12-07T01:01:51]     INFO Validating config against internal schema: files-to-stage
+[2024-12-07T01:01:53]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:53]    ERROR Relative path 'foo' requires target directory to be specified

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec.out
@@ -1,22 +1,29 @@
-[2024-08-26T23:03:41]     INFO Validating config against internal schema: files-to-stage
-[2024-08-26T23:03:41]     INFO 0 UW schema-validation errors found in fs config
-[2024-08-26T23:03:41]     INFO File copies: Initial state: Not Ready
-[2024-08-26T23:03:41]     INFO File copies: Checking requirements
-[2024-08-26T23:03:41]     INFO Copy src/foo -> copy-dst/foo: Initial state: Not Ready
-[2024-08-26T23:03:41]     INFO Copy src/foo -> copy-dst/foo: Checking requirements
-[2024-08-26T23:03:41]     INFO Copy src/foo -> copy-dst/foo: Requirement(s) ready
-[2024-08-26T23:03:41]     INFO Copy src/foo -> copy-dst/foo: Executing
-[2024-08-26T23:03:41]     INFO Copy src/foo -> copy-dst/foo: Final state: Ready
-[2024-08-26T23:03:41]     INFO Copy src/bar -> copy-dst/subdir/bar: Initial state: Not Ready
-[2024-08-26T23:03:41]     INFO Copy src/bar -> copy-dst/subdir/bar: Checking requirements
-[2024-08-26T23:03:41]     INFO Copy src/bar -> copy-dst/subdir/bar: Requirement(s) ready
-[2024-08-26T23:03:41]     INFO Copy src/bar -> copy-dst/subdir/bar: Executing
-[2024-08-26T23:03:41]     INFO Copy src/bar -> copy-dst/subdir/bar: Final state: Ready
-[2024-08-26T23:03:41]     INFO File copies: Final state: Ready
+[2024-12-07T01:01:56]     INFO Validating config against internal schema: files-to-stage
+[2024-12-07T01:01:56]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:56]     INFO File copies: Initial state: Not Ready
+[2024-12-07T01:01:56]     INFO File copies: Checking requirements
+[2024-12-07T01:01:56]     INFO Copy src/foo -> copy-dst/foo: Initial state: Not Ready
+[2024-12-07T01:01:56]     INFO Copy src/foo -> copy-dst/foo: Checking requirements
+[2024-12-07T01:01:56]     INFO Copy src/foo -> copy-dst/foo: Requirement(s) ready
+[2024-12-07T01:01:56]     INFO Copy src/foo -> copy-dst/foo: Executing
+[2024-12-07T01:01:56]     INFO Copy src/foo -> copy-dst/foo: Final state: Ready
+[2024-12-07T01:01:56]     INFO Copy https://www.gnu.org/licenses/gpl-3.0.txt -> copy-dst/licenses/gpl: Initial state: Not Ready
+[2024-12-07T01:01:56]     INFO Copy https://www.gnu.org/licenses/gpl-3.0.txt -> copy-dst/licenses/gpl: Checking requirements
+[2024-12-07T01:01:58]     INFO Copy https://www.gnu.org/licenses/gpl-3.0.txt -> copy-dst/licenses/gpl: Requirement(s) ready
+[2024-12-07T01:01:58]     INFO Copy https://www.gnu.org/licenses/gpl-3.0.txt -> copy-dst/licenses/gpl: Executing
+[2024-12-07T01:01:58]     INFO Copy https://www.gnu.org/licenses/gpl-3.0.txt -> copy-dst/licenses/gpl: Final state: Ready
+[2024-12-07T01:01:58]     INFO Copy src/bar -> copy-dst/subdir/bar: Initial state: Not Ready
+[2024-12-07T01:01:58]     INFO Copy src/bar -> copy-dst/subdir/bar: Checking requirements
+[2024-12-07T01:01:58]     INFO Copy src/bar -> copy-dst/subdir/bar: Requirement(s) ready
+[2024-12-07T01:01:58]     INFO Copy src/bar -> copy-dst/subdir/bar: Executing
+[2024-12-07T01:01:58]     INFO Copy src/bar -> copy-dst/subdir/bar: Final state: Ready
+[2024-12-07T01:01:58]     INFO File copies: Final state: Ready
 
 copy-dst
 ├── foo
+├── licenses
+│   └── gpl
 └── subdir
     └── bar
 
-2 directories, 2 files
+3 directories, 3 files

--- a/docs/sections/user_guide/cli/tools/fs/link-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/fs/link-exec-no-target-dir-err.out
@@ -1,3 +1,3 @@
-[2024-08-26T23:03:41]     INFO Validating config against internal schema: files-to-stage
-[2024-08-26T23:03:41]     INFO 0 UW schema-validation errors found in fs config
-[2024-08-26T23:03:41]    ERROR Relative path 'foo' requires the target directory to be specified
+[2024-12-07T01:01:55]     INFO Validating config against internal schema: files-to-stage
+[2024-12-07T01:01:55]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:55]    ERROR Relative path 'foo' requires target directory to be specified

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-exec-no-target-dir-err.out
@@ -1,3 +1,3 @@
-[2024-08-26T23:03:44]     INFO Validating config against internal schema: makedirs
-[2024-08-26T23:03:45]     INFO 0 UW schema-validation errors found in fs config
-[2024-08-26T23:03:45]    ERROR Relative path 'foo' requires the target directory to be specified
+[2024-12-07T01:01:55]     INFO Validating config against internal schema: makedirs
+[2024-12-07T01:01:55]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:55]    ERROR Relative path 'foo' requires target directory to be specified

--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -22,6 +22,7 @@
       "pytest-xdist =3.6.*",
       "python >=3.9,<3.13",
       "pyyaml =6.0.*",
+      "requests =2.32.*",
       "setuptools"
     ],
     "run": [
@@ -31,7 +32,8 @@
       "jsonschema >=4.18,<4.24",
       "lxml =5.3.*",
       "python >=3.9,<3.13",
-      "pyyaml =6.0.*"
+      "pyyaml =6.0.*",
+      "requests =2.32.*"
     ]
   },
   "version": "2.5.0"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - lxml 5.3.*
     - python >=3.9,<3.13
     - pyyaml 6.0.*
+    - requests 2.32.*
 test:
   requires:
     - black 24.8.*

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -94,7 +94,8 @@ def main() -> None:
         modes = {**tools, **drivers}
         sys.exit(0 if modes[args[STR.mode]](args) else 1)
     except UWError as e:
-        log.error(str(e))
+        for line in str(e).split("\n"):
+            log.error(line)
         sys.exit(1)
 
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -185,7 +185,8 @@ class Copier(FileStager):
             dst = Path((self._target_dir or "")) / dst
             info = {x: urlparse(str(x)) for x in (dst, src)}
             dst, src = [info[x].path if info[x].scheme == "file" else x for x in (dst, src)]
-            if (scheme := info[src].scheme) in ("", "file"):
+            scheme = info[src].scheme
+            if scheme in ("", "file"):
                 reqs.append(filecopy(src=Path(src), dst=Path(dst)))
             else:
                 raise UWConfigError(f"Support for scheme '{scheme}' not implemented")

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -58,7 +58,7 @@ class Stager(ABC):
         self._config = yaml_config.data
         self._set_config_block()
         self._validate()
-        # self._check_target_dir()
+        self._check_target_dir()
         self._check_destination_paths()
 
     def _check_destination_paths(self) -> None:
@@ -89,7 +89,11 @@ class Stager(ABC):
 
         :raises: UWConfigError when a bad path is detected.
         """
-        if self._target_dir and (scheme := urlparse(self._target_dir).scheme) and scheme != "file":
+        if (
+            self._target_dir
+            and (scheme := urlparse(str(self._target_dir)).scheme)
+            and scheme != "file"
+        ):
             msg = "Non-filesystem path '%s' invalid as target directory"
             raise UWConfigError(msg % self._target_dir)
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -171,14 +171,14 @@ class Copier(FileStager):
         """
         yield "File copies"
         yield [
-            filecopy(src=self._local(src), dst=self._local(self._target_dir) / self._local(dst))
+            filecopy(src=self._simple(src), dst=self._simple(self._target_dir) / self._simple(dst))
             for dst, src in self._config.items()
         ]
 
     @staticmethod
-    def _local(path: Union[Path, str]) -> Path:
+    def _simple(path: Union[Path, str]) -> Path:
         """
-        Convert a path, potentially prefixed with scheme file://, into a simple path.
+        Convert a path, potentially prefixed with scheme file://, into a simple filesystem path.
 
         :param path: The path to convert.
         """

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -70,7 +70,7 @@ class Stager(ABC):
         for dst in self._dst_paths:
             scheme = urlparse(dst).scheme
             absolute = scheme or Path(dst).is_absolute()
-            if scheme and scheme != "file":
+            if scheme and scheme != STR.url_scheme_file:
                 msg = "Non-filesystem destination path '%s' not currently supported"
                 raise UWConfigError(msg % dst)
             if self._target_dir and scheme:
@@ -92,7 +92,7 @@ class Stager(ABC):
         if (
             self._target_dir
             and (scheme := urlparse(str(self._target_dir)).scheme)
-            and scheme != "file"
+            and scheme != STR.url_scheme_file
         ):
             msg = "Non-filesystem path '%s' invalid as target directory"
             raise UWConfigError(msg % self._target_dir)
@@ -174,7 +174,9 @@ class Copier(FileStager):
         for dst, src in self._config.items():
             dst = Path((self._target_dir or "")) / dst
             info = {x: urlparse(str(x)) for x in (dst, src)}
-            dst, src = [info[x].path if info[x].scheme == "file" else x for x in (dst, src)]
+            dst, src = [
+                info[x].path if info[x].scheme == STR.url_scheme_file else x for x in (dst, src)
+            ]
             reqs.append(filecopy(src=src, dst=dst))
         yield reqs
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -170,15 +170,19 @@ class Copier(FileStager):
         Copy files.
         """
         yield "File copies"
-        reqs = []
-        for dst, src in self._config.items():
-            dst = Path((self._target_dir or "")) / dst
-            info = {x: urlparse(str(x)) for x in (dst, src)}
-            dst, src = [
-                info[x].path if info[x].scheme == STR.url_scheme_file else x for x in (dst, src)
-            ]
-            reqs.append(filecopy(src=src, dst=dst))
-        yield reqs
+        yield [
+            filecopy(src=self._local(src), dst=self._local(self._target_dir) / self._local(dst))
+            for dst, src in self._config.items()
+        ]
+
+    @staticmethod
+    def _local(path: Union[Path, str]) -> Path:
+        """
+        Convert a path, potentially prefixed with scheme file://, into a simple path.
+
+        :param path: The path to convert.
+        """
+        return Path(urlparse(str(path)).path)
 
 
 class Linker(FileStager):

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -164,16 +164,6 @@ class Copier(FileStager):
     Stage files by copying.
     """
 
-    # >>> urlparse("path/to/file")
-    # ParseResult(scheme='', netloc='', path='path/to/file', params='', query='', fragment='')
-    # >>> urlparse("/path/to/file")
-    # ParseResult(scheme='', netloc='', path='/path/to/file', params='', query='', fragment='')
-    # >>> urlparse("file:///path/to/file")
-    # ParseResult(scheme='file', netloc='', path='/path/to/file', params='', query='', fragment='')
-    # >>> urlparse("https://foo.com/path/to/file")
-    # ParseResult(scheme='https', netloc='foo.com',
-    #   path='/path/to/file', params='', query='', fragment='')
-
     @tasks
     def go(self):
         """
@@ -185,11 +175,7 @@ class Copier(FileStager):
             dst = Path((self._target_dir or "")) / dst
             info = {x: urlparse(str(x)) for x in (dst, src)}
             dst, src = [info[x].path if info[x].scheme == "file" else x for x in (dst, src)]
-            scheme = info[src].scheme
-            if scheme in ("", "file"):
-                reqs.append(filecopy(src=Path(src), dst=Path(dst)))
-            else:
-                raise UWConfigError(f"Support for scheme '{scheme}' not implemented")
+            reqs.append(filecopy(src=src, dst=dst))
         yield reqs
 
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -73,14 +73,19 @@ class Stager(ABC):
                 msg = "Non-filesystem destination path '%s' not currently supported"
                 raise UWConfigError(msg % dst)
             if self._target_dir and scheme:
-                msg = "Path '%s' invalid when target directory is specified"
+                msg = "Non-filesystem path '%s' invalid when target directory is specified"
                 raise UWConfigError(msg % dst)
             if self._target_dir and absolute:
-                msg = "When target directory is specified, path '%s' must be relative"
+                msg = "Path '%s' must be relative when target directory is specified"
                 raise UWConfigError(msg % dst)
             if not self._target_dir and not absolute:
                 msg = "Relative path '%s' requires target directory to be specified"
                 raise UWConfigError(msg % dst)
+
+    def _check_target_dir(self) -> None:
+        """
+        PM WRITEME.
+        """
 
     def _set_config_block(self) -> None:
         """

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -151,7 +151,7 @@ class Copier(FileStager):
         """
         yield "File copies"
         yield [
-            filecopy(src=self._simple(src), dst=self._simple(self._target_dir) / self._simple(dst))
+            filecopy(src=src, dst=self._simple(self._target_dir) / self._simple(dst))
             for dst, src in self._config.items()
         ]
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -184,10 +184,11 @@ class Copier(FileStager):
         for dst, src in self._config.items():
             dst = Path((self._target_dir or "")) / dst
             info = {x: urlparse(str(x)) for x in (dst, src)}
-            dst, src = [
-                Path(info[x].path) if info[x].scheme == "file" else Path(x) for x in (dst, src)
-            ]
-            reqs.append(filecopy(src=src, dst=dst))
+            dst, src = [info[x].path if info[x].scheme == "file" else x for x in (dst, src)]
+            if (scheme := info[src].scheme) in ("", "file"):
+                reqs.append(filecopy(src=Path(src), dst=Path(dst)))
+            else:
+                raise UWConfigError(f"Support for scheme '{scheme}' not implemented")
         yield reqs
 
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -69,7 +69,7 @@ class Stager(ABC):
         """
         for dst in self._dst_paths:
             scheme = urlparse(dst).scheme
-            absolute = Path(dst).is_absolute()
+            absolute = scheme or Path(dst).is_absolute()
             if scheme and scheme != "file":
                 msg = "Non-filesystem destination path '%s' not currently supported"
                 raise UWConfigError(msg % dst)

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -58,6 +58,7 @@ class Stager(ABC):
         self._config = yaml_config.data
         self._set_config_block()
         self._validate()
+        # self._check_target_dir()
         self._check_destination_paths()
 
     def _check_destination_paths(self) -> None:
@@ -84,8 +85,13 @@ class Stager(ABC):
 
     def _check_target_dir(self) -> None:
         """
-        PM WRITEME.
+        Check that target directory is valid.
+
+        :raises: UWConfigError when a bad path is detected.
         """
+        if self._target_dir and (scheme := urlparse(self._target_dir).scheme) and scheme != "file":
+            msg = "Non-filesystem path '%s' invalid as target directory"
+            raise UWConfigError(msg % self._target_dir)
 
     def _set_config_block(self) -> None:
         """

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -143,6 +143,7 @@ class STR:
     updatefmt: str = "update_format"
     updatevalues: str = "update_values"
     upp: str = "upp"
+    url_scheme_file: str = "file"
     validate: str = "validate"
     valsfile: str = "values_file"
     valsfmt: str = "values_format"

--- a/src/uwtools/tests/api/test_fs.py
+++ b/src/uwtools/tests/api/test_fs.py
@@ -17,7 +17,7 @@ def kwargs(tmp_path):
         f.touch()
     config = {"a": {"b": {str(dstdir / "f1"): str(srcfile1), str(dstdir / "f2"): str(srcfile2)}}}
     return {
-        "target_dir": dstdir,
+        "target_dir": None,
         "config": config,
         "cycle": dt.datetime.now(),
         "leadtime": dt.timedelta(hours=6),

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -130,14 +130,6 @@ def test_fs_Stager__check_destination_paths_fail_scheme_with_target_dir():
     assert str(e.value) == f"Path '{path}' invalid when target directory is specified"
 
 
-# def test_fs_Copier_no_targetdir_relpath_fail(assets):
-#     _, cfgdict, _ = assets
-#     with raises(UWConfigError) as e:
-#         fs.Copier(config=cfgdict, keys=["a", "b"]).go()
-#     errmsg = "Relative path '%s' requires target directory to be specified"
-#     assert errmsg % "foo" in str(e.value)
-
-
 @mark.parametrize("source", ("dict", "file"))
 def test_fs_Stager__config_block_fail_bad_key_path(assets, source):
     dstdir, cfgdict, cfgfile = assets

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -125,18 +125,8 @@ def test_fs_Linker(assets, source):
             "Non-filesystem path '%s' invalid when target directory is specified",
             True,
         ),
-        (
-            "other/path",
-            "/some/path",
-            None,
-            False,
-        ),
-        (
-            "other/path",
-            "file:///some/path",
-            None,
-            False,
-        ),
+        ("other/path", "/some/path", None, False),
+        ("other/path", "file:///some/path", None, False),
     ],
 )
 def test_fs_Stager__check_destination_paths_fail(path, target_dir, msg, fail_expected):

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -85,7 +85,7 @@ def test_Copier_no_targetdir_relpath_fail(assets):
     _, cfgdict, _ = assets
     with raises(UWConfigError) as e:
         fs.Copier(config=cfgdict, key_path=["a", "b"]).go()
-    errmsg = "Relative path '%s' requires the target directory to be specified"
+    errmsg = "Relative path '%s' requires target directory to be specified"
     assert errmsg % "foo" in str(e.value)
 
 

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -81,11 +81,11 @@ def test_fs_Copier_go_no_targetdir_abspath_pass(assets):
     assert all(asset.ready() for asset in assets)  # type: ignore
 
 
-def test_fs_Copier__local():
-    assert fs.Copier._local("relative/path") == Path("relative/path")
-    assert fs.Copier._local("/absolute/path") == Path("/absolute/path")
-    assert fs.Copier._local("file:///absolute/path") == Path("/absolute/path")
-    assert fs.Copier._local("") == Path("")
+def test_fs_Copier__simple():
+    assert fs.Copier._simple("relative/path") == Path("relative/path")
+    assert fs.Copier._simple("/absolute/path") == Path("/absolute/path")
+    assert fs.Copier._simple("file:///absolute/path") == Path("/absolute/path")
+    assert fs.Copier._simple("") == Path("")
 
 
 @mark.parametrize("source", ("dict", "file"))

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
 
+from pathlib import Path
 from unittest.mock import Mock
 
 import iotaa
@@ -52,7 +53,7 @@ class ConcreteStager(fs.Stager):
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_fs_Copier(assets, source):
+def test_fs_Copier_go(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
@@ -62,7 +63,7 @@ def test_fs_Copier(assets, source):
     assert (dstdir / "subdir" / "bar").is_file()
 
 
-def test_fs_Copier_config_file_dry_run(assets):
+def test_fs_Copier_go_config_file_dry_run(assets):
     dstdir, cfgdict, _ = assets
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
@@ -72,12 +73,19 @@ def test_fs_Copier_config_file_dry_run(assets):
     iotaa.dryrun(False)
 
 
-def test_fs_Copier_no_targetdir_abspath_pass(assets):
+def test_fs_Copier_go_no_targetdir_abspath_pass(assets):
     dstdir, cfgdict, _ = assets
     old = cfgdict["a"]["b"]
     cfgdict = {str(dstdir / "foo"): old["foo"], str(dstdir / "bar"): old["subdir/bar"]}
     assets = fs.Copier(config=cfgdict).go()
     assert all(asset.ready() for asset in assets)  # type: ignore
+
+
+def test_fs_Copier__local():
+    assert fs.Copier._local("relative/path") == Path("relative/path")
+    assert fs.Copier._local("/absolute/path") == Path("/absolute/path")
+    assert fs.Copier._local("file:///absolute/path") == Path("/absolute/path")
+    assert fs.Copier._local("") == Path("")
 
 
 @mark.parametrize("source", ("dict", "file"))

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -64,15 +64,26 @@ def test_fs_Copier(assets, source):
 
 
 @mark.parametrize(
-    "dst,target_dir",
-    [("/dst/file", None), ("file:///dst/file", None), ("file", "/dst"), ("file", "file:///dst")],
+    "dst,src,target_dir",
+    [
+        ("/dst/file", "/src/file", None),
+        ("file:///dst/file", "/src/file", None),
+        ("file", "/src/file", "/dst"),
+        ("file", "/src/file", "file:///dst"),
+    ],
 )
-def test_fs_Copier_scheme_file(dst, target_dir):
-    src = "/src/file"
+def test_fs_Copier_schemes(dst, src, target_dir):
     obj = Mock(_config={dst: src}, _target_dir=target_dir)
     with patch.object(fs, "filecopy") as filecopy:
         fs.Copier.go(obj)
         filecopy.assert_called_once_with(src=Path(src), dst=Path("/dst/file"))
+
+
+def test_fs_Copier_schemes_fail():
+    obj = Mock(_config={"/dst/file": "foo://x/y/z"}, _target_dir=None)
+    with raises(UWConfigError) as e:
+        fs.Copier.go(obj)
+    assert str(e.value) == "Support for scheme 'foo' not implemented"
 
 
 def test_fs_Copier_config_file_dry_run(assets):

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -49,7 +49,7 @@ class ConcreteStager(fs.Stager):
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_Copier(assets, source):
+def test_fs_Copier(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
@@ -59,7 +59,7 @@ def test_Copier(assets, source):
     assert (dstdir / "subdir" / "bar").is_file()
 
 
-def test_Copier_config_file_dry_run(assets):
+def test_fs_Copier_config_file_dry_run(assets):
     dstdir, cfgdict, _ = assets
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
@@ -69,7 +69,7 @@ def test_Copier_config_file_dry_run(assets):
     iotaa.dryrun(False)
 
 
-def test_Copier_no_targetdir_abspath_pass(assets):
+def test_fs_Copier_no_targetdir_abspath_pass(assets):
     dstdir, cfgdict, _ = assets
     old = cfgdict["a"]["b"]
     cfgdict = {str(dstdir / "foo"): old["foo"], str(dstdir / "bar"): old["subdir/bar"]}
@@ -77,23 +77,23 @@ def test_Copier_no_targetdir_abspath_pass(assets):
     assert all(asset.ready() for asset in assets)  # type: ignore
 
 
-def test_Copier_no_targetdir_relpath_fail(assets):
+def test_fs_Copier_no_targetdir_relpath_fail(assets):
     _, cfgdict, _ = assets
     with raises(UWConfigError) as e:
         fs.Copier(config=cfgdict, keys=["a", "b"]).go()
-    errmsg = "Relative path '%s' requires the target directory to be specified"
+    errmsg = "Relative path '%s' requires target directory to be specified"
     assert errmsg % "foo" in str(e.value)
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_FilerStager(assets, source):
+def test_fs_FilerStager(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     assert fs.FileStager(target_dir=dstdir, config=config, keys=["a", "b"])
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_Linker(assets, source):
+def test_fs_Linker(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
@@ -104,7 +104,7 @@ def test_Linker(assets, source):
 
 
 @mark.parametrize("source", ("dict", "file"))
-def test_Stager__config_block_fail_bad_key_path(assets, source):
+def test_fs_Stager__config_block_fail_bad_key_path(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     with raises(UWConfigError) as e:
@@ -113,7 +113,7 @@ def test_Stager__config_block_fail_bad_key_path(assets, source):
 
 
 @mark.parametrize("val", [None, True, False, "str", 42, 3.14, [], tuple()])
-def test_Stager__config_block_fails_bad_type(assets, val):
+def test_fs_Stager__config_block_fails_bad_type(assets, val):
     dstdir, cfgdict, _ = assets
     cfgdict["a"]["b"] = val
     with raises(UWConfigError) as e:

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -103,7 +103,7 @@ def test_fs_Stager__check_destination_paths_fail_absolute_with_target_dir():
     obj = Mock(_dst_paths=[path], _target_dir="/some/path")
     with raises(UWConfigError) as e:
         fs.Stager._check_destination_paths(obj)
-    assert str(e.value) == f"When target directory is specified, path '{path}' must be relative"
+    assert str(e.value) == f"Path '{path}' must be relative when target directory is specified"
 
 
 def test_fs_Stager__check_destination_paths_fail_bad_scheme():
@@ -127,7 +127,9 @@ def test_fs_Stager__check_destination_paths_fail_scheme_with_target_dir():
     obj = Mock(_dst_paths=[path], _target_dir="/some/path")
     with raises(UWConfigError) as e:
         fs.Stager._check_destination_paths(obj)
-    assert str(e.value) == f"Path '{path}' invalid when target directory is specified"
+    assert (
+        str(e.value) == f"Non-filesystem path '{path}' invalid when target directory is specified"
+    )
 
 
 @mark.parametrize("source", ("dict", "file"))

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -136,6 +136,20 @@ def test_tasks_filecopy_directory_hierarchy(tmp_path):
     assert dst.is_file()
 
 
+def test_tasks_filecopy_source_http(tmp_path):
+    src = "http://foo.com/obj"
+    dst = tmp_path / "a-file"
+    assert not dst.is_file()
+    with patch.object(tasks, "existing", exists):
+        with patch.object(tasks, "requests") as requests:
+            response = requests.get()
+            response.status_code = 200
+            response.content = "data".encode("utf-8")
+            tasks.filecopy(src=src, dst=dst)
+        requests.get.assert_called_with(src, allow_redirects=True, timeout=3)
+    assert dst.is_file()
+
+
 @mark.parametrize(
     "src,ok",
     [("/src/file", True), ("file:///src/file", True), ("foo://bucket/a/b", False)],

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -164,12 +164,12 @@ def test_tasks_filecopy_source_local(src, ok):
             with patch.object(tasks, "file", exists):
                 with patch.object(tasks, "copy") as copy:
                     tasks.filecopy(src=src, dst=dst)
+            mkdir.assert_called_once_with(parents=True, exist_ok=True)
             copy.assert_called_once_with(Path(src), Path(dst))
         else:
             with raises(UWConfigError) as e:
                 tasks.filecopy(src=src, dst=dst)
             assert str(e.value) == "Support for scheme 'foo' not implemented"
-    mkdir.assert_called_once_with(parents=True, exist_ok=True)
 
 
 def test_tasks_symlink_simple(tmp_path):

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -100,6 +100,13 @@ def test_tasks_existing_remote(caplog, code, expected, scheme):
     assert logged(caplog, msg)
 
 
+def test_tasks_existing_bad_scheme():
+    path = "foo://bucket/a/b"
+    with raises(UWConfigError) as e:
+        tasks.existing(path=path)
+    assert str(e.value) == "Support for scheme 'foo' not implemented"
+
+
 def test_tasks_file_missing(tmp_path):
     path = tmp_path / "file"
     assert not ready(tasks.file(path=path))

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -159,17 +159,17 @@ def test_tasks_filecopy_source_http(code, expected, src, tmp_path):
 )
 def test_tasks_filecopy_source_local(src, ok):
     dst = "/dst/file"
-    if ok:
-        with patch.object(tasks, "file", exists):
-            with patch.object(tasks, "copy") as copy:
-                with patch.object(tasks.Path, "mkdir") as mkdir:
+    with patch.object(tasks.Path, "mkdir") as mkdir:
+        if ok:
+            with patch.object(tasks, "file", exists):
+                with patch.object(tasks, "copy") as copy:
                     tasks.filecopy(src=src, dst=dst)
-        mkdir.assert_called_once_with(parents=True, exist_ok=True)
-        copy.assert_called_once_with(Path(src), Path(dst))
-    else:
-        with raises(UWConfigError) as e:
-            tasks.filecopy(src=src, dst=dst)
-        assert str(e.value) == "Support for scheme 'foo' not implemented"
+            copy.assert_called_once_with(Path(src), Path(dst))
+        else:
+            with raises(UWConfigError) as e:
+                tasks.filecopy(src=src, dst=dst)
+            assert str(e.value) == "Support for scheme 'foo' not implemented"
+    mkdir.assert_called_once_with(parents=True, exist_ok=True)
 
 
 def test_tasks_symlink_simple(tmp_path):

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -48,27 +48,37 @@ def test_tasks_executable(tmp_path):
         assert ready(tasks.executable(program=p))
 
 
-def test_tasks_existing_missing(tmp_path):
-    path = tmp_path / "x"
+@mark.parametrize("prefix", ["", "file://"])
+def test_tasks_existing_local_missing(prefix, tmp_path):
+    base = tmp_path / "x"
+    path = prefix + str(base) if prefix else base
     assert not ready(tasks.existing(path=path))
 
 
-def test_tasks_existing_present_directory(tmp_path):
+def test_tasks_existing_local_present_directory(tmp_path):
     path = tmp_path / "directory"
     path.mkdir()
     assert ready(tasks.existing(path=path))
 
 
-def test_tasks_existing_present_file(tmp_path):
-    path = tmp_path / "file"
-    path.touch()
+@mark.parametrize("prefix", ["", "file://"])
+def test_tasks_existing_local_present_file(prefix, tmp_path):
+    base = tmp_path / "file"
+    base.touch()
+    path = prefix + str(base) if prefix else base
     assert ready(tasks.existing(path=path))
 
 
-def test_tasks_existing_present_symlink(tmp_path):
-    path = tmp_path / "symlink"
-    path.symlink_to(os.devnull)
+@mark.parametrize("prefix", ["", "file://"])
+def test_tasks_existing_local_present_symlink(prefix, tmp_path):
+    base = tmp_path / "symlink"
+    base.symlink_to(os.devnull)
+    path = prefix + str(base) if prefix else base
     assert ready(tasks.existing(path=path))
+
+
+def test_tasks_existing_remote():
+    pass  # PM FIXME
 
 
 def test_tasks_file_missing(tmp_path):

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -14,7 +14,6 @@ from iotaa import asset, external, task
 
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
-from uwtools.utils.file import writable
 
 SCHEMES = ns(http=("http", "https"), local=("", "file"))
 
@@ -102,7 +101,7 @@ def filecopy(src: Union[Path, str], dst: Union[Path, str]):
         yield existing(src)
         response = requests.get(src, allow_redirects=True, timeout=3)
         if (code := response.status_code) == 200:
-            with writable(dst) as f:
+            with open(dst, "wb") as f:
                 f.write(response.content)
         else:
             log.error("Could not get '%s', HTTP status was: %s", src, code)

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -55,9 +55,10 @@ def existing(path: Union[Path, str]):
         yield "Filesystem item %s" % path
         yield asset(path, path.exists)
     elif scheme in SCHEMES.http:
+        okcodes = (200, 301)
         path = str(path)
         yield "Remote item %s" % path
-        yield asset(path, lambda: requests.head(path, timeout=5).status_code == 200)
+        yield asset(path, lambda: requests.head(path, timeout=3).status_code in okcodes)
     else:
         _bad_scheme(scheme)
 

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -55,10 +55,10 @@ def existing(path: Union[Path, str]):
         yield "Filesystem item %s" % path
         yield asset(path, path.exists)
     elif scheme in SCHEMES.http:
-        okcodes = (200, 301)
         path = str(path)
+        ready = lambda: requests.head(path, allow_redirects=True, timeout=3).status_code == 200
         yield "Remote item %s" % path
-        yield asset(path, lambda: requests.head(path, timeout=3).status_code in okcodes)
+        yield asset(path, ready)
     else:
         _bad_scheme(scheme)
 

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -49,9 +49,10 @@ def existing(path: Union[Path, str]):
     :param path: Path to the item.
     :raises: UWConfigError for unsupported URL schemes.
     """
-    scheme = urlparse(str(path)).scheme
+    info = urlparse(str(path))
+    scheme = info.scheme
     if scheme in SCHEMES.local:
-        path = Path(path)
+        path = Path(info.path if scheme == "file" else path)
         yield "Filesystem item %s" % path
         yield asset(path, path.exists)
     elif scheme in SCHEMES.http:

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -90,11 +90,11 @@ def filecopy(src: Union[Path, str], dst: Union[Path, str]):
     yield "Copy %s -> %s" % (src, dst)
     yield asset(Path(dst), Path(dst).is_file)
     dst = Path(dst)  # currently no support for remote destinations
+    dst.parent.mkdir(parents=True, exist_ok=True)
     scheme = urlparse(str(src)).scheme
     if scheme in SCHEMES.local:
         src = Path(src)
         yield file(src)
-        dst.parent.mkdir(parents=True, exist_ok=True)
         copy(src, dst)
     elif scheme in SCHEMES.http:
         src = str(src)

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -58,7 +58,7 @@ def existing(path: Union[Path, str]):
     elif scheme in SCHEMES.http:
         path = str(path)
         ready = lambda: requests.head(path, allow_redirects=True, timeout=3).status_code == 200
-        yield "Remote item %s" % path
+        yield "Remote object %s" % path
         yield asset(path, ready)
     else:
         _bad_scheme(scheme)

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -90,15 +90,16 @@ def filecopy(src: Union[Path, str], dst: Union[Path, str]):
     yield "Copy %s -> %s" % (src, dst)
     yield asset(Path(dst), Path(dst).is_file)
     dst = Path(dst)  # currently no support for remote destinations
-    dst.parent.mkdir(parents=True, exist_ok=True)
     scheme = urlparse(str(src)).scheme
     if scheme in SCHEMES.local:
         src = Path(src)
         yield file(src)
+        dst.parent.mkdir(parents=True, exist_ok=True)
         copy(src, dst)
     elif scheme in SCHEMES.http:
         src = str(src)
         yield existing(src)
+        dst.parent.mkdir(parents=True, exist_ok=True)
         response = requests.get(src, allow_redirects=True, timeout=3)
         if (code := response.status_code) == 200:
             with open(dst, "wb") as f:


### PR DESCRIPTION
**Synopsis**

Fixes #667.

See updated docs for an example but, in short, for file copies (CLI `uw fs copy`, API `uwtools.api.fs.copy()`), interpret paths starting with `http://` or `https://` as URLs of remote files and fetch them to the local filesystem with `requests`. For example:
```
$ echo "gpl: https://www.gnu.org/licenses/gpl.txt" | uw fs copy --target-dir licenses
[2024-12-07T01:12:25]     INFO Validating config against internal schema: files-to-stage
[2024-12-07T01:12:25]     INFO 0 UW schema-validation errors found in fs config
[2024-12-07T01:12:25]     INFO File copies: Initial state: Not Ready
[2024-12-07T01:12:25]     INFO File copies: Checking requirements
[2024-12-07T01:12:25]     INFO Copy https://www.gnu.org/licenses/gpl.txt -> licenses/gpl: Initial state: Not Ready
[2024-12-07T01:12:25]     INFO Copy https://www.gnu.org/licenses/gpl.txt -> licenses/gpl: Checking requirements
[2024-12-07T01:12:26]     INFO Copy https://www.gnu.org/licenses/gpl.txt -> licenses/gpl: Requirement(s) ready
[2024-12-07T01:12:26]     INFO Copy https://www.gnu.org/licenses/gpl.txt -> licenses/gpl: Executing
[2024-12-07T01:12:26]     INFO Copy https://www.gnu.org/licenses/gpl.txt -> licenses/gpl: Final state: Ready
[2024-12-07T01:12:26]     INFO File copies: Final state: Ready
```
```
$ tree licenses
licenses
└── gpl

1 directory, 1 file
```

Unavailable upstream files are detected, leading to a no-op:

```
$ echo "gpl: https://www.gnu.org/licenses/nope.txt" | uw fs copy --target-dir licenses
[2024-12-07T01:16:41]     INFO Validating config against internal schema: files-to-stage
[2024-12-07T01:16:41]     INFO 0 UW schema-validation errors found in fs config
[2024-12-07T01:16:41]     INFO File copies: Initial state: Not Ready
[2024-12-07T01:16:41]     INFO File copies: Checking requirements
[2024-12-07T01:16:41]     INFO Copy https://www.gnu.org/licenses/nope.txt -> licenses/gpl: Initial state: Not Ready
[2024-12-07T01:16:41]     INFO Copy https://www.gnu.org/licenses/nope.txt -> licenses/gpl: Checking requirements
[2024-12-07T01:16:41]  WARNING Remote object https://www.gnu.org/licenses/nope.txt: State: Not Ready (external asset)
[2024-12-07T01:16:42]     INFO Copy https://www.gnu.org/licenses/nope.txt -> licenses/gpl: Requirement(s) not ready
[2024-12-07T01:16:42]  WARNING Copy https://www.gnu.org/licenses/nope.txt -> licenses/gpl: Final state: Not Ready
[2024-12-07T01:16:42]  WARNING File copies: Final state: Not Ready
```
```
$ tree licenses
licenses  [error opening dir]

0 directories, 0 files
```

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

**Type**

- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
