### PR TITLE
Change wording about schema-validation errors

### DIFF
--- a/docs/sections/user_guide/cli/tools/config/validate-fail.out
+++ b/docs/sections/user_guide/cli/tools/config/validate-fail.out
@@ -1,3 +1,3 @@
-[2024-08-26T22:54:28]    ERROR 1 UW schema-validation error found in config
+[2024-08-26T22:54:28]    ERROR 1 schema-validation error found in config
 [2024-08-26T22:54:28]    ERROR Error at values:
 [2024-08-26T22:54:28]    ERROR   'recipient' is a required property

--- a/docs/sections/user_guide/cli/tools/config/validate-pass-stdin.out
+++ b/docs/sections/user_guide/cli/tools/config/validate-pass-stdin.out
@@ -1,1 +1,1 @@
-[2024-08-26T22:54:27]     INFO 0 UW schema-validation errors found in config
+[2024-08-26T22:54:27]     INFO 0 schema-validation errors found in config

--- a/docs/sections/user_guide/cli/tools/config/validate-pass.out
+++ b/docs/sections/user_guide/cli/tools/config/validate-pass.out
@@ -1,1 +1,1 @@
-[2024-08-26T22:54:28]     INFO 0 UW schema-validation errors found in config
+[2024-08-26T22:54:28]     INFO 0 schema-validation errors found in config

--- a/docs/sections/user_guide/cli/tools/config/validate-verbose.out
+++ b/docs/sections/user_guide/cli/tools/config/validate-verbose.out
@@ -18,4 +18,4 @@
 [2024-11-27T05:24:34]    DEBUG   values:
 [2024-11-27T05:24:34]    DEBUG     greeting: Hello
 [2024-11-27T05:24:34]    DEBUG     recipient: World
-[2024-11-27T05:24:34]     INFO 0 UW schema-validation errors found in config
+[2024-11-27T05:24:34]     INFO 0 schema-validation errors found in config

--- a/docs/sections/user_guide/cli/tools/execute/alt-schema.out
+++ b/docs/sections/user_guide/cli/tools/execute/alt-schema.out
@@ -1,4 +1,4 @@
-[2024-08-26T23:03:41]     INFO 0 UW schema-validation errors found in rand config
+[2024-08-26T23:03:41]     INFO 0 schema-validation errors found in rand config
 [2024-08-26T23:03:41]     INFO rand Random-integer file: Initial state: Not Ready
 [2024-08-26T23:03:41]     INFO rand Random-integer file: Checking requirements
 [2024-08-26T23:03:41]     INFO rand Random-integer file: Requirement(s) ready

--- a/docs/sections/user_guide/cli/tools/execute/execute.out
+++ b/docs/sections/user_guide/cli/tools/execute/execute.out
@@ -1,4 +1,4 @@
-[2024-08-26T23:03:40]     INFO 0 UW schema-validation errors found in rand config
+[2024-08-26T23:03:40]     INFO 0 schema-validation errors found in rand config
 [2024-08-26T23:03:40]     INFO rand Random-integer file: Initial state: Not Ready
 [2024-08-26T23:03:40]     INFO rand Random-integer file: Checking requirements
 [2024-08-26T23:03:40]     INFO rand Random-integer file: Requirement(s) ready

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec-no-target-dir-err.out
@@ -1,3 +1,3 @@
 [2024-12-07T01:01:51]     INFO Validating config against internal schema: files-to-stage
-[2024-12-07T01:01:53]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:53]     INFO 0 schema-validation errors found in fs config
 [2024-12-07T01:01:53]    ERROR Relative path 'foo' requires target directory to be specified

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec-timedep.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec-timedep.out
@@ -1,5 +1,5 @@
 [2024-08-26T23:03:42]     INFO Validating config against internal schema: files-to-stage
