### PR TITLE
Refresh Anaconda badges on GitHub page

### DIFF
--- a/.github/scripts/install-conda.sh
+++ b/.github/scripts/install-conda.sh
@@ -6,4 +6,4 @@ wget --no-verbose -O $installer $url
 bash $installer -bfp $CI_CONDA_DIR
 set +ux
 ci_conda_activate
-conda install --quiet --yes --channel maddenp --repodata-fn repodata.json anaconda-client condev
+conda install --quiet --yes --channel maddenp --repodata-fn repodata.json anaconda-client condev jq

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -7,3 +7,11 @@ glob="$(jq -r .name $f)-$(jq -r .version $f)-*_$(jq -r .buildnum $f).tar.bz2"
 for x in $(find $CI_CONDA_DIR/conda-bld -type f -name "$glob"); do
   anaconda -t $ANACONDA_TOKEN upload $x
 done
+# Refresh Anaconda badges on GitHub.
+ids=(
+  6c9ed105fbe1d674e82460d5e7fa6c7eb8e2eb6eb3640c763a8189f407e2a9a2/68747470733a2f2f616e61636f6e64612e6f72672f7566732d636f6d6d756e6974792f7577746f6f6c732f6261646765732f76657273696f6e2e737667
+  a6f1f3ab481647dc492ab577cb7e60522efded549caf0544ba863d0a72958179/68747470733a2f2f616e61636f6e64612e6f72672f7566732d636f6d6d756e6974792f7577746f6f6c732f6261646765732f6c61746573745f72656c656173655f646174652e737667
+)
+for id in ${ids[*]}; do
+  curl -X PURGE https://camo.githubusercontent.com/$id | jq .
+done

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -13,5 +13,5 @@ ids=(
   a6f1f3ab481647dc492ab577cb7e60522efded549caf0544ba863d0a72958179/68747470733a2f2f616e61636f6e64612e6f72672f7566732d636f6d6d756e6974792f7577746f6f6c732f6261646765732f6c61746573745f72656c656173655f646174652e737667
 )
 for id in ${ids[*]}; do
-  curl -X PURGE https://camo.githubusercontent.com/$id | jq .
+  curl -s -X PURGE https://camo.githubusercontent.com/$id | jq .
 done


### PR DESCRIPTION
**Synopsis**

GitHub caches the conda-package version number and last-updated badges for quite some time. Add code to the release workflow to refresh these after new packages are uploaded.

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
