### PR TITLE
Taskname optional suffix

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -112,7 +112,7 @@ class Assets(ABC):
         with open(internal_schema_file(schema_name=cls._schema_name()), "r", encoding="utf-8") as f:
             return bundle(json.load(f))
 
-    def taskname(self, suffix: str) -> str:
+    def taskname(self, suffix: Optional[str] = None) -> str:
         """
         Return a common tag for task-related log messages.
 

--- a/src/uwtools/drivers/make_solo_mosaic.py
+++ b/src/uwtools/drivers/make_solo_mosaic.py
@@ -2,6 +2,8 @@
 A driver for make_solo_mosaic.
 """
 
+from typing import Optional
+
 from iotaa import tasks
 
 from uwtools.drivers.driver import DriverTimeInvariant
@@ -26,7 +28,7 @@ class MakeSoloMosaic(DriverTimeInvariant):
 
     # Public helper methods
 
-    def taskname(self, suffix: str) -> str:
+    def taskname(self, suffix: Optional[str] = None) -> str:
         """
         Return a common tag for graph-task log messages.
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -233,6 +233,11 @@ def test_Assets_leadtime(config):
     assert obj.leadtime == leadtime
 
 
+def test_Assets_taskname(assetsobj):
+    assert assetsobj.taskname() == "concrete"
+    assert assetsobj.taskname(suffix="test") == "concrete test"
+
+
 def test_Assets_validate(assetsobj, caplog):
     log.setLevel(logging.INFO)
     assetsobj.validate()

--- a/src/uwtools/tests/drivers/test_support.py
+++ b/src/uwtools/tests/drivers/test_support.py
@@ -48,7 +48,7 @@ def test_tasks():
         def provisioned_rundir(self):
             pass
 
-        def taskname(self, suffix):
+        def taskname(self, suffix=None):
             pass
 
         @external


### PR DESCRIPTION
**Synopsis**

Make the `suffix` argument to `Asset.taskname()` optional. In an application using `uwtools`, I found it convenient to call this method to get a prefix to use in custom log messages so that they look nice in line with log messages coming from the driver itself. Currently I have to do `taskname("")`; with this change, that call can just be `.taskname()`.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
