### PR TITLE
Update fs mode to use --key-path CLI switch / key_path API argument

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - python >=3.9,<3.13 # keep in sync with meta.yaml run req
   - sphinx_rtd_theme 3.0.*
   - sphinxcontrib-bibtex 2.6.*
-  - tree
+  - tree 2.2.*

--- a/docs/sections/user_guide/cli/drivers/cdeps/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/cdeps/run-help.out
@@ -20,8 +20,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/chgres_cube/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/chgres_cube/run-help.out
@@ -25,8 +25,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/esg_grid/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/esg_grid/run-help.out
@@ -19,8 +19,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/filter_topo/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/filter_topo/run-help.out
@@ -19,8 +19,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/fv3/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/fv3/run-help.out
@@ -23,8 +23,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/global_equiv_resol/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/global_equiv_resol/run-help.out
@@ -19,8 +19,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/ioda/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/ioda/run-help.out
@@ -23,8 +23,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/jedi/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/jedi/run-help.out
@@ -23,8 +23,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/make_hgrid/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/make_hgrid/run-help.out
@@ -19,8 +19,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/make_solo_mosaic/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/make_solo_mosaic/run-help.out
@@ -19,8 +19,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/mpas/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/mpas/run-help.out
@@ -23,8 +23,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/mpas_init/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/mpas_init/run-help.out
@@ -23,8 +23,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/orog/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/orog/run-help.out
@@ -18,8 +18,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/orog_gsl/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/orog_gsl/run-help.out
@@ -19,8 +19,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/sfc_climo_gen/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/sfc_climo_gen/run-help.out
@@ -19,8 +19,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/shave/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/shave/run-help.out
@@ -18,8 +18,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/ungrib/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/ungrib/run-help.out
@@ -23,8 +23,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/upp/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/upp/run-help.out
@@ -25,8 +25,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/tools/execute/help.out
+++ b/docs/sections/user_guide/cli/tools/execute/help.out
@@ -34,8 +34,7 @@ Optional arguments:
   --graph-file PATH
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
-      Dot-separated path of keys leading through the config to the driver's
-      configuration block
+      Dot-separated path of keys to driver config block
   --quiet, -q
       Print no logging messages
   --verbose, -v

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec-no-target-dir-err.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec-no-target-dir-err.cmd
@@ -1,1 +1,1 @@
-uw fs copy --config-file copy-config.yaml config files
+uw fs copy --config-file copy-config.yaml --key-path config.files

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec-timedep.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec-timedep.cmd
@@ -1,4 +1,4 @@
 rm -rf copy-dst-timedep
-uw fs copy --target-dir copy-dst-timedep --config-file copy-config-timedep.yaml --cycle 2024-05-29T12 --leadtime 6 config files
+uw fs copy --target-dir copy-dst-timedep --config-file copy-config-timedep.yaml --cycle 2024-05-29T12 --leadtime 6 --key-path config.files
 echo
 tree copy-dst-timedep

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec.cmd
@@ -1,4 +1,4 @@
 rm -rf copy-dst
-uw fs copy --target-dir copy-dst --config-file copy-config.yaml config files
+uw fs copy --target-dir copy-dst --config-file copy-config.yaml --key-path config.files
 echo
 tree copy-dst

--- a/docs/sections/user_guide/cli/tools/fs/copy-help.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-help.out
@@ -1,7 +1,6 @@
 usage: uw fs copy [-h] [--version] [--config-file PATH] [--target-dir PATH]
-                  [--cycle CYCLE] [--leadtime LEADTIME] [--dry-run] [--quiet]
-                  [--verbose]
-                  [KEY ...]
+                  [--cycle CYCLE] [--leadtime LEADTIME] [--dry-run]
+                  [--key-path KEY[.KEY...]] [--quiet] [--verbose]
 
 Copy files
 
@@ -20,9 +19,9 @@ Optional arguments:
       The leadtime as hours[:minutes[:seconds]]
   --dry-run
       Only log info, making no changes
+  --key-path KEY[.KEY...]
+      Dot-separated path of keys to config block to use
   --quiet, -q
       Print no logging messages
   --verbose, -v
       Print all logging messages
-  KEY
-      YAML key leading to file dst/src block

--- a/docs/sections/user_guide/cli/tools/fs/link-exec-no-target-dir-err.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/link-exec-no-target-dir-err.cmd
@@ -1,1 +1,1 @@
-uw fs link --config-file link-config.yaml config files
+uw fs link --config-file link-config.yaml --key-path config.files

--- a/docs/sections/user_guide/cli/tools/fs/link-exec-timedep.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/link-exec-timedep.cmd
@@ -1,4 +1,4 @@
 rm -rf link-dst-timedep
-uw fs link --target-dir link-dst-timedep --config-file link-config-timedep.yaml --cycle 2024-05-29T12 --leadtime 6 config files
+uw fs link --target-dir link-dst-timedep --config-file link-config-timedep.yaml --cycle 2024-05-29T12 --leadtime 6 --key-path config.files
 echo
 tree link-dst-timedep

--- a/docs/sections/user_guide/cli/tools/fs/link-exec.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/link-exec.cmd
@@ -1,4 +1,4 @@
 rm -rf link-dst
-uw fs link --target-dir link-dst --config-file link-config.yaml config files
+uw fs link --target-dir link-dst --config-file link-config.yaml --key-path config.files
 echo
 tree link-dst

--- a/docs/sections/user_guide/cli/tools/fs/link-help.out
+++ b/docs/sections/user_guide/cli/tools/fs/link-help.out
@@ -1,7 +1,6 @@
 usage: uw fs link [-h] [--version] [--config-file PATH] [--target-dir PATH]
-                  [--cycle CYCLE] [--leadtime LEADTIME] [--dry-run] [--quiet]
-                  [--verbose]
-                  [KEY ...]
+                  [--cycle CYCLE] [--leadtime LEADTIME] [--dry-run]
+                  [--key-path KEY[.KEY...]] [--quiet] [--verbose]
 
 Link files
 
@@ -20,9 +19,9 @@ Optional arguments:
       The leadtime as hours[:minutes[:seconds]]
   --dry-run
       Only log info, making no changes
+  --key-path KEY[.KEY...]
+      Dot-separated path of keys to config block to use
   --quiet, -q
       Print no logging messages
   --verbose, -v
       Print all logging messages
-  KEY
-      YAML key leading to file dst/src block

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-exec-no-target-dir-err.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-exec-no-target-dir-err.cmd
@@ -1,1 +1,1 @@
-uw fs makedirs --config-file makedirs-config.yaml config
+uw fs makedirs --config-file makedirs-config.yaml --key-path config

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-exec-timedep.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-exec-timedep.cmd
@@ -1,4 +1,4 @@
 rm -rf makedirs-parent-timedep
-uw fs makedirs --target-dir makedirs-parent-timedep --config-file makedirs-config-timedep.yaml --cycle 2024-05-29T12 --leadtime 6 config
+uw fs makedirs --target-dir makedirs-parent-timedep --config-file makedirs-config-timedep.yaml --cycle 2024-05-29T12 --leadtime 6 --key-path config
 echo
 tree -F makedirs-parent-timedep

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-exec.cmd
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-exec.cmd
@@ -1,4 +1,4 @@
 rm -rf makedirs-parent
-uw fs makedirs --target-dir makedirs-parent --config-file makedirs-config.yaml config
+uw fs makedirs --target-dir makedirs-parent --config-file makedirs-config.yaml --key-path config
 echo
 tree -F makedirs-parent

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-help.out
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-help.out
@@ -1,7 +1,7 @@
 usage: uw fs makedirs [-h] [--version] [--config-file PATH]
                       [--target-dir PATH] [--cycle CYCLE]
-                      [--leadtime LEADTIME] [--dry-run] [--quiet] [--verbose]
-                      [KEY ...]
+                      [--leadtime LEADTIME] [--dry-run]
+                      [--key-path KEY[.KEY...]] [--quiet] [--verbose]
 
 Make directories
 
