### PR TITLE
Improvements to PBS batch runscripts

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -497,11 +497,12 @@ class Driver(Assets):
 
         {execution}
         """
+        directives, cmds = scheduler.directives_and_initcmds if scheduler else ("", [])
         rs = dedent(template).format(
-            directives="\n".join(scheduler.directives if scheduler else ""),
+            directives="\n".join(directives),
             envcmds="\n".join(envcmds or []),
             envvars="\n".join([f"export {k}={v}" for k, v in (envvars or {}).items()]),
-            execution="\n".join(execution),
+            execution="\n".join([*cmds, *execution]),
         )
         return re.sub(r"\n\n\n+", "\n\n", rs.strip())
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -497,12 +497,13 @@ class Driver(Assets):
 
         {execution}
         """
-        directives, cmds = scheduler.directives_and_initcmds if scheduler else ("", [])
+        directives = scheduler.directives if scheduler else ""
+        initcmds = scheduler.initcmds if scheduler else []
         rs = dedent(template).format(
             directives="\n".join(directives),
             envcmds="\n".join(envcmds or []),
             envvars="\n".join([f"export {k}={v}" for k, v in (envvars or {}).items()]),
-            execution="\n".join([*cmds, *execution]),
+            execution="\n".join([*initcmds, *execution]),
         )
         return re.sub(r"\n\n\n+", "\n\n", rs.strip())
 

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -224,9 +224,8 @@ class PBS(JobScheduler):
         """
         Additional initialization commands a PBS batch job must run.
         """
-        if rundir := self._props.get(_DirectivesOptional.RUNDIR):
-            return [f"cd {rundir}"]
-        return []
+        rundir = self._props.get(_DirectivesOptional.RUNDIR)
+        return [f"cd {rundir}"] if rundir else []
 
     @property
     def _directive_separator(self) -> str:

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -224,7 +224,7 @@ class PBS(JobScheduler):
         """
         Directives that this scheduler does not support.
         """
-        return []
+        return [_DirectivesOptional.RUNDIR]
 
     @property
     def _managed_directives(self) -> dict[str, Any]:
@@ -280,6 +280,7 @@ class PBS(JobScheduler):
         props.update(self._placement(props))
         props.pop(_DirectivesOptional.TASKS_PER_NODE, None)
         props.pop(_DirectivesOptional.NODES, None)
+        props.pop(_DirectivesOptional.RUNDIR, None)
         props.pop(_DirectivesOptional.THREADS, None)
         props.pop(_DirectivesOptional.MEMORY, None)
         props.pop("exclusive", None)

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -290,7 +290,7 @@ class PBS(JobScheduler):
         """
         Pre-processed runscript directives.
         """
-        props = self._props
+        props = deepcopy(self._props)
         props.update(self._select(props))
         props.update(self._placement(props))
         props.pop(_DirectivesOptional.TASKS_PER_NODE, None)

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -37,6 +37,7 @@ class JobScheduler(ABC):
         The resource-request scheduler directives.
         """
         pre, sep = self._prefix, self._directive_separator
+        sep_for = lambda val: "" if val.endswith("=") else sep
         ds = []
         for key, value in self._processed_props.items():
             if key in self._forbidden_directives:
@@ -47,11 +48,9 @@ class JobScheduler(ABC):
                 if callable(switch) and (x := switch(value)) is not None:
                     ds.append("%s %s" % (pre, x))
                 else:
-                    x = "" if switch.endswith("=") else sep
-                    ds.append("%s %s%s%s" % (pre, switch, x, value))
+                    ds.append("%s %s%s%s" % (pre, switch, sep_for(switch), value))
             else:
-                x = "" if key.endswith("=") else sep
-                ds.append("%s %s%s%s" % (pre, key, x, value))
+                ds.append("%s %s%s%s" % (pre, key, sep_for(key), value))
         return sorted(ds)
 
     @staticmethod

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -32,9 +32,9 @@ class JobScheduler(ABC):
     # Public methods
 
     @property
-    def directives(self) -> list[str]:
+    def directives_and_initcmds(self) -> tuple[list[str], list[str]]:
         """
-        The resource-request scheduler directives.
+        The resource-request scheduler directives and any additional setup commands.
         """
         pre, sep = self._prefix, self._directive_separator
         ds = []
@@ -52,7 +52,7 @@ class JobScheduler(ABC):
             else:
                 x = "" if key.endswith("=") else sep
                 ds.append("%s %s%s%s" % (pre, key, x, value))
-        return sorted(ds)
+        return sorted(ds), self._initcmds
 
     @staticmethod
     def get_scheduler(props: Mapping) -> JobScheduler:
@@ -95,6 +95,13 @@ class JobScheduler(ABC):
         """
         The character used to separate directive keys and values.
         """
+
+    @property
+    def _initcmds(self) -> list[str]:
+        """
+        Additional initialization commands a batch job must run.
+        """
+        return []
 
     @property
     @abstractmethod
@@ -225,6 +232,15 @@ class PBS(JobScheduler):
         Directives that this scheduler does not support.
         """
         return [_DirectivesOptional.RUNDIR]
