### PR TITLE
Return assets from driver invocation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpick_ignore = [
     ("py:class", "Path"),
     ("py:class", "f90nml.Namelist"),
+    ("py:class", "iotaa.Asset"),
 ]
 numfig = True
 numfig_format = {"figure": "Figure %s"}

--- a/docs/sections/user_guide/cli/tools/config/validate-verbose.out
+++ b/docs/sections/user_guide/cli/tools/config/validate-verbose.out
@@ -1,21 +1,21 @@
-[2025-01-05T21:15:07]    DEBUG Command: uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
-[2025-01-05T21:15:07]    DEBUG Using schema file: schema.jsonschema
-[2025-01-05T21:15:07]    DEBUG [dereference] Dereferencing, current value:
-[2025-01-05T21:15:07]    DEBUG [dereference]   values:
-[2025-01-05T21:15:07]    DEBUG [dereference]     greeting: Hello
-[2025-01-05T21:15:07]    DEBUG [dereference]     recipient: World
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendering: values
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendered: values
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendering: greeting
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendered: greeting
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendering: Hello
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendered: Hello
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendering: recipient
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendered: recipient
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendering: World
-[2025-01-05T21:15:07]    DEBUG [dereference] Rendered: World
-[2025-01-05T21:15:07]    DEBUG [dereference] Dereferencing, final value:
-[2025-01-05T21:15:07]    DEBUG [dereference]   values:
-[2025-01-05T21:15:07]    DEBUG [dereference]     greeting: Hello
-[2025-01-05T21:15:07]    DEBUG [dereference]     recipient: World
-[2025-01-05T21:15:07]     INFO 0 schema-validation errors found in config
+[2025-01-15T20:22:34]    DEBUG Command: uw config validate --schema-file schema.jsonschema --input-file values.yaml --verbose
+[2025-01-15T20:22:34]    DEBUG [dereference] Dereferencing, current value:
+[2025-01-15T20:22:34]    DEBUG [dereference]   values:
+[2025-01-15T20:22:34]    DEBUG [dereference]     greeting: Hello
+[2025-01-15T20:22:34]    DEBUG [dereference]     recipient: World
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendering: values
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendered: values
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendering: greeting
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendered: greeting
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendering: Hello
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendered: Hello
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendering: recipient
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendered: recipient
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendering: World
+[2025-01-15T20:22:34]    DEBUG [dereference] Rendered: World
+[2025-01-15T20:22:34]    DEBUG [dereference] Dereferencing, final value:
+[2025-01-15T20:22:34]    DEBUG [dereference]   values:
+[2025-01-15T20:22:34]    DEBUG [dereference]     greeting: Hello
+[2025-01-15T20:22:34]    DEBUG [dereference]     recipient: World
+[2025-01-15T20:22:34]    DEBUG Using schema file: schema.jsonschema
+[2025-01-15T20:22:34]     INFO 0 schema-validation errors found in config

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -289,7 +289,7 @@ def _dispatch_execute(args: Args) -> bool:
 
     :param args: Parsed command-line args.
     """
-    return uwtools.api.execute.execute(
+    assets = uwtools.api.execute.execute(
         classname=args[STR.classname],
         module=args[STR.module],
         task=args[STR.task],
@@ -303,6 +303,7 @@ def _dispatch_execute(args: Args) -> bool:
         batch=args[STR.batch],
         stdin_ok=True,
     )
+    return bool(assets)
 
 
 # Mode fs


### PR DESCRIPTION
**Synopsis**

Currently, `uwtools.api.execute.execute()` returns a `bool` meant to indicate whether the task ran to completion. Instead, return the `iotaa` `Asset`s that are yielded by the task, which allows a caller to extract references (via `iotaa.refs()`) to the assets the task made ready. For example, `execute()`ing a `namelist` driver task would now return a reference to the on-disk namelist file, which the caller could use for whatever purpose. See the updated unit tests for an example.

**Type**

- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality) **but it's unlikely any user would notice**

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