@@ -20,9 +20,9 @@ Optional arguments:
       The leadtime as hours[:minutes[:seconds]]
   --dry-run
       Only log info, making no changes
+  --key-path KEY[.KEY...]
+      Dot-separated path of keys to config block to use
   --quiet, -q
       Print no logging messages
   --verbose, -v
       Print all logging messages
-  KEY
-      YAML key leading to file dst/src block

--- a/notebooks/config.ipynb
+++ b/notebooks/config.ipynb
@@ -367,7 +367,7 @@
       "    :param update_format: Format of the update config (optional if file's extension is recognized).\n",
       "    :param output_file: Output config file (``None`` => write to ``stdout``).\n",
       "    :param output_format: Format of the output config (optional if file's extension is recognized).\n",
-      "    :param key_path: Path through keys to the desired output block.\n",
+      "    :param key_path: Path of keys to the desired output block.\n",
       "    :param values_needed: Report complete, missing, and template values.\n",
       "    :param total: Require rendering of all Jinja2 variables/expressions.\n",
       "    :param dry_run: Log output instead of writing to output.\n",

--- a/notebooks/fs.ipynb
+++ b/notebooks/fs.ipynb
@@ -64,14 +64,14 @@
      "text": [
       "Help on function copy in module uwtools.api.fs:\n",
       "\n",
-      "copy(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False, stdin_ok: bool = False) -> bool\n",
+      "copy(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False, stdin_ok: bool = False) -> bool\n",
       "    Copy files.\n",
       "\n",
       "    :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).\n",
       "    :param target_dir: Path to target directory.\n",
       "    :param cycle: A datetime object to make available for use in the config.\n",
       "    :param leadtime: A timedelta object to make available for use in the config.\n",
-      "    :param keys: YAML keys leading to file dst/src block.\n",
+      "    :param key_path: Path of keys to config block to use.\n",
       "    :param dry_run: Do not copy files.\n",
       "    :param stdin_ok: OK to read from ``stdin``?\n",
       "    :return: ``True`` if all copies were created.\n",
@@ -130,26 +130,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Final state: Ready\n"
+      "[2024-12-09T21:56:27]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:56:27]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:56:27]     INFO File copies: Initial state: Not Ready\n",
+      "[2024-12-09T21:56:27]     INFO File copies: Checking requirements\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Checking requirements\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Requirement(s) ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Executing\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Final state: Ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Initial state: Not Ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Checking requirements\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Requirement(s) ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Executing\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-target/data/file2-copy.txt: Final state: Ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Initial state: Not Ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Checking requirements\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Requirement(s) ready\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Executing\n",
+      "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-target/data/file3-copy.csv: Final state: Ready\n",
+      "[2024-12-09T21:56:27]     INFO File copies: Final state: Ready\n"
      ]
     },
     {
@@ -195,7 +195,7 @@
       "│   └── \u001b[00mfile3-copy.csv\u001b[0m\n",
       "└── \u001b[00mfile1-copy.nml\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -224,16 +224,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]  WARNING File fixtures/fs/missing-file.nml: State: Not Ready (external asset)\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Requirement(s) not ready\n",
-      "[2024-11-19T23:14:42]  WARNING Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Final state: Not Ready\n",
-      "[2024-11-19T23:14:42]  WARNING File copies: Final state: Not Ready\n"
+      "[2024-12-09T21:56:33]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:56:33]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:56:33]     INFO File copies: Initial state: Not Ready\n",
+      "[2024-12-09T21:56:33]     INFO File copies: Checking requirements\n",
+      "[2024-12-09T21:56:33]     INFO Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:56:33]     INFO Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Checking requirements\n",
+      "[2024-12-09T21:56:33]  WARNING File fixtures/fs/missing-file.nml: State: Not Ready (external asset)\n",
+      "[2024-12-09T21:56:33]     INFO Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Requirement(s) not ready\n",
+      "[2024-12-09T21:56:33]  WARNING Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Final state: Not Ready\n",
+      "[2024-12-09T21:56:33]  WARNING File copies: Final state: Not Ready\n"
      ]
     },
     {
@@ -278,7 +278,7 @@
       "│   └── \u001b[00mfile3-copy.csv\u001b[0m\n",
       "└── \u001b[00mfile1-copy.nml\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -292,7 +292,7 @@
    "id": "b2527839-c217-428d-a686-c684a682c0e8",
    "metadata": {},
    "source": [
-    "### Using the `keys` parameter<!--copy-->\n",
+    "### Using the `key_path` argument<!--copy-->\n",
     "\n",
     "Consider the following configuration, in which the destination/source mapping is not located at the top level of the configuration:"
    ]
@@ -326,7 +326,7 @@
    "id": "5311866f-a1f5-4243-81a8-2c52172e091a",
    "metadata": {},
    "source": [
-    "Without additional information, `copy()` would raise a `UWConfigError` given this configuration. However, the list of keys leading to the destination/source mapping can be provided with the `keys` parameter:"
+    "Without additional information, `copy()` would raise a `UWConfigError` given this configuration. However, the list of keys leading to the destination/source mapping can be provided with the `key_path` argument:"
    ]
   },
   {
@@ -339,26 +339,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Final state: Ready\n"
+      "[2024-12-09T21:57:25]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:57:25]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:25]     INFO File copies: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:25]     INFO File copies: Checking requirements\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Checking requirements\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Requirement(s) ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Executing\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Final state: Ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Checking requirements\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Requirement(s) ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Executing\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file2.txt -> tmp/copy-keys-target/data/file2-copy.txt: Final state: Ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Checking requirements\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Requirement(s) ready\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Executing\n",
+      "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file3.csv -> tmp/copy-keys-target/data/file3-copy.csv: Final state: Ready\n",
+      "[2024-12-09T21:57:25]     INFO File copies: Final state: Ready\n"
      ]
     },
     {
@@ -377,7 +377,7 @@
     "fs.copy(\n",
     "    config=\"fixtures/fs/copy-keys-config.yaml\",\n",
     "    target_dir=\"tmp/copy-keys-target\",\n",
-    "    keys=[\"files\",\"to\",\"copy\"]\n",
+    "    key_path=[\"files\",\"to\",\"copy\"]\n",
     ")"
    ]
   },
@@ -405,7 +405,7 @@
       "│   └── \u001b[00mfile3-copy.csv\u001b[0m\n",
       "└── \u001b[00mfile1-copy.nml\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -437,7 +437,7 @@
       "Help on class Copier in module uwtools.fs:\n",
       "\n",
       "class Copier(FileStager)\n",
-      " |  Copier(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False) -> None\n",
+      " |  Copier(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False) -> None\n",
       " |\n",
       " |  Stage files by copying.\n",
       " |\n",
@@ -461,14 +461,14 @@
       " |  ----------------------------------------------------------------------\n",
       " |  Methods inherited from Stager:\n",
       " |\n",
-      " |  __init__(self, config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False) -> None\n",
+      " |  __init__(self, config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False) -> None\n",
       " |      Stage files and directories.\n",
       " |\n",
       " |      :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).\n",
       " |      :param target_dir: Path to target directory.\n",
       " |      :param cycle: A ``datetime`` object to make available for use in the config.\n",
       " |      :param leadtime: A ``timedelta`` object to make available for use in the config.\n",
-      " |      :param keys: YAML keys leading to file dst/src block.\n",
+      " |      :param key_path: Path of keys to config block to use.\n",
       " |      :param dry_run: Do not copy files.\n",
       " |      :raises: ``UWConfigError`` if config fails validation.\n",
       " |\n",