-[2024-08-26T23:03:43]     INFO 0 UW schema-validation errors found in fs config
+[2024-08-26T23:03:43]     INFO 0 schema-validation errors found in fs config
 [2024-08-26T23:03:43]     INFO File copies: Initial state: Not Ready
 [2024-08-26T23:03:43]     INFO File copies: Checking requirements
 [2024-08-26T23:03:43]     INFO Copy src/20240529/12/006/baz -> copy-dst-timedep/baz-2024-05-29T18: Initial state: Not Ready

--- a/docs/sections/user_guide/cli/tools/fs/copy-exec.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-exec.out
@@ -1,5 +1,5 @@
 [2024-12-07T01:01:56]     INFO Validating config against internal schema: files-to-stage
-[2024-12-07T01:01:56]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:56]     INFO 0 schema-validation errors found in fs config
 [2024-12-07T01:01:56]     INFO File copies: Initial state: Not Ready
 [2024-12-07T01:01:56]     INFO File copies: Checking requirements
 [2024-12-07T01:01:56]     INFO Copy src/foo -> copy-dst/foo: Initial state: Not Ready

--- a/docs/sections/user_guide/cli/tools/fs/link-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/fs/link-exec-no-target-dir-err.out
@@ -1,3 +1,3 @@
 [2024-12-07T01:01:55]     INFO Validating config against internal schema: files-to-stage
-[2024-12-07T01:01:55]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:55]     INFO 0 schema-validation errors found in fs config
 [2024-12-07T01:01:55]    ERROR Relative path 'foo' requires target directory to be specified

--- a/docs/sections/user_guide/cli/tools/fs/link-exec-timedep.out
+++ b/docs/sections/user_guide/cli/tools/fs/link-exec-timedep.out
@@ -1,5 +1,5 @@
 [2024-08-26T23:03:41]     INFO Validating config against internal schema: files-to-stage
-[2024-08-26T23:03:41]     INFO 0 UW schema-validation errors found in fs config
+[2024-08-26T23:03:41]     INFO 0 schema-validation errors found in fs config
 [2024-08-26T23:03:41]     INFO File links: Initial state: Not Ready
 [2024-08-26T23:03:41]     INFO File links: Checking requirements
 [2024-08-26T23:03:41]     INFO Link link-dst-timedep/baz-2024-05-29T18 -> src/20240529/12/006/baz: Initial state: Not Ready

--- a/docs/sections/user_guide/cli/tools/fs/link-exec.out
+++ b/docs/sections/user_guide/cli/tools/fs/link-exec.out
@@ -1,5 +1,5 @@
 [2024-08-26T23:03:42]     INFO Validating config against internal schema: files-to-stage
-[2024-08-26T23:03:43]     INFO 0 UW schema-validation errors found in fs config
+[2024-08-26T23:03:43]     INFO 0 schema-validation errors found in fs config
 [2024-08-26T23:03:43]     INFO File links: Initial state: Not Ready
 [2024-08-26T23:03:43]     INFO File links: Checking requirements
 [2024-08-26T23:03:43]     INFO Link link-dst/foo -> src/foo: Initial state: Not Ready

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-exec-no-target-dir-err.out
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-exec-no-target-dir-err.out
@@ -1,3 +1,3 @@
 [2024-12-07T01:01:55]     INFO Validating config against internal schema: makedirs
-[2024-12-07T01:01:55]     INFO 0 UW schema-validation errors found in fs config
+[2024-12-07T01:01:55]     INFO 0 schema-validation errors found in fs config
 [2024-12-07T01:01:55]    ERROR Relative path 'foo' requires target directory to be specified

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-exec-timedep.out
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-exec-timedep.out
@@ -1,5 +1,5 @@
 [2024-08-26T23:03:46]     INFO Validating config against internal schema: makedirs
-[2024-08-26T23:03:46]     INFO 0 UW schema-validation errors found in fs config
+[2024-08-26T23:03:46]     INFO 0 schema-validation errors found in fs config
 [2024-08-26T23:03:46]     INFO Directories: Initial state: Not Ready
 [2024-08-26T23:03:46]     INFO Directories: Checking requirements
 [2024-08-26T23:03:46]     INFO Directory makedirs-parent-timedep/foo/20240529/12/006/bar: Initial state: Not Ready

