### PR TITLE
Bugfix config run duration

### DIFF
--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -49,7 +49,8 @@ class MPAS(MPASBase):
         base_file = self.config[STR.namelist].get(STR.basefile)
         yield file(Path(base_file)) if base_file else None
         duration = timedelta(hours=self.config["length"])
-        str_duration = str(duration).replace(" days, ", "_")
+        hhmmss = ":".join(f"{x:02}" for x in str(timedelta(seconds=duration.seconds)).split(":"))
+        str_duration = "%s%s" % (f"{duration.days:03}_" if duration.days else "", hhmmss)
         namelist = self.config[STR.namelist]
         update_values = namelist.get(STR.updatevalues, {})
         update_values.setdefault("nhyd_model", {}).update(

--- a/src/uwtools/resources/jsonschema/mpas.jsonschema
+++ b/src/uwtools/resources/jsonschema/mpas.jsonschema
@@ -58,8 +58,8 @@
           "type": "object"
         },
         "length": {
-          "minimum": 1,
-          "type": "integer"
+          "minimum": 0.25,
+          "type": "number"
         },
         "namelist": {
           "additionalProperties": false,

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -215,7 +215,7 @@ def test_MPAS_namelist_file_long_duration(caplog, config, cycle):
     assert logged(caplog, f"Wrote config to {path}")
     nml = f90nml.read(dst)
     assert isinstance(nml, f90nml.Namelist)
-    assert nml["nhyd_model"]["config_run_duration"] == "5_0:00:00"
+    assert nml["nhyd_model"]["config_run_duration"] == "005_00:00:00"
 
 
 def test_MPAS_namelist_file_missing_base_file(caplog, driverobj):

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -204,6 +204,20 @@ def test_MPAS_namelist_file_fails_validation(caplog, driverobj):
     assert logged(caplog, "  None is not of type 'array', 'boolean', 'number', 'string'")
 
 
+def test_MPAS_namelist_file_short_duration(caplog, config, cycle):
+    log.setLevel(logging.DEBUG)
+    config["mpas"]["length"] = 0.25
+    driverobj = MPAS(config=config, cycle=cycle)
+    dst = driverobj.rundir / "namelist.atmosphere"
+    assert not dst.is_file()
+    path = Path(iotaa.refs(driverobj.namelist_file()))
+    assert dst.is_file()
+    assert logged(caplog, f"Wrote config to {path}")
+    nml = f90nml.read(dst)
+    assert isinstance(nml, f90nml.Namelist)
+    assert nml["nhyd_model"]["config_run_duration"] == "00:15:00"
+
+
 def test_MPAS_namelist_file_long_duration(caplog, config, cycle):
     log.setLevel(logging.DEBUG)
     config["mpas"]["length"] = 120


### PR DESCRIPTION
**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->
Currently there is a known issue when a user changes the length of a forecast to run for 24 hours. The `config_run_duration` does not replace `days` to the correct format of `[DDD]_hh:mm:ss` that is acceptable to run the forecast. This causes `mpassit` to fail further down the workflow.  

Bug below:
```
        duration = timedelta(hours=self.config["length"])
        str_duration = str(duration).replace(" days, ", "_")
```

Example `config_run_duration` format not being generated correctly:
```
    config_start_time = '2024-11-20_00:00:00'
    config_run_duration = '1 day, 0:00:00'
```

Desired `config_run_duration` format:
```
    config_start_time = '2024-11-20_00:00:00'
    config_run_duration = '001_00:00:00'
```

**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