@@ -506,26 +506,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO File copies: Final state: Ready\n"
+      "[2024-12-09T21:57:38]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:57:38]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:38]     INFO File copies: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:38]     INFO File copies: Checking requirements\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Checking requirements\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Requirement(s) ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Executing\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Final state: Ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Checking requirements\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Requirement(s) ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Executing\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file2.txt -> tmp/copier-target/data/file2-copy.txt: Final state: Ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Checking requirements\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Requirement(s) ready\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Executing\n",
+      "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file3.csv -> tmp/copier-target/data/file3-copy.csv: Final state: Ready\n",
+      "[2024-12-09T21:57:38]     INFO File copies: Final state: Ready\n"
      ]
     },
     {
@@ -574,7 +574,7 @@
       "│   └── \u001b[00mfile3-copy.csv\u001b[0m\n",
       "└── \u001b[00mfile1-copy.nml\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -605,14 +605,14 @@
      "text": [
       "Help on function link in module uwtools.api.fs:\n",
       "\n",
-      "link(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False, stdin_ok: bool = False) -> bool\n",
+      "link(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False, stdin_ok: bool = False) -> bool\n",
       "    Link files.\n",
       "\n",
       "    :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).\n",
       "    :param target_dir: Path to target directory.\n",
       "    :param cycle: A datetime object to make available for use in the config.\n",
       "    :param leadtime: A timedelta object to make available for use in the config.\n",
-      "    :param keys: YAML keys leading to file dst/src block.\n",
+      "    :param key_path: Path of keys to config block to use.\n",
       "    :param dry_run: Do not link files.\n",
       "    :param stdin_ok: OK to read from ``stdin``?\n",
       "    :return: ``True`` if all links were created.\n",
@@ -671,26 +671,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File links: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File links: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO File links: Final state: Ready\n"
+      "[2024-12-09T21:57:45]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:57:45]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:45]     INFO File links: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:45]     INFO File links: Checking requirements\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Checking requirements\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Requirement(s) ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Executing\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Final state: Ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Checking requirements\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Requirement(s) ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Executing\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file2-link.txt -> fixtures/fs/file2.txt: Final state: Ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Checking requirements\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Requirement(s) ready\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Executing\n",
+      "[2024-12-09T21:57:45]     INFO Link tmp/link-target/data/file3-link.csv -> fixtures/fs/file3.csv: Final state: Ready\n",
+      "[2024-12-09T21:57:45]     INFO File links: Final state: Ready\n"
      ]
     },
     {
@@ -736,7 +736,7 @@
       "├── \u001b[01;36mfile1-link.nml\u001b[0m -> \u001b[00m../../fixtures/fs/file1.nml\u001b[0m\n",
       "└── \u001b[01;36mfile2-link.txt\u001b[0m -> \u001b[00m../../fixtures/fs/file2.txt\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -765,16 +765,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File links: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File links: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]  WARNING Filesystem item fixtures/fs/missing-file.nml: State: Not Ready (external asset)\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Requirement(s) not ready\n",
-      "[2024-11-19T23:14:42]  WARNING Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Final state: Not Ready\n",
-      "[2024-11-19T23:14:42]  WARNING File links: Final state: Not Ready\n"
+      "[2024-12-09T21:57:49]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:57:49]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:49]     INFO File links: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:49]     INFO File links: Checking requirements\n",
+      "[2024-12-09T21:57:49]     INFO Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:57:49]     INFO Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Checking requirements\n",
+      "[2024-12-09T21:57:49]  WARNING Filesystem item fixtures/fs/missing-file.nml: State: Not Ready (external asset)\n",
+      "[2024-12-09T21:57:49]     INFO Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Requirement(s) not ready\n",
+      "[2024-12-09T21:57:49]  WARNING Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Final state: Not Ready\n",
+      "[2024-12-09T21:57:49]  WARNING File links: Final state: Not Ready\n"
      ]
     },
     {
@@ -819,7 +819,7 @@
       "├── \u001b[01;36mfile1-link.nml\u001b[0m -> \u001b[00m../../fixtures/fs/file1.nml\u001b[0m\n",
       "└── \u001b[01;36mfile2-link.txt\u001b[0m -> \u001b[00m../../fixtures/fs/file2.txt\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -833,7 +833,7 @@
    "id": "b887c95e-f71f-4a26-b709-d410a3c30c2e",
    "metadata": {},
    "source": [
-    "### Using the `keys` parameter <!--link-->\n",
+    "### Using the `key_path` argument <!--link-->\n",
     "\n",
     "Consider the following configuration, in which the destination/source mapping is not located at the top level of the configuration:"
    ]
@@ -867,7 +867,7 @@
    "id": "9977ee46-17da-419e-821b-a32fac5139f8",
    "metadata": {},
    "source": [
-    "Without additional information, `link()` would raise a `UWConfigError` given this configuration. However, the list of keys leading to the destination/source mapping can be provided with the `keys` parameter:"
+    "Without additional information, `link()` would raise a `UWConfigError` given this configuration. However, the list of keys leading to the destination/source mapping can be provided with the `Key_path` argument:"
    ]
   },
   {
@@ -880,26 +880,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File links: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File links: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO File links: Final state: Ready\n"
+      "[2024-12-09T21:58:19]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:58:19]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:58:19]     INFO File links: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:19]     INFO File links: Checking requirements\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Checking requirements\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Requirement(s) ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Executing\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Final state: Ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Checking requirements\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Requirement(s) ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Executing\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file2-link.txt -> fixtures/fs/file2.txt: Final state: Ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Checking requirements\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Requirement(s) ready\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Executing\n",
+      "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/data/file3-link.csv -> fixtures/fs/file3.csv: Final state: Ready\n",
+      "[2024-12-09T21:58:19]     INFO File links: Final state: Ready\n"
      ]
     },
     {
@@ -918,7 +918,7 @@
     "fs.link(\n",
     "    config=\"fixtures/fs/link-keys-config.yaml\",\n",
     "    target_dir=\"tmp/link-keys-target\",\n",
-    "    keys=[\"files\",\"to\",\"link\"]\n",
+    "    key_path=[\"files\",\"to\",\"link\"]\n",
     ")"
    ]
   },
@@ -946,7 +946,7 @@
       "├── \u001b[01;36mfile1-link.nml\u001b[0m -> \u001b[00m../../fixtures/fs/file1.nml\u001b[0m\n",
       "└── \u001b[01;36mfile2-link.txt\u001b[0m -> \u001b[00m../../fixtures/fs/file2.txt\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -978,7 +978,7 @@
       "Help on class Linker in module uwtools.fs:\n",
       "\n",
       "class Linker(FileStager)\n",
-      " |  Linker(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False) -> None\n",
+      " |  Linker(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False) -> None\n",
       " |\n",
       " |  Stage files by linking.\n",
       " |\n",
@@ -1002,14 +1002,14 @@
       " |  ----------------------------------------------------------------------\n",
       " |  Methods inherited from Stager:\n",
       " |\n",
-      " |  __init__(self, config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False) -> None\n",
+      " |  __init__(self, config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False) -> None\n",
       " |      Stage files and directories.\n",
       " |\n",
       " |      :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).\n",
       " |      :param target_dir: Path to target directory.\n",
       " |      :param cycle: A ``datetime`` object to make available for use in the config.\n",
       " |      :param leadtime: A ``timedelta`` object to make available for use in the config.\n",
-      " |      :param keys: YAML keys leading to file dst/src block.\n",
+      " |      :param key_path: Path of keys to config block to use.\n",
       " |      :param dry_run: Do not copy files.\n",
       " |      :raises: ``UWConfigError`` if config fails validation.\n",
       " |\n",
@@ -1047,26 +1047,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO File links: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO File links: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO File links: Final state: Ready\n"
+      "[2024-12-09T21:58:29]     INFO Validating config against internal schema: files-to-stage\n",
+      "[2024-12-09T21:58:29]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:58:29]     INFO File links: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:29]     INFO File links: Checking requirements\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Checking requirements\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Requirement(s) ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Executing\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Final state: Ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Checking requirements\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Requirement(s) ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Executing\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file2-link.txt -> fixtures/fs/file2.txt: Final state: Ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Checking requirements\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Requirement(s) ready\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Executing\n",
+      "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/data/file3-link.csv -> fixtures/fs/file3.csv: Final state: Ready\n",
+      "[2024-12-09T21:58:29]     INFO File links: Final state: Ready\n"
      ]
     },
     {
@@ -1115,7 +1115,7 @@
       "├── \u001b[01;36mfile1-link.nml\u001b[0m -> \u001b[00m../../fixtures/fs/file1.nml\u001b[0m\n",
       "└── \u001b[01;36mfile2-link.txt\u001b[0m -> \u001b[00m../../fixtures/fs/file2.txt\u001b[0m\n",
       "\n",
-      "1 directory, 3 files\n"
+      "2 directories, 3 files\n"
      ]
     }
    ],
