### PR TITLE
Improve error message for top-level schema-validation errors 

### DIFF
--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -71,7 +71,8 @@ def validate(schema: dict, desc: str, config: dict) -> bool:
     log_msg = "%s schema-validation error%s found in %s"
     log_method(log_msg, len(errors), "" if len(errors) == 1 else "s", desc)
     for error in errors:
-        log.error("Error at %s:", ".".join(str(k) for k in error.path))
+        location = ".".join(str(k) for k in error.path) if error.path else "top level"
+        log.error("Error at %s:", location)
         log.error("%s%s", INDENT, error.message)
     return not bool(errors)
 


### PR DESCRIPTION
**Synopsis**

Given `a.jsonschema`
```
{
  "additionalProperties": false,
  "properties": {
    "n": {
      "type": "integer"
    }
  },
  "required": [
    "n"
  ],
  "type": "object"
}
```
and `a.yaml`
```
x: 42
```
Old behavior:
```
$ uw config validate --schema-file a.jsonschema --input-file a.yaml 
[2024-12-19T04:30:37]    ERROR 2 schema-validation errors found in config
[2024-12-19T04:30:37]    ERROR Error at :
[2024-12-19T04:30:37]    ERROR   Additional properties are not allowed ('x' was unexpected)
[2024-12-19T04:30:37]    ERROR Error at :
[2024-12-19T04:30:37]    ERROR   'n' is a required property
```
Note that `Error at :` is not useful, and looks like something is missing.

New behavior:
```
$ uw config validate --schema-file a.jsonschema --input-file a.yaml 
[2024-12-19T04:30:43]    ERROR 2 schema-validation errors found in config
[2024-12-19T04:30:43]    ERROR Error at top level:
[2024-12-19T04:30:43]    ERROR   Additional properties are not allowed ('x' was unexpected)
[2024-12-19T04:30:43]    ERROR Error at top level:
[2024-12-19T04:30:43]    ERROR   'n' is a required property
```
I think we haven't run into this yet because the driver configs we've been evaluating don't have useful content at the top level; instead, we immediately look under a key (e.g. `ungrib:`) for a specific driver and validate that. Once again, using `uwtools` in new contexts points out areas for improvement.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