--- a/docs/sections/user_guide/cli/tools/fs/makedirs-exec.out
+++ b/docs/sections/user_guide/cli/tools/fs/makedirs-exec.out
@@ -1,5 +1,5 @@
 [2024-08-26T23:03:46]     INFO Validating config against internal schema: makedirs
-[2024-08-26T23:03:46]     INFO 0 UW schema-validation errors found in fs config
+[2024-08-26T23:03:46]     INFO 0 schema-validation errors found in fs config
 [2024-08-26T23:03:46]     INFO Directories: Initial state: Not Ready
 [2024-08-26T23:03:46]     INFO Directories: Checking requirements
 [2024-08-26T23:03:46]     INFO Directory makedirs-parent/foo: Initial state: Not Ready

--- a/docs/sections/user_guide/cli/tools/rocoto/realize-exec-file.out
+++ b/docs/sections/user_guide/cli/tools/rocoto/realize-exec-file.out
@@ -1,4 +1,4 @@
-[2024-08-26T23:11:41]     INFO 0 UW schema-validation errors found in Rocoto config
+[2024-08-26T23:11:41]     INFO 0 schema-validation errors found in Rocoto config
 [2024-08-26T23:11:41]     INFO 0 Rocoto XML validation errors found
 
 <?xml version='1.0' encoding='utf-8'?>

--- a/docs/sections/user_guide/cli/tools/rocoto/realize-exec-stdin-stdout.out
+++ b/docs/sections/user_guide/cli/tools/rocoto/realize-exec-stdin-stdout.out
@@ -1,4 +1,4 @@
-[2024-08-26T23:11:42]     INFO 0 UW schema-validation errors found in Rocoto config
+[2024-08-26T23:11:42]     INFO 0 schema-validation errors found in Rocoto config
 [2024-08-26T23:11:42]     INFO 0 Rocoto XML validation errors found
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE workflow [

--- a/docs/sections/user_guide/cli/tools/rocoto/realize-exec-stdout.out
+++ b/docs/sections/user_guide/cli/tools/rocoto/realize-exec-stdout.out
@@ -1,4 +1,4 @@
-[2024-08-26T23:11:42]     INFO 0 UW schema-validation errors found in Rocoto config
+[2024-08-26T23:11:42]     INFO 0 schema-validation errors found in Rocoto config
 [2024-08-26T23:11:42]     INFO 0 Rocoto XML validation errors found
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE workflow [

--- a/notebooks/config.ipynb
+++ b/notebooks/config.ipynb
@@ -1336,7 +1336,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:12:53]     INFO 0 UW schema-validation errors found in config\n"
+      "[2024-11-19T23:12:53]     INFO 0 schema-validation errors found in config\n"
      ]
     },
     {
@@ -1376,7 +1376,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:12:53]    ERROR 1 UW schema-validation error found in config\n",
+      "[2024-11-19T23:12:53]    ERROR 1 schema-validation error found in config\n",
       "[2024-11-19T23:12:53]    ERROR Error at recipient:\n",
       "[2024-11-19T23:12:53]    ERROR   47 is not of type 'string'\n"
      ]

--- a/notebooks/exp-config-cb.ipynb
+++ b/notebooks/exp-config-cb.ipynb
@@ -351,9 +351,9 @@
      "output_type": "stream",
      "text": [
       "[2024-11-19T23:14:15]     INFO Validating config against internal schema: chgres-cube\n",
-      "[2024-11-19T23:14:15]     INFO 0 UW schema-validation errors found in chgres_cube config\n",
+      "[2024-11-19T23:14:15]     INFO 0 schema-validation errors found in chgres_cube config\n",
       "[2024-11-19T23:14:15]     INFO Validating config against internal schema: platform\n",
-      "[2024-11-19T23:14:15]     INFO 0 UW schema-validation errors found in platform config\n",
+      "[2024-11-19T23:14:15]     INFO 0 schema-validation errors found in platform config\n",
       "[2024-11-19T23:14:15]     INFO 20241120 05:14:15 chgres_cube valid schema: State: Ready\n"
      ]
     },