@@ -1146,14 +1146,14 @@
      "text": [
       "Help on function makedirs in module uwtools.api.fs:\n",
       "\n",
-      "makedirs(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False, stdin_ok: bool = False) -> bool\n",
+      "makedirs(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False, stdin_ok: bool = False) -> bool\n",
       "    Make directories.\n",
       "\n",
       "    :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).\n",
       "    :param target_dir: Path to target directory.\n",
       "    :param cycle: A datetime object to make available for use in the config.\n",
       "    :param leadtime: A timedelta object to make available for use in the config.\n",
-      "    :param keys: YAML keys leading to file dst/src block.\n",
+      "    :param key_path: Path of keys to config block to use.\n",
       "    :param dry_run: Do not link files.\n",
       "    :param stdin_ok: OK to read from ``stdin``?\n",
       "    :return: ``True`` if all directories were made.\n",
@@ -1212,21 +1212,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: makedirs\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/foo: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/foo: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/foo: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/foo: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/foo: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/bar/baz: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/bar/baz: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/bar/baz: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/bar/baz: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-target/bar/baz: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Final state: Ready\n"
+      "[2024-12-09T21:58:35]     INFO Validating config against internal schema: makedirs\n",
+      "[2024-12-09T21:58:35]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:58:35]     INFO Directories: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:35]     INFO Directories: Checking requirements\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/foo: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/foo: Checking requirements\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/foo: Requirement(s) ready\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/foo: Executing\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/foo: Final state: Ready\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/bar/baz: Initial state: Not Ready\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/bar/baz: Checking requirements\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/bar/baz: Requirement(s) ready\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/bar/baz: Executing\n",
+      "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/bar/baz: Final state: Ready\n",
+      "[2024-12-09T21:58:35]     INFO Directories: Final state: Ready\n"
      ]
     },
     {
@@ -1271,7 +1271,7 @@
       "│   └── \u001b[01;34mbaz\u001b[0m\n",
       "└── \u001b[01;34mfoo\u001b[0m\n",
       "\n",
-      "3 directories, 0 files\n"
+      "4 directories, 0 files\n"
      ]
     }
    ],
@@ -1285,7 +1285,7 @@
    "id": "329e939d-0f6d-412c-a36a-4682fe99609a",
    "metadata": {},
    "source": [
-    "### Using the `keys` parameter  <!--dir-->\n",
+    "### Using the `key_path` argument  <!--dir-->\n",
     "\n",
     "Consider the following configuration, in which the destination/source mapping is not located at the top level of the configuration:"
    ]
@@ -1319,7 +1319,7 @@
    "id": "909ff3ea-8577-4b91-94fc-6ce6effe4bec",
    "metadata": {},
    "source": [
-    "Without additional information, `makedirs()` would raise a `UWConfigError` given this configuration. However, the list of keys leading to the destination/source mapping can be provided with the `keys` parameter:"
+    "Without additional information, `makedirs()` would raise a `UWConfigError` given this configuration. However, the list of keys leading to the destination/source mapping can be provided with the `key_path` argument:"
    ]
   },
   {
@@ -1332,21 +1332,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: makedirs\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/foo/bar: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/foo/bar: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/foo/bar: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/foo/bar: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/foo/bar: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/baz: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/baz: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/baz: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/baz: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/dir-keys-target/baz: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Final state: Ready\n"
+      "[2024-12-09T21:59:02]     INFO Validating config against internal schema: makedirs\n",
+      "[2024-12-09T21:59:02]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:59:02]     INFO Directories: Initial state: Not Ready\n",
+      "[2024-12-09T21:59:02]     INFO Directories: Checking requirements\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/foo/bar: Initial state: Not Ready\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/foo/bar: Checking requirements\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/foo/bar: Requirement(s) ready\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/foo/bar: Executing\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/foo/bar: Final state: Ready\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/baz: Initial state: Not Ready\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/baz: Checking requirements\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/baz: Requirement(s) ready\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/baz: Executing\n",
+      "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/baz: Final state: Ready\n",
+      "[2024-12-09T21:59:02]     INFO Directories: Final state: Ready\n"
      ]
     },
     {
@@ -1365,7 +1365,7 @@
     "fs.makedirs(\n",
     "    config=\"fixtures/fs/dir-keys-config.yaml\",\n",
     "    target_dir=\"tmp/dir-keys-target\",\n",
-    "    keys=[\"path\",\"to\",\"dirs\"]\n",
+    "    key_path=[\"path\",\"to\",\"dirs\"]\n",
     ")"
    ]
   },
@@ -1392,7 +1392,7 @@
       "└── \u001b[01;34mfoo\u001b[0m\n",
       "    └── \u001b[01;34mbar\u001b[0m\n",
       "\n",
-      "3 directories, 0 files\n"
+      "4 directories, 0 files\n"
      ]
     }
    ],
@@ -1424,7 +1424,7 @@
       "Help on class MakeDirs in module uwtools.fs:\n",
       "\n",
       "class MakeDirs(Stager)\n",
-      " |  MakeDirs(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False) -> None\n",
+      " |  MakeDirs(config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False) -> None\n",
       " |\n",
       " |  Make directories.\n",
       " |\n",
@@ -1447,14 +1447,14 @@
       " |  ----------------------------------------------------------------------\n",
       " |  Methods inherited from Stager:\n",
       " |\n",
-      " |  __init__(self, config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, keys: Optional[list[str]] = None, dry_run: bool = False) -> None\n",
+      " |  __init__(self, config: Union[dict, str, pathlib.Path, NoneType] = None, target_dir: Union[str, pathlib.Path, NoneType] = None, cycle: Optional[datetime.datetime] = None, leadtime: Optional[datetime.timedelta] = None, key_path: Optional[list[Union[bool, float, int, str]]] = None, dry_run: bool = False) -> None\n",
       " |      Stage files and directories.\n",
       " |\n",
       " |      :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).\n",
       " |      :param target_dir: Path to target directory.\n",
       " |      :param cycle: A ``datetime`` object to make available for use in the config.\n",
       " |      :param leadtime: A ``timedelta`` object to make available for use in the config.\n",
-      " |      :param keys: YAML keys leading to file dst/src block.\n",
+      " |      :param key_path: Path of keys to config block to use.\n",
       " |      :param dry_run: Do not copy files.\n",
       " |      :raises: ``UWConfigError`` if config fails validation.\n",
       " |\n",
@@ -1492,21 +1492,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:14:42]     INFO Validating config against internal schema: makedirs\n",
-      "[2024-11-19T23:14:42]     INFO 0 UW schema-validation errors found in fs config\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/foo: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/foo: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/foo: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/foo: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/foo: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/bar/baz: Initial state: Not Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/bar/baz: Checking requirements\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/bar/baz: Requirement(s) ready\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/bar/baz: Executing\n",
-      "[2024-11-19T23:14:42]     INFO Directory tmp/makedirs-target/bar/baz: Final state: Ready\n",
-      "[2024-11-19T23:14:42]     INFO Directories: Final state: Ready\n"
+      "[2024-12-09T21:59:07]     INFO Validating config against internal schema: makedirs\n",
+      "[2024-12-09T21:59:07]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:59:07]     INFO Directories: Initial state: Not Ready\n",
+      "[2024-12-09T21:59:07]     INFO Directories: Checking requirements\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/foo: Initial state: Not Ready\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/foo: Checking requirements\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/foo: Requirement(s) ready\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/foo: Executing\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/foo: Final state: Ready\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/bar/baz: Initial state: Not Ready\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/bar/baz: Checking requirements\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/bar/baz: Requirement(s) ready\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/bar/baz: Executing\n",
+      "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/bar/baz: Final state: Ready\n",
+      "[2024-12-09T21:59:07]     INFO Directories: Final state: Ready\n"
      ]
     },
     {
@@ -1553,7 +1553,7 @@
       "│   └── \u001b[01;34mbaz\u001b[0m\n",
       "└── \u001b[01;34mfoo\u001b[0m\n",
       "\n",
-      "3 directories, 0 files\n"
+      "4 directories, 0 files\n"
      ]
     }
    ],