+
+    @property
+    def _initcmds(self) -> list[str]:
+        """
+        Additional initialization commands a PBS batch job must run.
+        """
+        if rundir := self._props.get(_DirectivesOptional.RUNDIR):
+            return [f"cd {rundir}"]
+        return []
 
     @property
     def _managed_directives(self) -> dict[str, Any]:

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -34,7 +34,7 @@ class JobScheduler(ABC):
     @property
     def directives(self) -> list[str]:
         """
-        The resource-request scheduler directives and any additional setup commands.
+        The resource-request scheduler directives.
         """
         pre, sep = self._prefix, self._directive_separator
         ds = []

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -36,8 +36,8 @@ class JobScheduler(ABC):
         """
         The resource-request scheduler directives.
         """
-        pre, sep = self._prefix, self._directive_separator
-        sep_for = lambda val: "" if val.endswith("=") else sep
+        prefix, separator = self._prefix, self._directive_separator
+        sep = lambda val: "%s%s" % (val, "" if val.endswith("=") else separator)
         ds = []
         for key, value in self._processed_props.items():
             if key in self._forbidden_directives:
@@ -46,11 +46,11 @@ class JobScheduler(ABC):
             if key in self._managed_directives:
                 switch = self._managed_directives[key]
                 if callable(switch) and (x := switch(value)) is not None:
-                    ds.append("%s %s" % (pre, x))
+                    ds.append("%s %s" % (prefix, x))
                 else:
-                    ds.append("%s %s%s%s" % (pre, switch, sep_for(switch), value))
+                    ds.append("%s %s%s" % (prefix, sep(switch), value))
             else:
-                ds.append("%s %s%s%s" % (pre, key, sep_for(key), value))
+                ds.append("%s %s%s" % (prefix, sep(key), value))
         return sorted(ds)
 
     @staticmethod

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -47,9 +47,11 @@ class JobScheduler(ABC):
                 if callable(switch) and (x := switch(value)) is not None:
                     ds.append("%s %s" % (pre, x))
                 else:
-                    ds.append("%s %s%s%s" % (pre, switch, sep, value))
+                    x = "" if switch.endswith("=") else sep
+                    ds.append("%s %s%s%s" % (pre, switch, x, value))
             else:
-                ds.append("%s %s%s%s" % (pre, key, sep, value))
+                x = "" if key.endswith("=") else sep
+                ds.append("%s %s%s%s" % (pre, key, x, value))
         return sorted(ds)
 
     @staticmethod

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -543,7 +543,7 @@ def test_Driver__runscript(driverobj):
     foo
     bar
     """
-    scheduler = Mock(directives=["#DIR --d1", "#DIR --d2"])
+    scheduler = Mock(directives_and_initcmds=(["#DIR --d1", "#DIR --d2"], []))
     assert (
         driverobj._runscript(
             execution=["foo", "bar"],

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -540,10 +540,11 @@ def test_Driver__runscript(driverobj):
     export VAR1=1
     export VAR2=2
 
+    cd /path/to/rundir
     foo
     bar
     """
