### PR TITLE
Output methods for shave, make_orog, sfc_climo components

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,6 @@ extlinks = {
     "rst": ("https://www.sphinx-doc.org/en/master/usage/restructuredtext/%s", "%s"),
     "rtd": ("https://readthedocs.org/projects/uwtools/%s", "%s"),
     "schism": ("https://schism-dev.github.io/schism/master/%s", "%s"),
-    "sfc-climo-gen": ("https://ufs-community.github.io/UFS_UTILS/sfc_climo_gen/%s", "%s"),
     "ufs": ("https://ufs.epic.noaa.gov/%s", "%s"),
     "ufs-utils": ("https://noaa-emcufs-utils.readthedocs.io/en/latest/ufs_utils.html#%s", "%s"),
     "ufs-weather-model": ("https://github.com/ufs-community/ufs-weather-model/%s", "%s"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ extlinks = {
     "rst": ("https://www.sphinx-doc.org/en/master/usage/restructuredtext/%s", "%s"),
     "rtd": ("https://readthedocs.org/projects/uwtools/%s", "%s"),
     "schism": ("https://schism-dev.github.io/schism/master/%s", "%s"),
+    "sfc-climo-gen": ("https://ufs-community.github.io/UFS_UTILS/sfc_climo_gen/%s", "%s"),
     "ufs": ("https://ufs.epic.noaa.gov/%s", "%s"),
     "ufs-utils": ("https://noaa-emcufs-utils.readthedocs.io/en/latest/ufs_utils.html#%s", "%s"),
     "ufs-weather-model": ("https://github.com/ufs-community/ufs-weather-model/%s", "%s"),

--- a/docs/sections/user_guide/cli/drivers/mpas_init/show-schema.out
+++ b/docs/sections/user_guide/cli/drivers/mpas_init/show-schema.out
@@ -11,7 +11,7 @@
               "type": "integer"
             },
             "length": {
-              "minimum": 1,
+              "minimum": 0,
               "type": "integer"
             },
             "offset": {

--- a/docs/sections/user_guide/cli/drivers/orog/index.rst
+++ b/docs/sections/user_guide/cli/drivers/orog/index.rst
@@ -3,7 +3,7 @@
 
 .. include:: ../shared/idempotent.rst
 
-The ``uw`` mode for configuring and running the UFS Utils preprocessing component ``orog``.
+The ``uw`` mode for configuring and running the UFS Utils preprocessing component ``orog``. Documentation for this UFS Utils component is :ufs-utils:`here <orog>`.
 
 .. include:: help.rst
 

--- a/docs/sections/user_guide/cli/drivers/sfc_climo_gen/index.rst
+++ b/docs/sections/user_guide/cli/drivers/sfc_climo_gen/index.rst
@@ -3,7 +3,7 @@
 
 .. include:: ../shared/idempotent.rst
 
-The ``uw`` mode for configuring and running the :sfc-climo-gen:`sfc_climo_gen<>` component.
+The ``uw`` mode for configuring and running the UFS Utils preprocessing component ``sfc_climo_gen``. Documentation for this UFS Utils component is :ufs-utils:`here <sfc-climo-gen>`.
 
 .. include:: help.rst
 

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -114,12 +114,12 @@ class ChgresCube(DriverCycleLeadtimeBased):
         return STR.chgrescube
 
     @property
-    def output(self) -> dict[str, Path]:
+    def output(self) -> dict[str, list[Path]]:
         """
         Returns a description of the file(s) created when this component runs.
         """
         outfile = lambda x: self.rundir / f"out.{x}.tile7.nc"
-        return {"atm": outfile("atm"), "sfc": outfile("sfc")}
+        return {"atm": [outfile("atm")], "sfc": [outfile("sfc")]}
 
 
 set_driver_docstring(ChgresCube)

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -118,10 +118,8 @@ class ChgresCube(DriverCycleLeadtimeBased):
         """
         Returns a description of the file(s) created when this component runs.
         """
-        return {
-            "atm": Path(f"{self.rundir}/out.atm.tile7.nc"),
-            "sfc": Path(f"{self.rundir}/out.sfc.tile7.nc"),
-        }
+        outfile = lambda x: Path(f"{self.rundir}/out.{x}.tile7.nc")
+        return {"atm": outfile("atm"), "sfc": outfile("sfc")}
 
 
 set_driver_docstring(ChgresCube)

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -114,13 +114,14 @@ class ChgresCube(DriverCycleLeadtimeBased):
         return STR.chgrescube
 
     @property
-    def output(self) -> dict[str, list[str]]:
+    def output(self) -> dict[str, Path]:
         """
         Returns a description of the file(s) created when this component runs.
         """
-        output_types = ["atm", "sfc"]
-        paths = [f"{self.rundir}/out.{t}.tile7.nc" for t in output_types]
-        return {"netcdffiles": paths}
+        return {
+            "atm": Path(f"{self.rundir}/out.atm.tile7.nc"),
+            "sfc": Path(f"{self.rundir}/out.sfc.tile7.nc"),
+        }
 
 
 set_driver_docstring(ChgresCube)

--- a/src/uwtools/drivers/chgres_cube.py
+++ b/src/uwtools/drivers/chgres_cube.py
@@ -118,7 +118,7 @@ class ChgresCube(DriverCycleLeadtimeBased):
         """
         Returns a description of the file(s) created when this component runs.
         """
-        outfile = lambda x: Path(f"{self.rundir}/out.{x}.tile7.nc")
+        outfile = lambda x: self.rundir / f"out.{x}.tile7.nc"
         return {"atm": outfile("atm"), "sfc": outfile("sfc")}
 
 

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -428,7 +428,7 @@ class Driver(Assets):
     # Public methods
 
     @property
-    def output(self) -> dict[str, str] | dict[str, list[str]]:
+    def output(self) -> dict[str, Path] | dict[str, list[Path]]:
         """
         Returns a description of the file(s) created when this component runs.
         """

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -37,7 +37,7 @@ class FilterTopo(DriverTimeInvariant):
         The filtered output file staged from raw input.
         """
         src = Path(self.config["config"]["input_raw_orog"])
-        dst = self.rundir / self.config["config"]["filtered_orog"]
+        dst = self.output["path"]
         yield self.taskname(f"Raw orog input {dst!s}")
         yield asset(dst, dst.is_file)
         yield filecopy(src=src, dst=dst)
@@ -82,11 +82,11 @@ class FilterTopo(DriverTimeInvariant):
         return STR.filtertopo
 
     @property
-    def output(self) -> dict[str, list[Path]]:
+    def output(self) -> dict[str, Path]:
         """
         Returns a description of the file(s) created when this component runs.
         """
-        return {"outputs": [Path("foo")]}
+        return {"path": self.rundir / self.config["config"]["filtered_orog"]}
 
 
 set_driver_docstring(FilterTopo)

--- a/src/uwtools/drivers/filter_topo.py
+++ b/src/uwtools/drivers/filter_topo.py
@@ -81,5 +81,12 @@ class FilterTopo(DriverTimeInvariant):
         """
         return STR.filtertopo
 
+    @property
+    def output(self) -> dict[str, list[Path]]:
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        return {"outputs": [Path("foo")]}
+
 
 set_driver_docstring(FilterTopo)

--- a/src/uwtools/drivers/orog.py
+++ b/src/uwtools/drivers/orog.py
@@ -113,7 +113,7 @@ class Orog(DriverTimeInvariant):
         """
         Returns a description of the file(s) created when this component runs.
         """
-        return {"output": self.rundir / "out.oro.nc"}
+        return {"path": self.rundir / "out.oro.nc"}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/orog.py
+++ b/src/uwtools/drivers/orog.py
@@ -108,6 +108,13 @@ class Orog(DriverTimeInvariant):
         """
         return STR.orog
 
+    @property
+    def output(self) -> dict[str, list[Path]]:
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        return {"outputs": [Path("foo")]}
+
     # Private helper methods
 
     @property

--- a/src/uwtools/drivers/orog.py
+++ b/src/uwtools/drivers/orog.py
@@ -109,11 +109,11 @@ class Orog(DriverTimeInvariant):
         return STR.orog
 
     @property
-    def output(self) -> dict[str, list[Path]]:
+    def output(self) -> dict[str, Path]:
         """
         Returns a description of the file(s) created when this component runs.
         """
-        return {"outputs": [Path("foo")]}
+        return {"output": self.rundir / "out.oro.nc"}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -94,6 +94,13 @@ class OrogGSL(DriverTimeInvariant):
         """
         return STR.oroggsl
 
+    @property
+    def output(self) -> dict[str, list[Path]]:
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        return {"outputs": [Path("foo")]}
+
     # Private helper methods
 
     @property

--- a/src/uwtools/drivers/orog_gsl.py
+++ b/src/uwtools/drivers/orog_gsl.py
@@ -95,11 +95,14 @@ class OrogGSL(DriverTimeInvariant):
         return STR.oroggsl
 
     @property
-    def output(self) -> dict[str, list[Path]]:
+    def output(self) -> dict[str, Path]:
         """
         Returns a description of the file(s) created when this component runs.
         """
-        return {"outputs": [Path("foo")]}
+        vals = tuple(self.config["config"][k] for k in ["resolution", "tile", "halo"])
+        template = "C%s_oro_data_{x}.tile%s.halo%s.nc" % vals
+        outfile = lambda x: self.rundir / template.format(x=x)
+        return {"ls": outfile("ls"), "ss": outfile("ss")}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -2,6 +2,7 @@
 A driver for sfc_climo_gen.
 """
 
+import re
 from pathlib import Path
 
 from iotaa import asset, task, tasks
@@ -51,6 +52,16 @@ class SfcClimoGen(DriverTimeInvariant):
             self.namelist_file(),
             self.runscript(),
         ]
+
+    @property
+    def output(self) -> dict[str, Path]:
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        cfg = self.config["namelist"]["update_values"]["config"]
+        n = cfg["halo"]
+        keys = [m[1] for key in cfg if (m := re.match(r"^input_(.*)_file$", key))]
+        return {key: self.rundir / f"{key}.tile7.halo{n}.nc" for key in keys}
 
     # Public helper methods
 

--- a/src/uwtools/drivers/sfc_climo_gen.py
+++ b/src/uwtools/drivers/sfc_climo_gen.py
@@ -54,14 +54,15 @@ class SfcClimoGen(DriverTimeInvariant):
         ]
 
     @property
-    def output(self) -> dict[str, Path]:
+    def output(self) -> dict[str, list[Path]]:
         """
         Returns a description of the file(s) created when this component runs.
         """
         cfg = self.config["namelist"]["update_values"]["config"]
-        n = cfg["halo"]
+        halo = cfg.get("halo")
+        ns = [0, halo] if halo else [0]
         keys = [m[1] for key in cfg if (m := re.match(r"^input_(.*)_file$", key))]
-        return {key: self.rundir / f"{key}.tile7.halo{n}.nc" for key in keys}
+        return {key: [self.rundir / f"{key}.tile7.halo{n}.nc" for n in ns] for key in keys}
 
     # Public helper methods
 

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -63,7 +63,7 @@ class Shave(DriverTimeInvariant):
         """
         Returns a description of the file(s) created when this component runs.
         """
-        return {"output": Path(self.config["config"]["output_grid_file"])}
+        return {"path": Path(self.config["config"]["output_grid_file"])}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -60,7 +60,10 @@ class Shave(DriverTimeInvariant):
 
     @property
     def output(self) -> dict[str, Path]:
-        return {"shaved": Path(self.config["config"]["output_grid_file"])}
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        return {"output": Path(self.config["config"]["output_grid_file"])}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -58,6 +58,10 @@ class Shave(DriverTimeInvariant):
         """
         return STR.shave
 
+    @property
+    def output(self) -> dict[str, list[Path]]:
+        return {"foo": [Path("bar")]}
+
     # Private helper methods
 
     @property

--- a/src/uwtools/drivers/shave.py
+++ b/src/uwtools/drivers/shave.py
@@ -59,8 +59,8 @@ class Shave(DriverTimeInvariant):
         return STR.shave
 
     @property
-    def output(self) -> dict[str, list[Path]]:
-        return {"foo": [Path("bar")]}
+    def output(self) -> dict[str, Path]:
+        return {"shaved": Path(self.config["config"]["output_grid_file"])}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -100,7 +100,7 @@ class UPP(DriverCycleLeadtimeBased):
         return STR.upp
 
     @property
-    def output(self) -> dict[str, list[str]]:
+    def output(self) -> dict[str, list[Path]]:
         """
         Returns a description of the file(s) created when this component runs.
         """
@@ -119,7 +119,7 @@ class UPP(DriverCycleLeadtimeBased):
         paths = []
         for _ in range(nblocks):
             identifier = lines[0]
-            paths.append(str(self.rundir / (identifier + suffix)))
+            paths.append(self.rundir / (identifier + suffix))
             fields, lines = lines[: self.NFIELDS], lines[self.NFIELDS :]
             _, lines = (
                 (lines[0], lines[1:])

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -127,7 +127,7 @@ class UPP(DriverCycleLeadtimeBased):
                 else (None, lines)
             )
             lines = lines[self.NPARAMS * nvars.pop() :]
-        return {"outputs": paths}
+        return {"paths": paths}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/upp.py
+++ b/src/uwtools/drivers/upp.py
@@ -127,7 +127,7 @@ class UPP(DriverCycleLeadtimeBased):
                 else (None, lines)
             )
             lines = lines[self.NPARAMS * nvars.pop() :]
-        return {"gribfiles": paths}
+        return {"outputs": paths}
 
     # Private helper methods
 

--- a/src/uwtools/tests/drivers/test_chgres_cube.py
+++ b/src/uwtools/tests/drivers/test_chgres_cube.py
@@ -138,9 +138,10 @@ def test_ChgresCube_namelist_file_missing_base_file(driverobj, logged):
 
 
 def test_ChgresCube_output(driverobj):
-    files = ["out.atm.tile7.nc", "out.sfc.tile7.nc"]
-    expected = {"netcdffiles": [str(driverobj.rundir / file) for file in files]}
-    assert driverobj.output == expected
+    assert driverobj.output == {
+        "atm": driverobj.rundir / "out.atm.tile7.nc",
+        "sfc": driverobj.rundir / "out.sfc.tile7.nc",
+    }
 
 
 def test_ChgresCube_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_chgres_cube.py
+++ b/src/uwtools/tests/drivers/test_chgres_cube.py
@@ -139,8 +139,8 @@ def test_ChgresCube_namelist_file_missing_base_file(driverobj, logged):
 
 def test_ChgresCube_output(driverobj):
     assert driverobj.output == {
-        "atm": driverobj.rundir / "out.atm.tile7.nc",
-        "sfc": driverobj.rundir / "out.sfc.tile7.nc",
+        "atm": [driverobj.rundir / "out.atm.tile7.nc"],
+        "sfc": [driverobj.rundir / "out.sfc.tile7.nc"],
     }
 
 

--- a/src/uwtools/tests/drivers/test_filter_topo.py
+++ b/src/uwtools/tests/drivers/test_filter_topo.py
@@ -6,12 +6,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import f90nml  # type: ignore[import-untyped]
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.config.support import from_od
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.filter_topo import FilterTopo
-from uwtools.exceptions import UWNotImplementedError
 
 # Fixtures
 
@@ -73,7 +72,6 @@ def driverobj(config):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "runscript",
         "taskname",
@@ -109,9 +107,7 @@ def test_FilterTopo_namelist_file(driverobj):
 
 
 def test_FilterTopo_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    pass
 
 
 def test_FilterTopo_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_filter_topo.py
+++ b/src/uwtools/tests/drivers/test_filter_topo.py
@@ -107,7 +107,9 @@ def test_FilterTopo_namelist_file(driverobj):
 
 
 def test_FilterTopo_output(driverobj):
-    pass
+    assert driverobj.output == {
+        "path": driverobj.rundir / driverobj.config["config"]["filtered_orog"]
+    }
 
 
 def test_FilterTopo_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_orog.py
+++ b/src/uwtools/tests/drivers/test_orog.py
@@ -138,7 +138,7 @@ def test_Orog_input_config_file_old(driverobj):
 
 
 def test_Orog_output(driverobj):
-    pass
+    assert driverobj.output == {"output": driverobj.rundir / "out.oro.nc"}
 
 
 def test_Orog_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_orog.py
+++ b/src/uwtools/tests/drivers/test_orog.py
@@ -138,7 +138,7 @@ def test_Orog_input_config_file_old(driverobj):
 
 
 def test_Orog_output(driverobj):
-    assert driverobj.output == {"output": driverobj.rundir / "out.oro.nc"}
+    assert driverobj.output == {"path": driverobj.rundir / "out.oro.nc"}
 
 
 def test_Orog_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_orog.py
+++ b/src/uwtools/tests/drivers/test_orog.py
@@ -5,11 +5,10 @@ Orog driver tests.
 from pathlib import Path
 from unittest.mock import patch
 
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.orog import Orog
-from uwtools.exceptions import UWNotImplementedError
 from uwtools.scheduler import Slurm
 
 # Fixtures
@@ -73,7 +72,6 @@ def driverobj(config):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "taskname",
     ],
@@ -140,9 +138,7 @@ def test_Orog_input_config_file_old(driverobj):
 
 
 def test_Orog_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    pass
 
 
 def test_Orog_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_orog_gsl.py
+++ b/src/uwtools/tests/drivers/test_orog_gsl.py
@@ -5,11 +5,10 @@ orog_gsl driver tests.
 from pathlib import Path
 from unittest.mock import patch
 
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.orog_gsl import OrogGSL
-from uwtools.exceptions import UWNotImplementedError
 
 # Fixtures
 
@@ -63,7 +62,6 @@ def driverobj(config):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "runscript",
         "taskname",
@@ -93,9 +91,7 @@ def test_OrogGSL_input_grid_file(driverobj):
 
 
 def test_OrogGSL_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    pass
 
 
 def test_OrogGSL_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_orog_gsl.py
+++ b/src/uwtools/tests/drivers/test_orog_gsl.py
@@ -91,7 +91,8 @@ def test_OrogGSL_input_grid_file(driverobj):
 
 
 def test_OrogGSL_output(driverobj):
-    pass
+    outfile = lambda x: driverobj.rundir / f"C403_oro_data_{x}.tile7.halo4.nc"
+    assert driverobj.output == {"ls": outfile("ls"), "ss": outfile("ss")}
 
 
 def test_OrogGSL_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -115,7 +115,9 @@ def test_SfcClimoGen_namelist_file_fails_validation(driverobj, logged, ready_tas
     assert logged("  'string' is not of type 'integer'")
 
 
-def test_SfcClimoGen_output(driverobj):
+@mark.parametrize("halo", [1, None])
+def test_SfcClimoGen_output(driverobj, halo):
+    driverobj._config["namelist"]["update_values"]["config"]["halo"] = halo
     keys = [
         "facsf",
         "maximum_snow_albedo",
@@ -126,8 +128,10 @@ def test_SfcClimoGen_output(driverobj):
         "vegetation_greenness",
         "vegetation_type",
     ]
-    n = driverobj.config["namelist"]["update_values"]["config"]["halo"]
-    assert driverobj.output == {key: driverobj.rundir / f"{key}.tile7.halo{n}.nc" for key in keys}
+    ns = [0, halo] if halo else [0]
+    assert driverobj.output == {
+        key: [driverobj.rundir / f"{key}.tile7.halo{n}.nc" for n in ns] for key in keys
+    }
 
 
 def test_SfcClimoGen_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -6,12 +6,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import f90nml  # type: ignore[import-untyped]
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.drivers import sfc_climo_gen
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.sfc_climo_gen import SfcClimoGen
-from uwtools.exceptions import UWNotImplementedError
 
 # Fixtures
 
@@ -84,7 +83,6 @@ def driverobj(config):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "runscript",
         "taskname",
@@ -118,9 +116,18 @@ def test_SfcClimoGen_namelist_file_fails_validation(driverobj, logged, ready_tas
 
 
 def test_SfcClimoGen_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    keys = [
+        "facsf",
+        "maximum_snow_albedo",
+        "slope_type",
+        "snowfree_albedo",
+        "soil_type",
+        "substrate_temperature",
+        "vegetation_greenness",
+        "vegetation_type",
+    ]
+    n = driverobj.config["namelist"]["update_values"]["config"]["halo"]
+    assert driverobj.output == {key: driverobj.rundir / f"{key}.tile7.halo{n}.nc" for key in keys}
 
 
 def test_SfcClimoGen_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -89,7 +89,7 @@ def test_Shave_input_config_file(driverobj):
 
 
 def test_Shave_output(driverobj):
-    assert driverobj.output == {"shaved": Path(driverobj.config["config"]["output_grid_file"])}
+    assert driverobj.output == {"output": Path(driverobj.config["config"]["output_grid_file"])}
 
 
 def test_Shave_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -5,11 +5,10 @@ Shave driver tests.
 from pathlib import Path
 from unittest.mock import patch
 
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.shave import Shave
-from uwtools.exceptions import UWNotImplementedError
 
 # Fixtures
 
@@ -63,7 +62,6 @@ def driverobj(config):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "runscript",
         "taskname",
@@ -91,9 +89,7 @@ def test_Shave_input_config_file(driverobj):
 
 
 def test_Shave_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    pass
 
 
 def test_Shave_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -89,7 +89,7 @@ def test_Shave_input_config_file(driverobj):
 
 
 def test_Shave_output(driverobj):
-    assert driverobj.output == {"output": Path(driverobj.config["config"]["output_grid_file"])}
+    assert driverobj.output == {"path": Path(driverobj.config["config"]["output_grid_file"])}
 
 
 def test_Shave_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -81,7 +81,7 @@ def test_Shave_input_config_file(driverobj):
     nhalo = driverobj.config["config"]["nhalo"]
     input_file_path = driverobj._config["config"]["input_grid_file"]
     Path(input_file_path).touch()
-    output_file_path = driverobj._config["config"]["output_grid_file"]
+    output_file_path = driverobj.config["config"]["output_grid_file"]
     driverobj.input_config_file()
     content = Path(driverobj._input_config_path).read_text().strip().split("\n")
     assert len(content) == 1
@@ -89,7 +89,7 @@ def test_Shave_input_config_file(driverobj):
 
 
 def test_Shave_output(driverobj):
-    pass
+    assert driverobj.output == {"shaved": Path(driverobj.config["config"]["output_grid_file"])}
 
 
 def test_Shave_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_upp.py
+++ b/src/uwtools/tests/drivers/test_upp.py
@@ -171,7 +171,7 @@ def test_UPP_output(driverobj, tmp_path):
     control_file = tmp_path / "postxconfig-NT.txt"
     control_file.write_text("\n".join(control_data))
     driverobj._config["control_file"] = str(control_file)
-    expected = {"gribfiles": [str(driverobj.rundir / ("%s.GrbF24" % x)) for x in ("FOO", "BAR")]}
+    expected = {"gribfiles": [driverobj.rundir / ("%s.GrbF24" % x) for x in ("FOO", "BAR")]}
     assert driverobj.output == expected
 
 

--- a/src/uwtools/tests/drivers/test_upp.py
+++ b/src/uwtools/tests/drivers/test_upp.py
@@ -171,7 +171,7 @@ def test_UPP_output(driverobj, tmp_path):
     control_file = tmp_path / "postxconfig-NT.txt"
     control_file.write_text("\n".join(control_data))
     driverobj._config["control_file"] = str(control_file)
-    expected = {"gribfiles": [driverobj.rundir / ("%s.GrbF24" % x) for x in ("FOO", "BAR")]}
+    expected = {"outputs": [driverobj.rundir / ("%s.GrbF24" % x) for x in ("FOO", "BAR")]}
     assert driverobj.output == expected
 
 

--- a/src/uwtools/tests/drivers/test_upp.py
+++ b/src/uwtools/tests/drivers/test_upp.py
@@ -171,7 +171,7 @@ def test_UPP_output(driverobj, tmp_path):
     control_file = tmp_path / "postxconfig-NT.txt"
     control_file.write_text("\n".join(control_data))
     driverobj._config["control_file"] = str(control_file)
-    expected = {"outputs": [driverobj.rundir / ("%s.GrbF24" % x) for x in ("FOO", "BAR")]}
+    expected = {"paths": [driverobj.rundir / ("%s.GrbF24" % x) for x in ("FOO", "BAR")]}
     assert driverobj.output == expected
 
 


### PR DESCRIPTION
**Synopsis**

Implement `.output` property methods in `filter_topo`, `orog`, `orog_gsl`, `sfc_climo_gen`, and `shave` drivers.

Fixes #633 #634 #635 

**Type**

- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