@@ -1565,9 +1565,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:DEV-uwtools] *",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-DEV-uwtools-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1579,7 +1579,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/install-deps
+++ b/notebooks/install-deps
@@ -1,1 +1,1 @@
-conda install -q -y --repodata-fn repodata.json "jupyterlab<4.4" "testbook<0.5"
+conda install -q -y --repodata-fn repodata.json "jupyterlab<4.4" "testbook<0.5" "tree 2.2.*"

--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -12,6 +12,7 @@ from uwtools.config.formats.ini import INIConfig
 from uwtools.config.formats.nml import NMLConfig
 from uwtools.config.formats.sh import SHConfig
 from uwtools.config.formats.yaml import YAMLConfig
+from uwtools.config.support import YAMLKey
 from uwtools.config.tools import compare_configs as _compare
 from uwtools.config.tools import realize_config as _realize
 from uwtools.config.validator import validate_external as _validate_external
@@ -116,7 +117,7 @@ def realize(
     update_format: Optional[str] = None,
     output_file: Optional[Union[Path, str]] = None,
     output_format: Optional[str] = None,
-    key_path: Optional[list[Union[str, int]]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     values_needed: bool = False,
     total: bool = False,
     dry_run: bool = False,
@@ -146,7 +147,7 @@ def realize_to_dict(  # pylint: disable=unused-argument
     input_format: Optional[str] = None,
     update_config: Optional[Union[dict, _Config, Path, str]] = None,
     update_format: Optional[str] = None,
-    key_path: Optional[list[Union[str, int]]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     values_needed: bool = False,
     total: bool = False,
     dry_run: bool = False,

--- a/src/uwtools/api/config.py
+++ b/src/uwtools/api/config.py
@@ -239,7 +239,7 @@ Recognized file extensions are: {extensions}
 :param update_format: Format of the update config (optional if file's extension is recognized).
 :param output_file: Output config file (``None`` => write to ``stdout``).
 :param output_format: Format of the output config (optional if file's extension is recognized).
-:param key_path: Path through keys to the desired output block.
+:param key_path: Path of keys to the desired output block.
 :param values_needed: Report complete, missing, and template values.
 :param total: Require rendering of all Jinja2 variables/expressions.
 :param dry_run: Log output instead of writing to output.

--- a/src/uwtools/api/execute.py
+++ b/src/uwtools/api/execute.py
@@ -48,7 +48,7 @@ def execute(
     :param batch: Submit run to the batch system?
     :param dry_run: Do not run the executable, just report what would have been done.
     :param graph_file: Write Graphviz DOT output here.
-    :param key_path: Path of keys to subsection of config file.
+    :param key_path: Path of keys to config block to use.
     :param stdin_ok: OK to read from stdin?
     :return: ``True`` if task completes without raising an exception.
     """

--- a/src/uwtools/api/execute.py
+++ b/src/uwtools/api/execute.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Optional, Type, Union
 
+from uwtools.config.support import YAMLKey
 from uwtools.drivers.support import graph
 from uwtools.drivers.support import tasks as _tasks
 from uwtools.logging import log
@@ -28,7 +29,7 @@ def execute(
     batch: Optional[bool] = False,  # pylint: disable=unused-argument
     dry_run: Optional[bool] = False,
     graph_file: Optional[Union[Path, str]] = None,
-    key_path: Optional[list[str]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     stdin_ok: Optional[bool] = False,
 ) -> bool:
     """

--- a/src/uwtools/api/fs.py
+++ b/src/uwtools/api/fs.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 
 from iotaa import Asset
 
+from uwtools.config.support import YAMLKey
 from uwtools.fs import Copier, Linker, MakeDirs
 from uwtools.utils.api import ensure_data_source as _ensure_data_source
 
@@ -17,7 +18,7 @@ def copy(
     target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    key_path: Optional[list[Union[str, int]]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:
@@ -50,7 +51,7 @@ def link(
     target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    key_path: Optional[list[Union[str, int]]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:
@@ -83,7 +84,7 @@ def makedirs(
     target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    key_path: Optional[list[Union[str, int]]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:

--- a/src/uwtools/api/fs.py
+++ b/src/uwtools/api/fs.py
@@ -17,7 +17,7 @@ def copy(
     target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    keys: Optional[list[str]] = None,
+    key_path: Optional[list[Union[str, int]]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:
@@ -28,7 +28,7 @@ def copy(
     :param target_dir: Path to target directory.
     :param cycle: A datetime object to make available for use in the config.
     :param leadtime: A timedelta object to make available for use in the config.
-    :param keys: YAML keys leading to file dst/src block.
+    :param key_path: Path of keys to config block to use.
     :param dry_run: Do not copy files.
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if all copies were created.
@@ -38,7 +38,7 @@ def copy(
         config=_ensure_data_source(config, stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
-        keys=keys,
+        key_path=key_path,
         dry_run=dry_run,
     )
     assets: list[Asset] = stager.go()  # type: ignore
@@ -50,7 +50,7 @@ def link(
     target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    keys: Optional[list[str]] = None,
+    key_path: Optional[list[Union[str, int]]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:
@@ -61,7 +61,7 @@ def link(
     :param target_dir: Path to target directory.
     :param cycle: A datetime object to make available for use in the config.
     :param leadtime: A timedelta object to make available for use in the config.
-    :param keys: YAML keys leading to file dst/src block.
+    :param key_path: Path of keys to config block to use.
     :param dry_run: Do not link files.
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if all links were created.
@@ -71,7 +71,7 @@ def link(
         config=_ensure_data_source(config, stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
-        keys=keys,
+        key_path=key_path,
         dry_run=dry_run,
     )
     assets: list[Asset] = stager.go()  # type: ignore
@@ -83,7 +83,7 @@ def makedirs(
     target_dir: Optional[Union[Path, str]] = None,
     cycle: Optional[dt.datetime] = None,
     leadtime: Optional[dt.timedelta] = None,
-    keys: Optional[list[str]] = None,
+    key_path: Optional[list[Union[str, int]]] = None,
     dry_run: bool = False,
     stdin_ok: bool = False,
 ) -> bool:
@@ -94,7 +94,7 @@ def makedirs(
     :param target_dir: Path to target directory.
     :param cycle: A datetime object to make available for use in the config.
     :param leadtime: A timedelta object to make available for use in the config.
-    :param keys: YAML keys leading to file dst/src block.
+    :param key_path: Path of keys to config block to use.
     :param dry_run: Do not link files.
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if all directories were made.
@@ -104,7 +104,7 @@ def makedirs(
         config=_ensure_data_source(config, stdin_ok),
         cycle=cycle,
         leadtime=leadtime,
-        keys=keys,
+        key_path=key_path,
         dry_run=dry_run,
     )
     assets: list[Asset] = stager.go()  # type: ignore

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -280,8 +280,7 @@ def _add_subparser_execute(subparsers: Subparsers) -> ModeChecks:
     _add_arg_graph_file(optional)
     _add_arg_key_path(
         optional,
-        helpmsg="Dot-separated path of keys leading through the config "
-        "to the driver's configuration block",
+        helpmsg="Dot-separated path of keys to driver config block"
     )
     return {STR.execute: _add_args_verbosity(optional)}
 
@@ -339,8 +338,8 @@ def _add_subparser_fs_common(parser: Parser) -> ActionChecks:
     _add_arg_cycle(optional)
     _add_arg_leadtime(optional)
     _add_arg_dry_run(optional)
+    _add_arg_key_path(optional, helpmsg="Dot-separated path of keys to config block to use")
     checks = _add_args_verbosity(optional)
-    _add_arg_keys(optional)
     return checks
 
 
@@ -399,7 +398,7 @@ def _dispatch_fs_copy(args: Args) -> bool:
         config=args[STR.cfgfile],
         cycle=args[STR.cycle],
         leadtime=args[STR.leadtime],
-        keys=args[STR.keys],
+        key_path=args[STR.keypath],
         dry_run=args[STR.dryrun],
         stdin_ok=True,
     )
@@ -416,7 +415,7 @@ def _dispatch_fs_link(args: Args) -> bool:
         config=args[STR.cfgfile],
         cycle=args[STR.cycle],
         leadtime=args[STR.leadtime],
-        keys=args[STR.keys],
+        key_path=args[STR.keypath],
         dry_run=args[STR.dryrun],
         stdin_ok=True,
     )
@@ -433,7 +432,7 @@ def _dispatch_fs_makedirs(args: Args) -> bool:
         config=args[STR.cfgfile],
         cycle=args[STR.cycle],
         leadtime=args[STR.leadtime],
-        keys=args[STR.keys],
+        key_path=args[STR.keypath],
         dry_run=args[STR.dryrun],
         stdin_ok=True,
     )
@@ -756,15 +755,6 @@ def _add_arg_key_path(group: Group, helpmsg: str) -> None:
     )
 
 
-def _add_arg_keys(group: Group) -> None:
-    group.add_argument(
-        STR.keys,
-        help="YAML key leading to file dst/src block",
-        metavar="KEY",
-        nargs="*",
-    )
-
-
 def _add_arg_leadtime(group: Group, required: bool = False) -> None:
     group.add_argument(
         _switch(STR.leadtime),
@@ -1031,8 +1021,7 @@ def _add_subparser_for_driver_task(
     _add_arg_graph_file(optional)
     _add_arg_key_path(
         optional,
-        helpmsg="Dot-separated path of keys leading through the config "
-        "to the driver's configuration block",
+        helpmsg="Dot-separated path of keys to driver config block",
     )
     _add_arg_schema_file(optional)
     checks = _add_args_verbosity(optional)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -278,10 +278,7 @@ def _add_subparser_execute(subparsers: Subparsers) -> ModeChecks:
     _add_arg_batch(optional)
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
-    _add_arg_key_path(
-        optional,
-        helpmsg="Dot-separated path of keys to driver config block"
-    )
+    _add_arg_key_path(optional, helpmsg="Dot-separated path of keys to driver config block")
     return {STR.execute: _add_args_verbosity(optional)}
 
 

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -13,7 +13,7 @@ from uwtools.logging import log
 from uwtools.strings import FORMAT
 
 INCLUDE_TAG = "!include"
-
+YAMLKey = Union[bool, float, int, str]
 
 # Public functions
 

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -121,7 +121,7 @@ def walk_key_path(config: dict, key_path: list[str]) -> tuple[dict, str]:
     pathstr = "<unknown>"
     for key in key_path:
         keys.append(key)
-        pathstr = ".".join(keys)
+        pathstr = ".".join(str(key) for key in keys)
         try:
             subconfig = config[key]
         except KeyError as e:

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 
 from uwtools.config.formats.base import Config
 from uwtools.config.jinja2 import unrendered
-from uwtools.config.support import depth, format_to_config, log_and_error
+from uwtools.config.support import YAMLKey, depth, format_to_config, log_and_error
 from uwtools.exceptions import UWConfigError, UWConfigRealizeError, UWError
 from uwtools.logging import log
 from uwtools.strings import FORMAT
@@ -81,7 +81,7 @@ def realize_config(
     update_format: Optional[str] = None,
     output_file: Optional[Path] = None,
     output_format: Optional[str] = None,
-    key_path: Optional[list[Union[str, int]]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     values_needed: bool = False,
     total: bool = False,
     dry_run: bool = False,
@@ -109,7 +109,7 @@ def realize_config(
     return input_obj.data
 
 
-def walk_key_path(config: dict, key_path: list[str]) -> tuple[dict, str]:
+def walk_key_path(config: dict, key_path: list[YAMLKey]) -> tuple[dict, str]:
     """
     Navigate to the sub-config at the end of the path of given keys.
 
@@ -158,22 +158,6 @@ def _ensure_format(
     return fmt
 
 
-def _print_config_section(config: dict, key_path: list[str]) -> None:
-    """
-    Print the contents of the located subtree as key=value pairs, one per line.
-
-    :param config: A config.
-    :param key_path: Path of keys to config block to use.
-    """
-    config, pathstr = walk_key_path(config, key_path)
-    output_lines = []
-    for key, value in config.items():
-        if type(value) not in (bool, float, int, str):
-            raise log_and_error(f"Non-scalar value {value} found at {pathstr}")
-        output_lines.append(f"{key}={value}")
-    print("\n".join(sorted(output_lines)))
-
-
 def _realize_config_input_setup(
     input_config: Optional[Union[Config, Path, dict]] = None, input_format: Optional[str] = None
 ) -> Config:
@@ -197,7 +181,7 @@ def _realize_config_output_setup(
     input_obj: Config,
     output_file: Optional[Path] = None,
     output_format: Optional[str] = None,
-    key_path: Optional[list[Union[str, int]]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
 ) -> tuple[dict, str]:
     """
     Set up config-realize output.

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -114,7 +114,7 @@ def walk_key_path(config: dict, key_path: list[str]) -> tuple[dict, str]:
     Navigate to the sub-config at the end of the path of given keys.
 
     :param config: A config.
-    :param key_path: Path of keys to subsection of config file.
+    :param key_path: Path of keys to config block to use.
     :return: The sub-config and a string representation of the key path.
     """
     keys = []
@@ -163,7 +163,7 @@ def _print_config_section(config: dict, key_path: list[str]) -> None:
     Print the contents of the located subtree as key=value pairs, one per line.
 
     :param config: A config.
-    :param key_path: Path of keys to subsection of config file.
+    :param key_path: Path of keys to config block to use.
     """
     config, pathstr = walk_key_path(config, key_path)
     output_lines = []
@@ -205,7 +205,7 @@ def _realize_config_output_setup(
     :param input_obj: The input Config object.
     :param output_file: Output config destination (None => write to stdout).
     :param output_format: Format of the output config.
-    :param key_path: Path through keys to the desired output block.
+    :param key_path: Path of keys to config block to use.
     :return: The unrealized data to output and the output format name.
     """
     output_format = _ensure_format("output", output_format, output_file)
@@ -344,7 +344,7 @@ Recognized file extensions are: {extensions}
 :param update_format: Format of the update config.
 :param output_file: Output config destination (None => write to ``stdout``).
 :param output_format: Format of the output config.
-:param key_path: Path through keys to the desired output block.
+:param key_path: Path of keys to the desired output block.
 :param values_needed: Report complete, missing, and template values.
 :param total: Require rendering of all Jinja2 variables/expressions.
 :param dry_run: Log output instead of writing to output.

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -18,6 +18,7 @@ from iotaa import asset, dryrun, external, task, tasks
 
 from uwtools.config.formats.base import Config
 from uwtools.config.formats.yaml import YAMLConfig
+from uwtools.config.support import YAMLKey
 from uwtools.config.tools import walk_key_path
 from uwtools.config.validator import (
     bundle,
@@ -47,9 +48,9 @@ class Assets(ABC):
         leadtime: Optional[timedelta] = None,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ) -> None:
         config_input = config if isinstance(config, YAMLConfig) else YAMLConfig(config=config)
         config_input.dereference(
@@ -166,7 +167,7 @@ class Assets(ABC):
         else:
             log.debug(f"Failed to validate {path}")
 
-    def _delegate(self, controller: Optional[list[str]], config_key: str) -> None:
+    def _delegate(self, controller: Optional[list[YAMLKey]], config_key: str) -> None:
         """
         Selectively delegate config to controller.
 
@@ -189,7 +190,7 @@ class Assets(ABC):
         """
 
     def namelist_schema(
-        self, config_keys: Optional[list[str]] = None, schema_keys: Optional[list[str]] = None
+        self, config_keys: Optional[list[YAMLKey]] = None, schema_keys: Optional[list[str]] = None
     ) -> dict:
         """
         Return the (sub)schema for validating the driver's namelist content.
@@ -251,9 +252,9 @@ class AssetsCycleBased(Assets):
         cycle: datetime,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -284,9 +285,9 @@ class AssetsCycleLeadtimeBased(Assets):
         leadtime: timedelta,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -324,9 +325,9 @@ class AssetsTimeInvariant(Assets):
         self,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ):
         super().__init__(
             config=config,
@@ -348,10 +349,10 @@ class Driver(Assets):
         leadtime: Optional[timedelta] = None,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -570,10 +571,10 @@ class DriverCycleBased(Driver):
         cycle: datetime,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -605,10 +606,10 @@ class DriverCycleLeadtimeBased(Driver):
         leadtime: timedelta,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ):
         super().__init__(
             cycle=cycle,
@@ -647,10 +648,10 @@ class DriverTimeInvariant(Driver):
         self,
         config: Optional[Union[dict, str, YAMLConfig, Path]] = None,
         dry_run: bool = False,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         batch: bool = False,
         schema_file: Optional[Path] = None,
-        controller: Optional[list[str]] = None,
+        controller: Optional[list[YAMLKey]] = None,
     ):
         super().__init__(
             config=config,

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -679,7 +679,7 @@ def _add_docstring(class_: type, omit: Optional[list[str]] = None) -> None:
     :param leadtime: The leadtime.
     :param config: Path to config file (read stdin if missing or None).
     :param dry_run: Run in dry-run mode?
-    :param key_path: Keys leading through the config to the driver's configuration block.
+    :param key_path: Keys of keys to driver config block.
     :param batch: Run component via the batch system?
     :param schema_file: Path to schema file to use to validate an external driver.
     :param controller: Key(s) leading to block in config controlling run-time values.

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -13,7 +13,6 @@ from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.tools import walk_key_path
 from uwtools.config.validator import validate_internal
 from uwtools.exceptions import UWConfigError
-from uwtools.logging import log
 from uwtools.strings import STR
 from uwtools.utils.api import str2path
 from uwtools.utils.tasks import directory, filecopy, symlink
@@ -55,8 +54,7 @@ class Stager(ABC):
                 **yaml_config.data,
             }
         )
-        self._config = walk_key_path(yaml_config.data, self._key_path)
-        self._set_config_block()
+        self._config, _ = walk_key_path(yaml_config.data, self._key_path)
         self._validate()
         self._check_paths()
 
@@ -106,7 +104,7 @@ class FileStager(Stager):
         """
         The paths to files to create.
         """
-        return list(self._config.key_path())
+        return list(self._config.keys())
 
     @property
     def _schema(self) -> str:

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -10,13 +10,13 @@ from typing import Optional, Union
 from iotaa import dryrun, tasks
 
 from uwtools.config.formats.yaml import YAMLConfig
+from uwtools.config.tools import walk_key_path
 from uwtools.config.validator import validate_internal
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.strings import STR
 from uwtools.utils.api import str2path
 from uwtools.utils.tasks import directory, filecopy, symlink
-from uwtools.config.tools import walk_key_path
 
 
 class Stager(ABC):

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -44,7 +44,6 @@ class Stager(ABC):
         :raises: ``UWConfigError`` if config fails validation.
         """
         dryrun(enable=dry_run)
-        self._key_path = key_path or []
         self._target_dir = str2path(target_dir)
         yaml_config = YAMLConfig(config=str2path(config))
         yaml_config.dereference(
@@ -54,7 +53,7 @@ class Stager(ABC):
                 **yaml_config.data,
             }
         )
-        self._config, _ = walk_key_path(yaml_config.data, self._key_path)
+        self._config, _ = walk_key_path(yaml_config.data, key_path or [])
         self._validate()
         self._check_paths()
 

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -10,6 +10,7 @@ from typing import Optional, Union
 from iotaa import dryrun, tasks
 
 from uwtools.config.formats.yaml import YAMLConfig
+from uwtools.config.support import YAMLKey
 from uwtools.config.tools import walk_key_path
 from uwtools.config.validator import validate_internal
 from uwtools.exceptions import UWConfigError
@@ -29,7 +30,7 @@ class Stager(ABC):
         target_dir: Optional[Union[str, Path]] = None,
         cycle: Optional[dt.datetime] = None,
         leadtime: Optional[dt.timedelta] = None,
-        key_path: Optional[list[Union[str, int]]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         dry_run: bool = False,
     ) -> None:
         """

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -96,7 +96,6 @@ class STR:
     ioda: str = "ioda"
     jedi: str = "jedi"
     keypath: str = "key_path"
-    keys: str = "keys"
     keyvalpairs: str = "key_eq_val_pairs"
     leadtime: str = "leadtime"
     link: str = "link"

--- a/src/uwtools/tests/api/test_fs.py
+++ b/src/uwtools/tests/api/test_fs.py
@@ -21,7 +21,7 @@ def kwargs(tmp_path):
         "config": config,
         "cycle": dt.datetime.now(),
         "leadtime": dt.timedelta(hours=6),
-        "keys": ["a", "b"],
+        "key_path": ["a", "b"],
         "dry_run": False,
     }
 

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -666,65 +666,6 @@ def test__ensure_format_explicitly_specified_with_path():
     )
 
 
-def test__print_config_section_ini(capsys):
-    config_obj = INIConfig(fixture_path("simple3.ini"))
-    section = ["dessert"]
-    tools._print_config_section(config_obj.data, section)
-    actual = capsys.readouterr().out
-    expected = """
-    flavor={{ flavor }}
-    servings=0
-    side=False
-    type=pie
-    """
-    assert actual.strip() == dedent(expected).strip()
-
-
-def test__print_config_section_ini_missing_section():
-    config_obj = INIConfig(fixture_path("simple3.ini"))
-    section = ["sandwich"]
-    msg = "Bad config path: sandwich"
-    with raises(UWConfigError) as e:
-        tools._print_config_section(config_obj.data, section)
-    assert msg in str(e.value)
-
-
-def test__print_config_section_yaml(capsys):
-    config_obj = YAMLConfig(fixture_path("FV3_GFS_v16.yaml"))
-    section = ["sgs_tke", "profile_type"]
-    tools._print_config_section(config_obj.data, section)
-    actual = capsys.readouterr().out
-    expected = """
-    name=fixed
-    surface_value=0.0
-    """
-    assert actual.strip() == dedent(expected).strip()
-
-
-def test__print_config_section_yaml_for_nonscalar():
-    config_obj = YAMLConfig(fixture_path("FV3_GFS_v16.yaml"))
-    section = ["o3mr"]
-    with raises(UWConfigError) as e:
-        tools._print_config_section(config_obj.data, section)
-    assert "Non-scalar value" in str(e.value)
-
-
-def test__print_config_section_yaml_list():
-    config_obj = YAMLConfig(fixture_path("srw_example.yaml"))
-    section = ["FV3GFS", "nomads", "file_names", "grib2", "anl"]
-    with raises(UWConfigError) as e:
-        tools._print_config_section(config_obj.data, section)
-    assert "must be a dictionary" in str(e.value)
-
-
-def test__print_config_section_yaml_not_dict():
-    config_obj = YAMLConfig(fixture_path("FV3_GFS_v16.yaml"))
-    section = ["sgs_tke", "units"]
-    with raises(UWConfigError) as e:
-        tools._print_config_section(config_obj.data, section)
-    assert "must be a dictionary" in str(e.value)
-
-
 def test__realize_config_input_setup_ini_cfgobj():
     data = {"section": {"foo": "bar"}}
     cfgobj = INIConfig(config=data)

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -59,7 +59,7 @@ def args_dispatch_fs():
         "config_file": "/config/file",
         "cycle": dt.datetime.now(),
         "leadtime": dt.timedelta(hours=6),
-        "keys": ["a", "b"],
+        "key_path": ["a", "b"],
         "dry_run": False,
         "stdin_ok": True,
     }
@@ -401,7 +401,7 @@ def test__dispatch_fs_action(action, args_dispatch_fs):
         config=args["config_file"],
         cycle=args["cycle"],
         leadtime=args["leadtime"],
-        keys=args["keys"],
+        key_path=args["key_path"],
         dry_run=args["dry_run"],
         stdin_ok=args["stdin_ok"],
     )

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -54,7 +54,7 @@ def test_Copier(assets, source):
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    fs.Copier(target_dir=dstdir, config=config, keys=["a", "b"]).go()
+    fs.Copier(target_dir=dstdir, config=config, key_path=["a", "b"]).go()
     assert (dstdir / "foo").is_file()
     assert (dstdir / "subdir" / "bar").is_file()
 
@@ -63,7 +63,7 @@ def test_Copier_config_file_dry_run(assets):
     dstdir, cfgdict, _ = assets
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    fs.Copier(target_dir=dstdir, config=cfgdict, keys=["a", "b"], dry_run=True).go()
+    fs.Copier(target_dir=dstdir, config=cfgdict, key_path=["a", "b"], dry_run=True).go()
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
     iotaa.dryrun(False)
@@ -80,7 +80,7 @@ def test_Copier_no_targetdir_abspath_pass(assets):
 def test_Copier_no_targetdir_relpath_fail(assets):
     _, cfgdict, _ = assets
     with raises(UWConfigError) as e:
-        fs.Copier(config=cfgdict, keys=["a", "b"]).go()
+        fs.Copier(config=cfgdict, key_path=["a", "b"]).go()
     errmsg = "Relative path '%s' requires the target directory to be specified"
     assert errmsg % "foo" in str(e.value)
 
@@ -89,7 +89,7 @@ def test_Copier_no_targetdir_relpath_fail(assets):
 def test_FilerStager(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
-    assert fs.FileStager(target_dir=dstdir, config=config, keys=["a", "b"])
+    assert fs.FileStager(target_dir=dstdir, config=config, key_path=["a", "b"])
 
 
 @mark.parametrize("source", ("dict", "file"))
@@ -98,7 +98,7 @@ def test_Linker(assets, source):
     config = cfgdict if source == "dict" else cfgfile
     assert not (dstdir / "foo").exists()
     assert not (dstdir / "subdir" / "bar").exists()
-    fs.Linker(target_dir=dstdir, config=config, keys=["a", "b"]).go()
+    fs.Linker(target_dir=dstdir, config=config, key_path=["a", "b"]).go()
     assert (dstdir / "foo").is_symlink()
     assert (dstdir / "subdir" / "bar").is_symlink()
 
@@ -108,7 +108,7 @@ def test_Stager__config_block_fail_bad_key_path(assets, source):
     dstdir, cfgdict, cfgfile = assets
     config = cfgdict if source == "dict" else cfgfile
     with raises(UWConfigError) as e:
-        ConcreteStager(target_dir=dstdir, config=config, keys=["a", "x"])
+        ConcreteStager(target_dir=dstdir, config=config, key_path=["a", "x"])
     assert str(e.value) == "Failed following YAML key(s): a.x"
 
 
@@ -117,5 +117,5 @@ def test_Stager__config_block_fails_bad_type(assets, val):
     dstdir, cfgdict, _ = assets
     cfgdict["a"]["b"] = val
     with raises(UWConfigError) as e:
-        ConcreteStager(target_dir=dstdir, config=cfgdict, keys=["a", "b"])
+        ConcreteStager(target_dir=dstdir, config=cfgdict, key_path=["a", "b"])
     assert str(e.value) == "Expected block not found at key path: a.b"

--- a/src/uwtools/tests/test_fs.py
+++ b/src/uwtools/tests/test_fs.py
@@ -109,7 +109,7 @@ def test_Stager__config_block_fail_bad_key_path(assets, source):
     config = cfgdict if source == "dict" else cfgfile
     with raises(UWConfigError) as e:
         ConcreteStager(target_dir=dstdir, config=config, key_path=["a", "x"])
-    assert str(e.value) == "Failed following YAML key(s): a.x"
+    assert str(e.value) == "Bad config path: a.x"
 
 
 @mark.parametrize("val", [None, True, False, "str", 42, 3.14, [], tuple()])
@@ -118,4 +118,4 @@ def test_Stager__config_block_fails_bad_type(assets, val):
     cfgdict["a"]["b"] = val
     with raises(UWConfigError) as e:
         ConcreteStager(target_dir=dstdir, config=cfgdict, key_path=["a", "b"])
-    assert str(e.value) == "Expected block not found at key path: a.b"
+    assert str(e.value) == "Value at a.b must be a dictionary"

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -169,7 +169,7 @@ def _execute(
     :param batch: Submit run to the batch system?
     :param dry_run: Do not run the executable, just report what would have been done.
     :param graph_file: Write Graphviz DOT output here.
-    :param key_path: Path of keys to subsection of config file.
+    :param key_path: Path of keys to config block to use.
     :param schema_file: The JSON Schema file to use for validation.
     :param stdin_ok: OK to read from stdin?
     :return: ``True`` if task completes without raising an exception.

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -8,6 +8,7 @@ from inspect import getfullargspec
 from pathlib import Path
 from typing import Callable, Optional, TypeVar, Union
 
+from uwtools.config.support import YAMLKey
 from uwtools.drivers.driver import DriverT
 from uwtools.drivers.support import graph
 from uwtools.exceptions import UWError
@@ -51,7 +52,7 @@ def make_execute(
         batch: bool = False,
         dry_run: bool = False,
         graph_file: Optional[Union[Path, str]] = None,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         schema_file: Optional[Union[Path, str]] = None,
         stdin_ok: bool = False,
     ) -> bool:
@@ -76,7 +77,7 @@ def make_execute(
         batch: bool = False,
         dry_run: bool = False,
         graph_file: Optional[Union[Path, str]] = None,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         schema_file: Optional[Union[Path, str]] = None,
         stdin_ok: bool = False,
     ) -> bool:
@@ -102,7 +103,7 @@ def make_execute(
         batch: bool = False,
         dry_run: bool = False,
         graph_file: Optional[Union[Path, str]] = None,
-        key_path: Optional[list[str]] = None,
+        key_path: Optional[list[YAMLKey]] = None,
         schema_file: Optional[Union[Path, str]] = None,
         stdin_ok: bool = False,
     ) -> bool:
@@ -151,7 +152,7 @@ def _execute(
     batch: bool = False,  # pylint: disable=unused-argument
     dry_run: bool = False,
     graph_file: Optional[Union[Path, str]] = None,
-    key_path: Optional[list[str]] = None,
+    key_path: Optional[list[YAMLKey]] = None,
     schema_file: Optional[Union[Path, str]] = None,
     stdin_ok: bool = False,
 ) -> bool:


### PR DESCRIPTION
**Synopsis**

Fixes #668.

- In `fs` mode/actions, replace position key-path arguments on CLI with an explicit `--key-path` argument, consistent with other modes.
- Updated typing to accept YAML immutable types -- `bool`, `float`, `int`, `str` -- as key-path values, to support a wider variety of user configs.
- Updated docs to exercise `--key-path` CLI argument.
- Updated `fs` notebook to exercise `key_path` API argument.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