--- a/notebooks/fs.ipynb
+++ b/notebooks/fs.ipynb
@@ -131,7 +131,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:56:27]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:56:27]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:56:27]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:56:27]     INFO File copies: Initial state: Not Ready\n",
       "[2024-12-09T21:56:27]     INFO File copies: Checking requirements\n",
       "[2024-12-09T21:56:27]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-target/file1-copy.nml: Initial state: Not Ready\n",
@@ -225,7 +225,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:56:33]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:56:33]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:56:33]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:56:33]     INFO File copies: Initial state: Not Ready\n",
       "[2024-12-09T21:56:33]     INFO File copies: Checking requirements\n",
       "[2024-12-09T21:56:33]     INFO Copy fixtures/fs/missing-file.nml -> tmp/copy-target/missing-copy.nml: Initial state: Not Ready\n",
@@ -340,7 +340,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:57:25]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:57:25]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:25]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:57:25]     INFO File copies: Initial state: Not Ready\n",
       "[2024-12-09T21:57:25]     INFO File copies: Checking requirements\n",
       "[2024-12-09T21:57:25]     INFO Copy fixtures/fs/file1.nml -> tmp/copy-keys-target/file1-copy.nml: Initial state: Not Ready\n",
@@ -507,7 +507,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:57:38]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:57:38]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:38]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:57:38]     INFO File copies: Initial state: Not Ready\n",
       "[2024-12-09T21:57:38]     INFO File copies: Checking requirements\n",
       "[2024-12-09T21:57:38]     INFO Copy fixtures/fs/file1.nml -> tmp/copier-target/file1-copy.nml: Initial state: Not Ready\n",
@@ -672,7 +672,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:57:45]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:57:45]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:45]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:57:45]     INFO File links: Initial state: Not Ready\n",
       "[2024-12-09T21:57:45]     INFO File links: Checking requirements\n",
       "[2024-12-09T21:57:45]     INFO Link tmp/link-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
@@ -766,7 +766,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:57:49]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:57:49]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:57:49]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:57:49]     INFO File links: Initial state: Not Ready\n",
       "[2024-12-09T21:57:49]     INFO File links: Checking requirements\n",
       "[2024-12-09T21:57:49]     INFO Link tmp/link-target/missing-link.nml -> fixtures/fs/missing-file.nml: Initial state: Not Ready\n",
@@ -881,7 +881,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:58:19]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:58:19]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:58:19]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:58:19]     INFO File links: Initial state: Not Ready\n",
       "[2024-12-09T21:58:19]     INFO File links: Checking requirements\n",
       "[2024-12-09T21:58:19]     INFO Link tmp/link-keys-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
@@ -1048,7 +1048,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:58:29]     INFO Validating config against internal schema: files-to-stage\n",
-      "[2024-12-09T21:58:29]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:58:29]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:58:29]     INFO File links: Initial state: Not Ready\n",
       "[2024-12-09T21:58:29]     INFO File links: Checking requirements\n",
       "[2024-12-09T21:58:29]     INFO Link tmp/linker-target/file1-link.nml -> fixtures/fs/file1.nml: Initial state: Not Ready\n",
@@ -1213,7 +1213,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:58:35]     INFO Validating config against internal schema: makedirs\n",
-      "[2024-12-09T21:58:35]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:58:35]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:58:35]     INFO Directories: Initial state: Not Ready\n",
       "[2024-12-09T21:58:35]     INFO Directories: Checking requirements\n",
       "[2024-12-09T21:58:35]     INFO Directory tmp/dir-target/foo: Initial state: Not Ready\n",
