### PR TITLE
Log traceback from certain failures to load a module via `uwtools.api.execute`

### DIFF
--- a/src/uwtools/api/execute.py
+++ b/src/uwtools/api/execute.py
@@ -7,6 +7,7 @@ from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from inspect import getfullargspec
 from pathlib import Path
+from traceback import format_exc
 from types import ModuleType
 from typing import Optional, Type, Union
 
@@ -138,7 +139,8 @@ def _get_driver_module_explicit(module: Path) -> Optional[ModuleType]:
                 log.debug("Loaded module %s", module)
                 return m
             except Exception:  # pylint: disable=broad-exception-caught
-                pass
+                for line in format_exc().strip().split("\n"):
+                    log.error(line)
     return None
 
 


### PR DESCRIPTION
**Synopsis**

Talking with a user, it surfaced that, when an attempt is made to load a module via `execute()` in `uwtools.api.execute` and fails, certain information from a suppressed exception would be helpful for debugging. More concretely, consider this external module:

```
syntax error
from iotaa import asset, task
from uwtools.drivers.driver import AssetsTimeInvariant

class C(AssetsTimeInvariant):

    @classmethod
    def driver_name(self):
        return "c"

    @task
    def demo(self):
        path = "foo"
        yield "demo"
        yield asset(path, path.exists)
        yield None
        path.touch()
```

Note that the first line is not valid Python and that an attempt to load this module must fail. Currently, though, and given appropriate minimal `config.yaml` and `demo.jsonschema` not shown here:

```
$ uw execute --module demo.py --class C --task demo --config config.yaml 
[2025-02-19T01:25:35]    ERROR Could not load module demo.py
```

Not very informative. With the changes from this PR:

```
$ uw execute --module demo.py --class C --task demo --config config.yaml 
[2025-02-19T01:26:02]    ERROR Traceback (most recent call last):
[2025-02-19T01:26:02]    ERROR   File "/home/maddenp/git/uwtools/src/uwtools/api/execute.py", line 138, in _get_driver_module_explicit
[2025-02-19T01:26:02]    ERROR     loader.exec_module(m)
[2025-02-19T01:26:02]    ERROR   File "<frozen importlib._bootstrap_external>", line 995, in exec_module
[2025-02-19T01:26:02]    ERROR   File "<frozen importlib._bootstrap_external>", line 1133, in get_code
[2025-02-19T01:26:02]    ERROR   File "<frozen importlib._bootstrap_external>", line 1063, in source_to_code
[2025-02-19T01:26:02]    ERROR   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
[2025-02-19T01:26:02]    ERROR   File "/home/maddenp/git/uwtools/demo.py", line 1
[2025-02-19T01:26:02]    ERROR     syntax error
[2025-02-19T01:26:02]    ERROR            ^^^^^
[2025-02-19T01:26:02]    ERROR SyntaxError: invalid syntax
[2025-02-19T01:26:02]    ERROR Could not load module demo.py
```

Better.

I'd like to get this included in our upcoming `v2.5.2` and `v2.6.1` bugfix releases alongside [this update](https://github.com/ufs-community/uwtools/pull/698).

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
