### PR TITLE
Render fix

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -216,9 +216,9 @@ class Config(ABC, UserDict):
         """
 
         def logstate(state: str) -> None:
-            log.debug("Dereferencing, %s value:", state)
+            jinja2.deref_debug("Dereferencing, %s value:" % state)
             for line in yaml_to_str(self.data).split("\n"):
-                log.debug("%s%s", INDENT, line)
+                jinja2.deref_debug("%s%s" % (INDENT, line))
 
         while True:
             logstate("current")

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -339,6 +339,14 @@ def test__deref_render_ok(caplog, deref_render_assets):
     assert not regex_logged(caplog, "Rendering failed")
 
 
+def test__deref_render_unloadable_val(caplog):
+    log.setLevel(logging.DEBUG)
+    val = "&PARTITION_DEFAULT;"
+    assert jinja2._deref_render(val='{{ "%s" if True }}' % val, context={}) == val
+    assert regex_logged(caplog, "Rendered")
+    assert not regex_logged(caplog, "Rendering failed")
+
+
 def test__dry_run_template(caplog):
     log.setLevel(logging.DEBUG)
     jinja2._dry_run_template("roses are red\nviolets are blue")

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -341,7 +341,7 @@ def test__deref_render_ok(caplog, deref_render_assets):
 
 def test__deref_render_unloadable_val(caplog):
     log.setLevel(logging.DEBUG)
-    val = "&PARTITION_DEFAULT;"
+    val = "&XMLENTITY;"
     assert jinja2._deref_render(val='{{ "%s" if True }}' % val, context={}) == val
     assert regex_logged(caplog, "Rendered")
     assert not regex_logged(caplog, "Rendering failed")

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -167,6 +167,12 @@ def test_dereference_str_variable_rendered_str():
     assert jinja2.dereference(val=val, context={"greeting": "hello"}) == "hello"
 
 
+def test_deref_debug(caplog):
+    log.setLevel(logging.DEBUG)
+    jinja2.deref_debug(action="Frobnicated", val="foo")
+    assert logged(caplog, "[dereference] Frobnicated: foo")
+
+
 def test_register_filters_env():
     s = "hello {{ 'RECIPIENT' | env }}"
     template = jinja2._register_filters(Environment(undefined=DebugUndefined)).from_string(s)
@@ -309,20 +315,16 @@ def test__deref_convert_ok(caplog, converted, tag, value):
     assert not regex_logged(caplog, "Conversion failed")
 
 
-def test__deref_debug(caplog):
-    log.setLevel(logging.DEBUG)
-    jinja2._deref_debug(action="Frobnicated", val="foo")
-    assert logged(caplog, "[dereference] Frobnicated: foo")
-
-
 def test__deref_render_held(caplog):
+    log.setLevel(logging.DEBUG)
     val, context = "!int '{{ a }}'", yaml.load("a: !int '{{ 42 }}'", Loader=uw_yaml_loader())
     assert jinja2._deref_render(val=val, context=context) == val
-    assert not regex_logged(caplog, "Rendered")
+    assert regex_logged(caplog, "Rendered")
     assert regex_logged(caplog, "Held")
 
 
 def test__deref_render_no(caplog, deref_render_assets):
+    log.setLevel(logging.DEBUG)
     val, context, _ = deref_render_assets
     assert jinja2._deref_render(val=val, context=context) == val
     assert not regex_logged(caplog, "Rendered")
@@ -330,6 +332,7 @@ def test__deref_render_no(caplog, deref_render_assets):
 
 
 def test__deref_render_ok(caplog, deref_render_assets):
+    log.setLevel(logging.DEBUG)
     val, context, local = deref_render_assets
     assert jinja2._deref_render(val=val, context=context, local=local) == "hello world"
     assert regex_logged(caplog, "Rendered")
@@ -337,12 +340,14 @@ def test__deref_render_ok(caplog, deref_render_assets):
 
 
 def test__dry_run_template(caplog):
+    log.setLevel(logging.DEBUG)
     jinja2._dry_run_template("roses are red\nviolets are blue")
     assert logged(caplog, "roses are red")
     assert logged(caplog, "violets are blue")
 
 
 def test__log_missing_values(caplog):
+    log.setLevel(logging.DEBUG)
     missing = ["roses_color", "violets_color"]
     jinja2._log_missing_values(missing)
     assert logged(caplog, "Value(s) required to render template not provided:")


### PR DESCRIPTION
**Synopsis**

Fixes a bug whereby a value like `&XMLENTITY;` that cannot be parsed as YAML on its own would lead to a dereferencing failure. See the new unit test for an example.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