@@ -1333,7 +1333,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:59:02]     INFO Validating config against internal schema: makedirs\n",
-      "[2024-12-09T21:59:02]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:59:02]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:59:02]     INFO Directories: Initial state: Not Ready\n",
       "[2024-12-09T21:59:02]     INFO Directories: Checking requirements\n",
       "[2024-12-09T21:59:02]     INFO Directory tmp/dir-keys-target/foo/bar: Initial state: Not Ready\n",
@@ -1493,7 +1493,7 @@
      "output_type": "stream",
      "text": [
       "[2024-12-09T21:59:07]     INFO Validating config against internal schema: makedirs\n",
-      "[2024-12-09T21:59:07]     INFO 0 UW schema-validation errors found in fs config\n",
+      "[2024-12-09T21:59:07]     INFO 0 schema-validation errors found in fs config\n",
       "[2024-12-09T21:59:07]     INFO Directories: Initial state: Not Ready\n",
       "[2024-12-09T21:59:07]     INFO Directories: Checking requirements\n",
       "[2024-12-09T21:59:07]     INFO Directory tmp/makedirs-target/foo: Initial state: Not Ready\n",

--- a/notebooks/rocoto.ipynb
+++ b/notebooks/rocoto.ipynb
@@ -139,7 +139,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:15:43]     INFO 0 UW schema-validation errors found in Rocoto config\n",
+      "[2024-11-19T23:15:43]     INFO 0 schema-validation errors found in Rocoto config\n",
       "[2024-11-19T23:15:43]     INFO 0 Rocoto XML validation errors found\n"
      ]
     },
@@ -256,7 +256,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:15:43]    ERROR 3 UW schema-validation errors found in Rocoto config\n",
+      "[2024-11-19T23:15:43]    ERROR 3 schema-validation errors found in Rocoto config\n",
       "[2024-11-19T23:15:43]    ERROR Error at workflow -> attrs:\n",
       "[2024-11-19T23:15:43]    ERROR   'realtime' is a required property\n",
       "[2024-11-19T23:15:43]    ERROR Error at workflow -> tasks -> task_greet:\n",
@@ -388,7 +388,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:15:43]     INFO 0 UW schema-validation errors found in Rocoto config\n",
+      "[2024-11-19T23:15:43]     INFO 0 schema-validation errors found in Rocoto config\n",
       "[2024-11-19T23:15:43]     INFO 0 Rocoto XML validation errors found\n"
      ]
     },
@@ -577,7 +577,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:15:43]     INFO 0 UW schema-validation errors found in Rocoto config\n",
+      "[2024-11-19T23:15:43]     INFO 0 schema-validation errors found in Rocoto config\n",
       "[2024-11-19T23:15:43]     INFO 0 Rocoto XML validation errors found\n"
      ]
     },
@@ -722,7 +722,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2024-11-19T23:15:43]     INFO 0 UW schema-validation errors found in Rocoto config\n",
+      "[2024-11-19T23:15:43]     INFO 0 schema-validation errors found in Rocoto config\n",
       "[2024-11-19T23:15:43]     INFO 0 Rocoto XML validation errors found\n"
      ]
     },

--- a/notebooks/tests/test_config.py
+++ b/notebooks/tests/test_config.py
@@ -112,10 +112,10 @@ def test_validate():
     with testbook("config.ipynb", execute=True) as tb:
         assert tb.cell_output_text(69) == cfg
         assert tb.cell_output_text(71) == schema
-        valid_out = ("INFO 0 UW schema-validation errors found", "True")
+        valid_out = ("INFO 0 schema-validation errors found", "True")
         assert all(x in tb.cell_output_text(73) for x in valid_out)
         invalid_out = (
-            "ERROR 1 UW schema-validation error found",
+            "ERROR 1 schema-validation error found",
             "ERROR   47 is not of type 'string'",
             "False",
         )

--- a/notebooks/tests/test_exp_config_cb.py
+++ b/notebooks/tests/test_exp_config_cb.py
@@ -28,7 +28,7 @@ def test_exp_config():
         assert all(x in tb.cell_output_text(13) for x in deref_cfg)
         validate_out = (
             "INFO Validating config against internal schema: chgres-cube",
-            "INFO 0 UW schema-validation errors found",
+            "INFO 0 schema-validation errors found",
             "INFO Validating config against internal schema: platform",
             "chgres_cube valid schema: State: Ready",
         )

