### PR TITLE
Add public config_file attribute to Config classes

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -4,6 +4,6 @@ CI_CONDA_DIR=/tmp/conda
 CI_CONDA_SH=$CI_CONDA_DIR/etc/profile.d/conda.sh
 
 ci_conda_activate() {
-  source $CI_CONDA_SH
+  . $CI_CONDA_SH
   conda activate
 }

--- a/.github/scripts/format-check.sh
+++ b/.github/scripts/format-check.sh
@@ -11,6 +11,6 @@ unformatted() {
   return 0
 }
 
-source $(dirname ${BASH_SOURCE[0]})/common.sh
+. $(dirname ${BASH_SOURCE[0]})/common.sh
 ci_conda_activate
 CONDEV_SHELL_CMD=unformatted condev-shell

--- a/.github/scripts/install-conda.sh
+++ b/.github/scripts/install-conda.sh
@@ -1,5 +1,5 @@
 set -eux
-source $(dirname ${BASH_SOURCE[0]})/common.sh
+. $(dirname ${BASH_SOURCE[0]})/common.sh
 url=https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Miniforge3-Linux-x86_64.sh
 installer=/tmp/$(basename $url)
 wget --no-verbose -O $installer $url

--- a/.github/scripts/make-docs.sh
+++ b/.github/scripts/make-docs.sh
@@ -1,6 +1,6 @@
 set -ae
-source $(dirname ${BASH_SOURCE[0]})/common.sh
+. $(dirname ${BASH_SOURCE[0]})/common.sh
 ci_conda_activate
 cd docs
-source install-deps
+. install-deps
 make docs

--- a/.github/scripts/make-package.sh
+++ b/.github/scripts/make-package.sh
@@ -1,5 +1,5 @@
 set -ae
-source $(dirname ${BASH_SOURCE[0]})/common.sh
+. $(dirname ${BASH_SOURCE[0]})/common.sh
 ci_conda_activate
 set -x
 make package

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,5 +1,5 @@
 set -ae
-source $(dirname ${BASH_SOURCE[0]})/common.sh
+. $(dirname ${BASH_SOURCE[0]})/common.sh
 ci_conda_activate
 set -ux
 f=recipe/meta.json

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -20,7 +20,7 @@ run_tests() {
   return $status
 }
 
-source $(dirname ${BASH_SOURCE[0]})/common.sh
+. $(dirname ${BASH_SOURCE[0]})/common.sh
 ci_conda_activate
 for version in ${SUPPORTED_PYTHON_VERSIONS[*]}; do
   PYTHON_VERSION=$version

--- a/docs/deps
+++ b/docs/deps
@@ -14,5 +14,5 @@ for dep in deps:
     pkg, ver = m.groups()
     if re.match(r"^\d", ver):
         ver = f"={ver}"
-    specs.append(f"'{pkg}{ver}'")
+    specs.append(f"{pkg}{ver}")
 print(" ".join(sorted(specs)))

--- a/format
+++ b/format
@@ -10,6 +10,6 @@ echo "=> Running docformatter"
 (cd src && docformatter . || test $? -eq 3)
 
 echo "=> Running jq"
-for a in $(find src -type f -name "*.jsonschema"); do
+for a in $(find src -not -path "*/.*" -type f -name "*.json*"); do
   b=$(jq -S . $a) && echo "$b" >$a || (echo "    in $a"; false)
 done

--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -1,6 +1,6 @@
 {
   "build": "py_0",
-  "buildnum": "0",
+  "buildnum": 0,
   "name": "uwtools",
   "packages": {
     "dev": [

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -210,6 +210,13 @@ class Config(ABC, UserDict):
             log.info(diffline.rstrip())
         return False
 
+    @property
+    def config_file(self) -> Optional[Path]:
+        """
+        Return the path to the config file from which this object was instantiated, if applicable.
+        """
+        return self._config_file
+
     def dereference(self, context: Optional[dict] = None) -> None:
         """
         Render as much Jinja2 syntax as possible.

--- a/src/uwtools/resources/info.json
+++ b/src/uwtools/resources/info.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.5.0",
-  "buildnum": "0"
+  "buildnum": "0",
+  "version": "2.5.0"
 }

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -194,6 +194,11 @@ def test_compare_config_ini(caplog, salad_base):
         assert not logged(caplog, line)
 
 
+def test_config_file(config):
+    assert config.config_file.name == "config.yaml"
+    assert config.config_file.is_file()
+
+
 def test_dereference(tmp_path):
     # Test demonstrates that:
     #   - Config dereferencing ignores environment variables.


### PR DESCRIPTION
**Synopsis**

During some design discussion today with @uturuncoglu, we considered a kind of hybrid readiness criterion for `uwtools` driver tasks that would specify both that 1. The expected output file exists, and 2. It is newer than the driver's config file. This would permit definition of assets that mimic the behavior of `make`, where action is taken either if the output does not exist, *or* if it is older than the source file. This way, task designers could choose to have drivers update output files if the config file has been changed. (More nuanced criteria would be possible, too, like checking if a specific _section_ of the config had changed, but that would take more work.)

This PR simply exposes a read-only `config_file` attribute on `Config` objects, wrapping the private `_config_file` attribute. Driver could use the path named by this attribute to get a timestamp on the config file to compare to output files. `Config` objects not instantiated from files (e.g. from `dict` objects) will return `None`.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