-    scheduler = Mock(directives_and_initcmds=(["#DIR --d1", "#DIR --d2"], []))
+    scheduler = Mock(directives=["#DIR --d1", "#DIR --d2"], initcmds=["cd /path/to/rundir"])
     assert (
         driverobj._runscript(
             execution=["foo", "bar"],

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -206,6 +206,10 @@ def test_PBS_directives(pbs):
     ]
 
 
+def test_PBS_initcmds(pbs):
+    assert pbs.initcmds == ["cd /path/to/rundir"]
+
+
 def test_PBS__directive_separator(pbs):
     assert pbs._directive_separator == " "
 

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -247,7 +247,12 @@ def test_PBS__prefix(pbs):
 
 
 def test_PBS__processed_props(pbs):
-    assert pbs._processed_props == pbs._props
+    assert pbs._processed_props == {
+        "--pi": 3.14,
+        "account": "foo",
+        "walltime": "01:10:00",
+        "-l select=": "ompthreads=1",
+    }
 
 
 def test_PBS__select(pbs):

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -81,18 +81,20 @@ def test_JobScheduler(schedulerobj):
 
 
 def test_JobScheduler_directives(schedulerobj):
-    assert schedulerobj.directives == [
+    directives, cmds = schedulerobj.directives_and_initcmds
+    assert directives == [
         "#DIR --a=foo",
         "#DIR --pi=3.14",
         "#DIR --r=/path/to/rundir",
         "#DIR --t=01:10:00",
     ]
+    assert cmds == []
 
 
 def test_JobScheduler_get_scheduler_fail_bad_directive_specified(props):
     scheduler = ConcreteScheduler.get_scheduler(props={**props, "shell": "csh"})
     with raises(UWConfigError) as e:
-        assert scheduler.directives
+        assert scheduler.directives_and_initcmds
     assert str(e.value).startswith("Directive 'shell' invalid for scheduler 'slurm'")
 
 
@@ -198,12 +200,14 @@ def test_PBS(pbs):
 
 
 def test_PBS_directives(pbs):
-    assert pbs.directives == [
+    directives, cmds = pbs.directives_and_initcmds
+    assert directives == [
         "#PBS --pi 3.14",
         "#PBS -A foo",
         "#PBS -l select=ompthreads=1",
         "#PBS -l walltime=01:10:00",
     ]
+    assert cmds == []  # == ["cd /path/to/rundir"]
 
 
 def test_PBS__directive_separator(pbs):

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -182,6 +182,15 @@ def test_PBS(pbs):
     assert isinstance(pbs, JobScheduler)
 
 
+def test_PBS_directives(pbs):
+    assert pbs.directives == [
+        "#PBS --pi 3.14",
+        "#PBS -A foo",
+        "#PBS -l select=ompthreads=1",
+        "#PBS -l walltime=01:10:00",
+    ]
+
+
 def test_PBS__directive_separator(pbs):
     assert pbs._directive_separator == " "
 

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -81,20 +81,18 @@ def test_JobScheduler(schedulerobj):
 
 
 def test_JobScheduler_directives(schedulerobj):
-    directives, cmds = schedulerobj.directives_and_initcmds
-    assert directives == [
+    assert schedulerobj.directives == [
         "#DIR --a=foo",
         "#DIR --pi=3.14",
         "#DIR --r=/path/to/rundir",
         "#DIR --t=01:10:00",
     ]
-    assert cmds == []
 
 
 def test_JobScheduler_get_scheduler_fail_bad_directive_specified(props):
     scheduler = ConcreteScheduler.get_scheduler(props={**props, "shell": "csh"})
     with raises(UWConfigError) as e:
-        assert scheduler.directives_and_initcmds
+        assert scheduler.directives
     assert str(e.value).startswith("Directive 'shell' invalid for scheduler 'slurm'")
 
 
@@ -200,14 +198,12 @@ def test_PBS(pbs):
 
 
 def test_PBS_directives(pbs):
-    directives, cmds = pbs.directives_and_initcmds
-    assert directives == [
+    assert pbs.directives == [
         "#PBS --pi 3.14",
         "#PBS -A foo",
         "#PBS -l select=ompthreads=1",
         "#PBS -l walltime=01:10:00",
     ]
-    assert cmds == []  # == ["cd /path/to/rundir"]
 
 
 def test_PBS__directive_separator(pbs):

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -14,14 +14,24 @@ from uwtools.scheduler import JobScheduler
 # Fixtures
 
 directive_separator = "="
-managed_directives = {"account": lambda x: f"--a={x}", "walltime": lambda x: f"--t={x}"}
+managed_directives = {
+    "account": lambda x: f"--a={x}",
+    "rundir": lambda x: f"--r={x}",
+    "walltime": lambda x: f"--t={x}",
+}
 prefix = "#DIR"
 submit_cmd = "sub"
 
 
 @fixture
 def props():
-    return {"scheduler": "slurm", "walltime": "01:10:00", "account": "foo", "--pi": 3.14}
+    return {
+        "--pi": 3.14,
+        "account": "foo",
+        "rundir": "/path/to/rundir",
+        "scheduler": "slurm",
+        "walltime": "01:10:00",
+    }
 
 
 @fixture
@@ -71,7 +81,12 @@ def test_JobScheduler(schedulerobj):
 
 
 def test_JobScheduler_directives(schedulerobj):
-    assert schedulerobj.directives == ["#DIR --a=foo", "#DIR --pi=3.14", "#DIR --t=01:10:00"]
+    assert schedulerobj.directives == [
+        "#DIR --a=foo",
+        "#DIR --pi=3.14",
+        "#DIR --r=/path/to/rundir",
+        "#DIR --t=01:10:00",
+    ]
 
 
 def test_JobScheduler_get_scheduler_fail_bad_directive_specified(props):
@@ -196,7 +211,7 @@ def test_PBS__directive_separator(pbs):
 
 
 def test_PBS__forbidden_directives(pbs):
-    assert pbs._forbidden_directives == []
+    assert pbs._forbidden_directives == ["rundir"]
 
 
 def test_PBS__managed_directives(pbs):


### PR DESCRIPTION
**Synopsis**

Fixes #726.

- Removes spaces around `=` in PBS directives.
- Arranges for a `cd` command to be executed in place of a non-existent PBS run-directory directive.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