--- a/notebooks/tests/test_rocoto.py
+++ b/notebooks/tests/test_rocoto.py
@@ -11,7 +11,7 @@ def test_building_simple_workflow():
             simple_xml = f.read().rstrip()
         assert tb.cell_output_text(5) == simple_yaml
         valid_out = (
-            "INFO 0 UW schema-validation errors found",
+            "INFO 0 schema-validation errors found",
             "INFO 0 Rocoto XML validation errors found",
             "True",
         )
@@ -19,7 +19,7 @@ def test_building_simple_workflow():
         assert tb.cell_output_text(9) == simple_xml
         assert tb.cell_output_text(11) == err_yaml
         err_out = (
-            "ERROR 3 UW schema-validation errors found",
+            "ERROR 3 schema-validation errors found",
             "ERROR Error at workflow.attrs:",
             "ERROR   'realtime' is a required property",
             "ERROR Error at workflow.tasks.task_greet:",
@@ -54,7 +54,7 @@ def test_building_workflows():
         assert tb.cell_output_text(15) == ent_yaml
         assert tb.cell_output_text(17) == ent_cs_yaml
         valid_out = (
-            "INFO 0 UW schema-validation errors found",
+            "INFO 0 schema-validation errors found",
             "INFO 0 Rocoto XML validation errors found",
             "True",
         )

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -68,7 +68,7 @@ def validate(schema: dict, desc: str, config: dict) -> bool:
     """
     errors = _validation_errors(config, schema)
     log_method = log.error if errors else log.info
-    log_msg = "%s UW schema-validation error%s found in %s"
+    log_msg = "%s schema-validation error%s found in %s"
     log_method(log_msg, len(errors), "" if len(errors) == 1 else "s", desc)
     for error in errors:
         log.error("Error at %s:", ".".join(str(k) for k in error.path))

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -162,7 +162,7 @@ def test_validate_fail_bad_enum_val(caplog, config, schema):
     log.setLevel(logging.INFO)
     config["color"] = "yellow"  # invalid enum value
     assert not validator.validate(schema=schema, desc="test", config=config)
-    assert any(x for x in caplog.records if "1 UW schema-validation error found" in x.message)
+    assert any(x for x in caplog.records if "1 schema-validation error found" in x.message)
     assert any(x for x in caplog.records if "'yellow' is not one of" in x.message)
 
 
@@ -170,7 +170,7 @@ def test_validate_fail_bad_number_val(caplog, config, schema):
     log.setLevel(logging.INFO)
     config["number"] = "string"  # invalid number value
     assert not validator.validate(schema=schema, desc="test", config=config)
-    assert any(x for x in caplog.records if "1 UW schema-validation error found" in x.message)
+    assert any(x for x in caplog.records if "1 schema-validation error found" in x.message)
     assert any(x for x in caplog.records if "'string' is not of type 'number'" in x.message)
 
 


### PR DESCRIPTION
**Synopsis**

A simple wording change in a log message, with a lot of updates in docs, notebooks, and tests.

I am using `uwtools` as a package in the ML verification tool I'm working on, and at the moment am using `uwtools.api.config.validate()` to do schema validation of that tool's config file. On a faulty config, the output currently looks like
```
[2024-12-18T19:53:21]    ERROR 4 UW schema-validation errors found in config
...
```
It's the `UW` part that's confusing: A user of this tool wouldn't have any idea what `UW` means, and the schema doesn't belong to `uwtools` anyway. I think I added the `UW` part to this message to differentiate it from errors arising from validation of Rocoto XML schemas, so the messages mention `UW` and `Rocoto` respectively. I think keeping `Rocoto` in place will keep the difference clear, but removing `UW` will make the `validate()` function more useful in external applications.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
