### PR TITLE
Implement output() methods on driver classes Ungrib and MPASInit

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ extlinks = {
     "ufs-weather-model": ("https://github.com/ufs-community/ufs-weather-model/%s", "%s"),
     "uwtools": ("https://github.com/ufs-community/uwtools/%s", "%s"),
     "weather-model-io": ("https://ufs-weather-model.readthedocs.io/en/latest/InputsOutputs.html#%s", "%s"),
+    "wps": ("https://www2.mmm.ucar.edu/wrf/users/wrf_users_guide/build/html/wps.html#%s", "%s"),
     "ww3": ("https://polar.ncep.noaa.gov/waves/wavewatch/%s", "%s"),
 }
 

--- a/docs/sections/user_guide/cli/drivers/ungrib/index.rst
+++ b/docs/sections/user_guide/cli/drivers/ungrib/index.rst
@@ -3,7 +3,7 @@
 
 .. include:: ../shared/idempotent.rst
 
-The ``uw`` mode for configuring and running the WRF preprocessing component ``ungrib``.
+The ``uw`` mode for configuring and running the WRF preprocessing component ``ungrib``. Documentation for this component is :wps:`here <program-ungrib>`.
 
 .. include:: help.rst
 

--- a/docs/sections/user_guide/yaml/components/ungrib.rst
+++ b/docs/sections/user_guide/yaml/components/ungrib.rst
@@ -3,7 +3,7 @@
 ungrib
 ======
 
-Structured YAML to run the WRF preprocessing component ``ungrib`` is validated by JSON Schema and requires the ``ungrib:`` block, described below. If ``ungrib`` is to be run via a batch system, the ``platform:`` block, described :ref:`here <platform_yaml>`, is also required.
+Structured YAML to run the WRF preprocessing component ``ungrib`` (:wps:`documentation <program-ungrib>`) is validated by JSON Schema and requires the ``ungrib:`` block, described below. If ``ungrib`` is to be run via a batch system, the ``platform:`` block, described :ref:`here <platform_yaml>`, is also required.
 
 .. include:: /shared/injected_cycle.rst
 

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -81,10 +81,10 @@ class MPASBase(DriverCycleBased):
                 stream.set(attr, v[attr])
             for attr in [
                 "clobber_mode",
+                "filename_interval",
                 "input_interval",
                 "io_type",
                 "output_interval",
-                "filename_interval",
                 "packages",
                 "precision",
                 "reference_time",

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -132,11 +132,11 @@ class MPASInit(MPASBase):
 
     @staticmethod
     def _decode_interval(interval: str) -> dict[str, int]:
-        # See MPAS User Guide section 5 for a description of the interval format and semantics, but
-        # the general form is years-months-days_hours:minutes:seconds, e.g. 1-2-3_4:5:6 means 1
-        # year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds. Leading components can be omitted,
-        # so reverse for an ascending seconds -> years order, pad with trailing zeros as needed,
-        # then reverse again for a natural descending years -> seconds order.
+        # See MPAS User Guide section 5 in re: interval format and semantics, but the general form
+        # is years-months-days_hours:minutes:seconds, e.g. 1-2-3_4:5:6 means 1 year, 2 months, 3
+        # days, 4 hours, 5 minutes, 6 seconds. Leading components can be omitted, so reverse for an
+        # ascending seconds -> years order, pad with trailing zeros as needed, then reverse again
+        # for a natural descending years -> seconds order.
         keys = ["years", "months", "days", "hours", "minutes", "seconds"]
         components = re.sub(r"[-_:]", " ", interval).split()[::-1]
         vals = [next(islice(components, i, i + 1), 0) for i in range(len(keys))][::-1]
@@ -158,7 +158,7 @@ class MPASInit(MPASBase):
     def _filename_interval_timestamps(
         self, interval: str, reference_time: str | None
     ) -> list[datetime]:
-        # See MPAS User Guide sections 5.2 and 5.3.3 for info on the semantics of reference_time.
+        # See MPAS User Guide sections 5.2 and 5.3.3 in re: the semantics of reference_time.
         # First, create a timestamp for each expected output file, per the timestamp-pattern value
         # of filename_interval. By default, the first timestamp will match the model start time, but
         # reference_time, if present, shifts it to a different time. In this case, the number of

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -109,13 +109,13 @@ class MPASInit(MPASBase):
                 continue
             filename_interval = self._filename_interval(stream)
             if filename_interval == "none":
-                paths.append(self._path(stream))
+                paths.append(self._path(stream, self._cycle))
             elif filename_interval == "output_interval":
                 interval = stream["output_interval"]
                 if interval == "none":
                     continue  # stream will not be written
                 if interval == "initial_only":
-                    paths.append(self._path(stream))
+                    paths.append(self._path(stream, self._cycle))
                 else:
                     decoded = self._decode_interval(interval)
                     assert decoded
@@ -149,7 +149,7 @@ class MPASInit(MPASBase):
         final = initial + timedelta(hours=self.config["boundary_conditions"]["length"])
         return initial, final
 
-    def _path(self, stream: dict) -> Path:
+    def _path(self, stream: dict, dtobj: datetime) -> Path:
         # See MPAS User Guide section 5.1 in re: filename_template logic.
         kvs = [
             ("$Y", "%Y"),
@@ -161,7 +161,7 @@ class MPASInit(MPASBase):
             ("$s", "%S"),
         ]
         template = reduce(lambda m, e: m.replace(e[0], e[1]), kvs, stream["filename_template"])
-        return self.rundir / self._cycle.strftime(template)
+        return self.rundir / dtobj.strftime(template)
 
     @property
     def _streams_fn(self) -> str:

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -112,10 +112,10 @@ class MPASInit(MPASBase):
                 paths.append(self._path(stream, self._cycle))
             elif filename_interval == "output_interval":
                 interval = stream["output_interval"]
-                if interval == "none":
-                    continue  # stream will not be written
                 if interval == "initial_only":
                     paths.append(self._path(stream, self._cycle))
+                elif interval == "none":
+                    continue  # stream will not be written
                 else:
                     decoded = self._decode_interval(interval)
                     assert decoded

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -159,10 +159,9 @@ class MPASInit(MPASBase):
         self, interval: str, reference_time: str | None
     ) -> list[datetime]:
         # See MPAS User Guide sections 5.2 and 5.3.3 for info on the semantics of reference_time.
-        # The idea here is to create a set of timestamps corresponding to the output filenames as
-        # defined by the filename_interval value when it is a timestamp pattern. By default, the
-        # first timestamp will correspond to the start time of the model, but reference_time can be
-        # provided to move the first timestamp to a different time, in which case the number of
+        # First, create a timestamp for each expected output file, per the timestamp-pattern value
+        # of filename_interval. By default, the first timestamp will match the model start time, but
+        # reference_time, if present, shifts it to a different time. In this case, the number of
         # output files does not change, but their timestamps and contents do.
         tss = self._interval_timestamps(interval)
         if reference_time:

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -125,9 +125,9 @@ class MPASInit(MPASBase):
             if filename_interval == "none":
                 paths.append(path(self._cycle))
             elif filename_interval == "output_interval":
-                bcs = cfg["boundary_conditions"]
-                initial_ts, final_ts = self._initial_and_final_ts
-                td, ts, tss = timedelta(hours=bcs["interval_hours"]), initial_ts, []
+                td = timedelta(hours=cfg["boundary_conditions"]["interval_hours"])
+                tss = []
+                ts, final_ts = self._initial_and_final_ts
                 while ts <= final_ts:
                     tss.append(ts)
                     ts += td

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -112,20 +112,20 @@ class MPASInit(MPASBase):
             filename_interval = self._filename_interval(stream)
             template = stream["filename_template"]
             if filename_interval == "none":
-                paths.append(self._path(template, self._cycle))
+                paths.append(self._output_path(template, self._cycle))
             elif filename_interval in ("input_interval", "output_interval"):
                 interval = stream[filename_interval]
                 if interval == "none":
                     continue  # stream will not be written
                 if interval == "initial_only":
-                    paths.append(self._path(template, self._cycle))
+                    paths.append(self._output_path(template, self._cycle))
                 else:  # interval is a timestamp
                     tss = self._interval_timestamps(interval)
-                    paths.extend(self._path(template, ts) for ts in tss)
+                    paths.extend(self._output_path(template, ts) for ts in tss)
             else:  # filename_interval is a timestamp
                 reference_time = stream.get("reference_time")
                 tss = self._filename_interval_timestamps(filename_interval, reference_time)
-                paths.extend(self._path(template, ts) for ts in tss)
+                paths.extend(self._output_path(template, ts) for ts in tss)
         return {"paths": sorted(set(paths))}
 
     # Private helper methods
@@ -187,7 +187,7 @@ class MPASInit(MPASBase):
             ts = ts + delta
         return tss
 
-    def _path(self, template: str, dtobj: datetime) -> Path:
+    def _output_path(self, template: str, dtobj: datetime) -> Path:
         # See MPAS User Guide section 5.1 in re: filename_template logic.
         kvs = [
             ("$Y", "%Y"),

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -139,8 +139,8 @@ class MPASInit(MPASBase):
         # then reverse again for a natural descending years -> seconds order.
         keys = ["years", "months", "days", "hours", "minutes", "seconds"]
         components = re.sub(r"[-_:]", " ", interval).split()[::-1]
-        vals = [int(x) for x in (next(islice(components, i, i + 1), 0) for i in range(6))][::-1]
-        return dict(zip(keys, vals))
+        vals = [next(islice(components, i, i + 1), 0) for i in range(len(keys))][::-1]
+        return dict(zip(keys, map(int, vals)))
 
     @staticmethod
     def _decode_timestamp(timestamp: str) -> datetime:

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -144,6 +144,7 @@ class MPASInit(MPASBase):
     @staticmethod
     def _filename_interval(stream: dict) -> str:
         # See MPAS User Guide section 5.2 in re: filename_interval logic.
+        assert stream["type"] in ("output", "input;output")
         filename_interval = "output_interval"
         if stream["type"] == "input;output" and stream["input_interval"] != "initial_only":
             filename_interval = "input_interval"

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -120,10 +120,10 @@ class MPASInit(MPASBase):
             template = reduce(lambda m, e: m.replace(e[0], e[1]), kvs, stream["filename_template"])
             path = lambda ts: self.rundir / ts.strftime(template)  # noqa: B023
             # See MPAS User Guide section 5.2 in re: filename_interval logic.
-            default_filename_interval = "output_interval"
+            filename_interval = "output_interval"
             if stream["type"] == "input;output" and stream["input_interval"] != "initial_only":
-                default_filename_interval = "input_interval"
-            filename_interval = stream.get("filename_interval", default_filename_interval)
+                filename_interval = "input_interval"
+            filename_interval = stream.get("filename_interval", filename_interval)
             if filename_interval == "none":
                 paths.append(path(self._cycle))
             elif filename_interval == "output_interval":

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -107,10 +107,10 @@ class MPASInit(MPASBase):
         """
         paths = []
         for stream in self.config["streams"].values():
-            template = stream["filename_template"]
             if stream["type"] not in ("output", "input;output"):
                 continue
             filename_interval = self._filename_interval(stream)
+            template = stream["filename_template"]
             if filename_interval == "none":
                 paths.append(self._path(template, self._cycle))
             elif filename_interval in ("input_interval", "output_interval"):

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -108,7 +108,7 @@ class MPASInit(MPASBase):
             ("$m", "%M"),
             ("$s", "%S"),
         ]:
-            template.replace(k, v)
+            template = template.replace(k, v)
         return {"path": self.rundir / self._cycle.strftime(template)}
 
     # Private helper methods

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -119,16 +119,12 @@ class MPASInit(MPASBase):
                 if interval == "initial_only":
                     paths.append(self._path(stream, self._cycle))
                 else:  # interval is a timestamp
-                    paths.extend(
-                        self._path(stream, ts) for ts in self._interval_timestamps(interval)
-                    )
+                    tss = self._interval_timestamps(interval)
+                    paths.extend(self._path(stream, ts) for ts in tss)
             else:  # filename_interval is a timestamp
-                paths.extend(
-                    self._path(stream, ts)
-                    for ts in self._filename_interval_timestamps(
-                        filename_interval, stream.get("reference_time")
-                    )
-                )
+                reference_time = stream.get("reference_time")
+                tss = self._filename_interval_timestamps(filename_interval, reference_time)
+                paths.extend(self._path(stream, ts) for ts in tss)
         return {"paths": sorted(set(paths))}
 
     # Private helper methods

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -98,7 +98,6 @@ class MPASInit(MPASBase):
         """
         return STR.mpasinit
 
-    # ruff: noqa: ERA001
     @property
     def output(self) -> dict[str, list[Path]]:
         """

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -132,10 +132,14 @@ class MPASInit(MPASBase):
 
     @staticmethod
     def _decode_interval(interval: str) -> dict[str, int]:
-        val = lambda x: int(x) if x else 0
-        parts = re.sub(r"[-_:]", " ", interval).split()[::-1]
+        # See MPAS User Guide section 5 for a description of the interval format and semantics, but
+        # the general form is years-months-days_hours:minutes:seconds, e.g. 1-2-3_4:5:6 means 1
+        # year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds. Leading components can be omitted,
+        # so reverse for an ascending seconds -> years order, pad with trailing zeros as needed,
+        # then reverse again for a natural descending years -> seconds order.
         keys = ["years", "months", "days", "hours", "minutes", "seconds"]
-        vals = [val(x) for x in (next(islice(parts, i, i + 1), None) for i in range(6))][::-1]
+        components = re.sub(r"[-_:]", " ", interval).split()[::-1]
+        vals = [int(x) for x in (next(islice(components, i, i + 1), 0) for i in range(6))][::-1]
         return dict(zip(keys, vals))
 
     @staticmethod

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -120,13 +120,12 @@ class MPASInit(MPASBase):
                     tss = self._interval_timestamps(interval)
                     paths.extend(self._path(stream, ts) for ts in tss)
             else:  # filename_interval is a timestamp
-                """
-                reference_ts = ( _self._decode_timestamp(stream["reference_time"]) if
-                "reference_time" in stream.
-
-                else initial_ts )
-                """
-                raise NotImplementedError(3)
+                tss = self._interval_timestamps(filename_interval)
+                if reference_time := stream.get("reference_time"):
+                    initial_ts, _ = self._initial_and_final_ts
+                    delta = initial_ts - self._decode_timestamp(reference_time)
+                    tss = [ts - delta for ts in tss]
+                paths.extend(self._path(stream, ts) for ts in tss)
         return {"paths": sorted(set(paths))}
 
     # Private helper methods
@@ -153,7 +152,7 @@ class MPASInit(MPASBase):
 
     @property
     def _initial_and_final_ts(self) -> tuple[datetime, datetime]:
-        initial = self._cycle
+        initial = self._cycle.replace(tzinfo=timezone.utc)
         final = initial + timedelta(hours=self.config["boundary_conditions"]["length"])
         return initial, final
 

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -110,21 +110,19 @@ class MPASInit(MPASBase):
             filename_interval = self._filename_interval(stream)
             if filename_interval == "none":
                 paths.append(self._path(stream, self._cycle))
-            elif filename_interval == "output_interval":
-                interval = stream["output_interval"]
+            elif filename_interval in ("input_interval", "output_interval"):
+                interval = stream[filename_interval]
                 if interval == "none":
                     continue  # stream will not be written
                 if interval == "initial_only":
                     paths.append(self._path(stream, self._cycle))
-                else:  # output_interval is a timestamp
+                else:  # interval is a timestamp
                     kwargs = self._decode_interval(interval)
                     delta = relativedelta(**kwargs)  # type: ignore[arg-type]
                     ts, final_ts = self._initial_and_final_ts
                     while ts <= final_ts:
                         paths.append(self._path(stream, ts))
                         ts = ts + delta
-            elif filename_interval == "input_interval":
-                raise NotImplementedError(2)
             else:  # filename_interval is a timestamp
                 """
                 reference_ts = ( _self._decode_timestamp(stream["reference_time"]) if

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -158,6 +158,12 @@ class MPASInit(MPASBase):
     def _filename_interval_timestamps(
         self, interval: str, reference_time: str | None
     ) -> list[datetime]:
+        # See MPAS User Guide sections 5.2 and 5.3.3 for info on the semantics of reference_time.
+        # The idea here is to create a set of timestamps corresponding to the output filenames as
+        # defined by the filename_interval value when it is a timestamp pattern. By default, the
+        # first timestamp will correspond to the start time of the model, but reference_time can be
+        # provided to move the first timestamp to a different time, in which case the number of
+        # output files does not change, but their timestamps and contents do.
         tss = self._interval_timestamps(interval)
         if reference_time:
             initial_ts, _ = self._initial_and_final_ts

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -94,22 +94,25 @@ class MPASInit(MPASBase):
         return STR.mpasinit
 
     @property
-    def output(self) -> dict[str, Path]:
+    def output(self) -> dict[str, list[Path]]:
         """
         Returns a description of the file(s) created when this component runs.
         """
-        template = self.config["streams"]["output"]["filename_template"]
-        for k, v in [
-            ("$Y", "%Y"),
-            ("$M", "%m"),
-            ("$D", "%d"),
-            ("$d", "%j"),
-            ("$h", "%H"),
-            ("$m", "%M"),
-            ("$s", "%S"),
-        ]:
-            template = template.replace(k, v)
-        return {"path": self.rundir / self._cycle.strftime(template)}
+        paths = []
+        for stream in [x for x in self.config["streams"].values() if x["type"] == "output"]:
+            template = stream["filename_template"]
+            for k, v in [
+                ("$Y", "%Y"),
+                ("$M", "%m"),
+                ("$D", "%d"),
+                ("$d", "%j"),
+                ("$h", "%H"),
+                ("$m", "%M"),
+                ("$s", "%S"),
+            ]:
+                template = template.replace(k, v)
+            paths.append(self.rundir / self._cycle.strftime(template))
+        return {"paths": paths}
 
     # Private helper methods
 

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -93,6 +93,24 @@ class MPASInit(MPASBase):
         """
         return STR.mpasinit
 
+    @property
+    def output(self) -> dict[str, Path]:
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        template = self.config["streams"]["output"]["filename_template"]
+        for k, v in [
+            ("$Y", "%Y"),
+            ("$M", "%m"),
+            ("$D", "%d"),
+            ("$d", "%j"),
+            ("$h", "%H"),
+            ("$m", "%M"),
+            ("$s", "%S"),
+        ]:
+            template.replace(k, v)
+        return {"path": self.rundir / self._cycle.strftime(template)}
+
     # Private helper methods
 
     @property

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -127,7 +127,7 @@ class MPASInit(MPASBase):
             elif filename_interval == "output_interval":
                 bcs = cfg["boundary_conditions"]
                 initial_ts, final_ts = self._initial_and_final_ts
-                ts, tss, td = initial_ts, [], timedelta(hours=bcs["interval_hours"])
+                td, ts, tss = timedelta(hours=bcs["interval_hours"]), initial_ts, []
                 while ts <= final_ts:
                     tss.append(ts)
                     ts += td

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -2,7 +2,7 @@
 A driver for the ungrib component.
 """
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 from pathlib import Path
 
 from iotaa import asset, task, tasks
@@ -46,16 +46,11 @@ class Ungrib(DriverCycleBased):
         """
         The namelist file.
         """
-        # Do not use offset here. It's relative to the MPAS fcst to run.
-        gribfiles = self.config["gribfiles"]
-        endhour = gribfiles["max_leadtime"]
-        end_date = self._cycle + timedelta(hours=endhour)
-        interval = int(gribfiles["interval_hours"]) * 3600  # hour to sec
         d = {
             "update_values": {
                 "share": {
-                    "end_date": end_date.strftime("%Y-%m-%d_%H:00:00"),
-                    "interval_seconds": interval,
+                    "end_date": self._end_date.strftime("%Y-%m-%d_%H:00:00"),
+                    "interval_seconds": self._interval,
                     "max_dom": 1,
                     "start_date": self._cycle.strftime("%Y-%m-%d_%H:00:00"),
                     "wrf_core": "ARW",
@@ -111,7 +106,19 @@ class Ungrib(DriverCycleBased):
         """
         return STR.ungrib
 
+    @property
+    def output(self) -> dict[str, Path]:
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        return {"path": Path(self.config["config"]["output_grid_file"])}
+
     # Private helper methods
+
+    @property
+    def _end_date(self) -> datetime:
+        endhour = self.config["gribfiles"]["max_leadtime"]
+        return self._cycle + timedelta(hours=endhour)
 
     @task
     def _gribfile(self, infile: Path, link: Path):
@@ -126,6 +133,10 @@ class Ungrib(DriverCycleBased):
         yield file(path=infile)
         link.parent.mkdir(parents=True, exist_ok=True)
         link.symlink_to(infile)
+
+    @property
+    def _interval(self) -> int:
+        return int(self.config["gribfiles"]["interval_hours"]) * 3600
 
 
 def _ext(n: int) -> str:

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -2,7 +2,7 @@
 A driver for the ungrib component.
 """
 
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from iotaa import asset, task, tasks

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -286,16 +286,21 @@ def test_MPASInit_streams_file(config, driverobj):
     streams_file(config, driverobj, "mpas_init")
 
 
-def test_MPASInit__decode_interval():
+@mark.parametrize(
+    ("interval", "vals"),
+    [
+        ("1-2-3_04:05:06", [1, 2, 3, 4, 5, 6]),
+        ("1-2-3_4:5:6", [1, 2, 3, 4, 5, 6]),
+        ("2-3_4:5:6", [0, 2, 3, 4, 5, 6]),
+        ("3_4:5:6", [0, 0, 3, 4, 5, 6]),
+        ("4:5:6", [0, 0, 0, 4, 5, 6]),
+        ("5:6", [0, 0, 0, 0, 5, 6]),
+        ("6", [0, 0, 0, 0, 0, 6]),
+    ],
+)
+def test_MPASInit__decode_interval(interval, vals):
     keys = ("years", "months", "days", "hours", "minutes", "seconds")
-    expected = lambda vals: dict(zip(keys, vals))
-    assert MPASInit._decode_interval(interval="1-2-3_04:05:06") == expected([1, 2, 3, 4, 5, 6])
-    assert MPASInit._decode_interval(interval="1-2-3_4:5:6") == expected([1, 2, 3, 4, 5, 6])
-    assert MPASInit._decode_interval(interval="2-3_4:5:6") == expected([0, 2, 3, 4, 5, 6])
-    assert MPASInit._decode_interval(interval="3_4:5:6") == expected([0, 0, 3, 4, 5, 6])
-    assert MPASInit._decode_interval(interval="4:5:6") == expected([0, 0, 0, 4, 5, 6])
-    assert MPASInit._decode_interval(interval="5:6") == expected([0, 0, 0, 0, 5, 6])
-    assert MPASInit._decode_interval(interval="6") == expected([0, 0, 0, 0, 0, 6])
+    assert MPASInit._decode_interval(interval=interval) == dict(zip(keys, vals))
 
 
 def test_MPASInit__decode_timestamp():

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -352,5 +352,12 @@ def test_MPASInit__interval_timestamps(driverobj, dtargs, interval, length):
     assert driverobj._interval_timestamps(interval=interval) == expected
 
 
+def test_MPASInit__path(driverobj):
+    t = "out.$Y_$M_$D-$d-$h_$m_$s.nc"
+    d = datetime(2025, 5, 7, 1, 2, 3, tzinfo=timezone.utc)
+    expected = driverobj.rundir / "out.2025_05_07-127-01_02_03.nc"
+    assert driverobj._path(template=t, dtobj=d) == expected
+
+
 def test_MPASInit__streams_fn(driverobj):
     assert driverobj._streams_fn == "streams.init_atmosphere"

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -7,11 +7,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import f90nml  # type: ignore[import-untyped]
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.drivers.mpas_base import MPASBase
 from uwtools.drivers.mpas_init import MPASInit
-from uwtools.exceptions import UWNotImplementedError
 from uwtools.tests.drivers.test_mpas import streams_file
 from uwtools.tests.support import fixture_path
 
@@ -109,7 +108,6 @@ def driverobj(config, cycle):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "runscript",
         "streams_file",
@@ -196,9 +194,7 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
 
 
 def test_MPASInit_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    assert driverobj.output["path"] == driverobj.rundir / "conus.init.nc"
 
 
 def test_MPASInit_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -233,6 +233,35 @@ def test_MPASInit_output__filename_interval_output_interval_timestamp(driverobj,
     ]
 
 
+def test_MPASInit_output__filename_interval_timestamp(driverobj, outpath):
+    updates = {
+        "filename_interval": "1_00:00:00",
+        "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
+        "output_interval": "06:00:00",
+    }
+    driverobj._config["streams"]["output"].update(updates)
+    driverobj._config["boundary_conditions"].update({"interval_hours": 6, "length": 36})
+    assert driverobj.output["paths"] == [
+        outpath("2024-02-01_032_18-00-00.nc"),
+        outpath("2024-02-02_033_18-00-00.nc"),
+    ]
+
+
+def test_MPASInit_output__filename_interval_timestamp_reference_time(driverobj, outpath):
+    updates = {
+        "filename_interval": "1_00:00:00",
+        "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
+        "output_interval": "06:00:00",
+        "reference_time": "2024-02-01_00:00:00",
+    }
+    driverobj._config["streams"]["output"].update(updates)
+    driverobj._config["boundary_conditions"].update({"interval_hours": 6, "length": 36})
+    assert driverobj.output["paths"] == [
+        outpath("2024-02-01_032_00-00-00.nc"),
+        outpath("2024-02-02_033_00-00-00.nc"),
+    ]
+
+
 def test_MPASInit_output__non_output_stream(driverobj):
     driverobj._config["streams"]["output"].update({"type": "input"})
     assert driverobj.output["paths"] == []

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -286,5 +286,17 @@ def test_MPASInit_streams_file(config, driverobj):
     streams_file(config, driverobj, "mpas_init")
 
 
+def test_MPASInit__decode_interval():
+    keys = ("years", "months", "days", "hours", "minutes", "seconds")
+    expected = lambda vals: dict(zip(keys, vals))
+    assert MPASInit._decode_interval(interval="1-2-3_04:05:06") == expected([1, 2, 3, 4, 5, 6])
+    assert MPASInit._decode_interval(interval="1-2-3_4:5:6") == expected([1, 2, 3, 4, 5, 6])
+    assert MPASInit._decode_interval(interval="2-3_4:5:6") == expected([0, 2, 3, 4, 5, 6])
+    assert MPASInit._decode_interval(interval="3_4:5:6") == expected([0, 0, 3, 4, 5, 6])
+    assert MPASInit._decode_interval(interval="4:5:6") == expected([0, 0, 0, 4, 5, 6])
+    assert MPASInit._decode_interval(interval="5:6") == expected([0, 0, 0, 0, 5, 6])
+    assert MPASInit._decode_interval(interval="6") == expected([0, 0, 0, 0, 0, 6])
+
+
 def test_MPASInit__streams_fn(driverobj):
     assert driverobj._streams_fn == "streams.init_atmosphere"

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -339,5 +339,18 @@ def test_MPASInit__initial_and_final_ts(driverobj):
     assert driverobj._initial_and_final_ts == (initial, final)
 
 
+@mark.parametrize(
+    ("dtargs", "interval", "length"),
+    [
+        ([(2024, 2, 1, 18), (2024, 2, 2, 18), (2024, 2, 3, 18)], "1_00:00:00", 48),
+        ([(2024, 2, 1, 18), (2024, 2, 2, 6)], "12:00:00", 18),
+    ],
+)
+def test_MPASInit__interval_timestamps(driverobj, dtargs, interval, length):
+    driverobj._config["boundary_conditions"]["length"] = length
+    expected = [datetime(*args, tzinfo=timezone.utc) for args in dtargs]  # type: ignore[misc]
+    assert driverobj._interval_timestamps(interval=interval) == expected
+
+
 def test_MPASInit__streams_fn(driverobj):
     assert driverobj._streams_fn == "streams.init_atmosphere"

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -316,5 +316,22 @@ def test_MPASInit__filename_interval(expected, stream):
     assert MPASInit._filename_interval(stream) == expected
 
 
+@mark.parametrize(
+    ("dtargs", "interval", "reference_time"),
+    [
+        ([(2024, 2, 1), (2024, 2, 2)], "1_00:00:00", "2024-02-01_00:00:00"),
+        ([(2024, 2, 1, 18), (2024, 2, 2, 12), (2024, 2, 3, 6)], "18:00:00", None),
+        ([(2024, 2, 1, 18), (2024, 2, 2, 18)], "1_00:00:00", None),
+    ],
+)
+def test_MPASInit__filename_interval_timestamps(driverobj, dtargs, interval, reference_time):
+    driverobj._config["boundary_conditions"]["length"] = 36
+    expected = [datetime(*args, tzinfo=timezone.utc) for args in dtargs]  # type: ignore[misc]
+    assert (
+        driverobj._filename_interval_timestamps(interval=interval, reference_time=reference_time)
+        == expected
+    )
+
+
 def test_MPASInit__streams_fn(driverobj):
     assert driverobj._streams_fn == "streams.init_atmosphere"

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -200,20 +200,14 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
 
 def test_MPASInit_output__filename_interval_none(driverobj, outpath):
     driverobj._config["streams"]["output"].update(
-        {
-            "filename_interval": "none",
-            "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
-        },
+        {"filename_interval": "none", "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc"},
     )
     assert driverobj.output["paths"] == [outpath("2024-02-01_032_18-00-00.nc")]
 
 
 def test_MPASInit_output__filename_interval_output_interval_initial_only(driverobj, outpath):
     driverobj._config["streams"]["output"].update(
-        {
-            "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
-            "output_interval": "initial_only",
-        }
+        {"filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc", "output_interval": "initial_only"}
     )
     assert driverobj.output["paths"] == [outpath("2024-02-01_032_18-00-00.nc")]
 
@@ -222,17 +216,25 @@ def test_MPASInit_output__filename_interval_output_interval_initial_only(drivero
 def test_MPASInit_output__filename_interval_output_interval_none(driverobj, explicit):
     updates = {"output_interval": "none"}
     if explicit:
-        updates["filename_interval"] = "output_interval"  # also the default value
+        updates["filename_interval"] = "output_interval"
     driverobj._config["streams"]["output"].update(updates)
     assert driverobj.output["paths"] == []
 
 
+@mark.parametrize("explicit", [True, False])
+def test_MPASInit_output__filename_interval_output_interval_timestamp(driverobj, explicit, outpath):
+    updates = {"filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc", "output_interval": "01:00:00"}
+    if explicit:
+        updates["filename_interval"] = "output_interval"
+    driverobj._config["streams"]["output"].update(updates)
+    assert driverobj.output["paths"] == [
+        outpath("2024-02-01_032_18-00-00.nc"),
+        outpath("2024-02-01_032_19-00-00.nc"),
+    ]
+
+
 def test_MPASInit_output__non_output_stream(driverobj):
-    driverobj._config["streams"]["output"].update(
-        {
-            "type": "input",
-        }
-    )
+    driverobj._config["streams"]["output"].update({"type": "input"})
     assert driverobj.output["paths"] == []
 
 

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -69,9 +69,9 @@ def config(tmp_path):
                     "output_interval": "initial_only",
                     "streams": ["stream1", "stream2"],
                     "type": "output",
-                    "vars": ["v1", "v2"],
                     "var_arrays": ["va1", "va2"],
                     "var_structs": ["vs1", "vs2"],
+                    "vars": ["v1", "v2"],
                 },
             },
         },
@@ -193,17 +193,21 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
     assert logged("Not ready [external asset]")
 
 
-def test_MPASInit_output(driverobj):
+def test_MPASInit_output__initial_only(driverobj):
     path = lambda fn: driverobj.rundir / fn
-    driverobj._config["streams"]["output"]["filename_template"] = "$Y-$M-$D_$d_$h-$m-$s.nc"
-    driverobj._config["boundary_conditions"]["length"] = 1
-    assert driverobj.output["paths"] == [
-        path("2024-02-01_032_18-00-00.nc"),
-        path("2024-02-01_032_19-00-00.nc"),
-    ]
-    driverobj._config["streams"]["output"]["filename_template"] = "conus.init.nc"
-    driverobj._config["boundary_conditions"]["length"] = 0
+    driverobj._config["streams"]["output"].update(
+        {"filename_template": "conus.init.nc", "output_interval": "initial_only"}
+    )
     assert driverobj.output["paths"] == [path("conus.init.nc")]
+
+
+s = """
+    # driverobj._config["streams"]["output"]["filename_template"] = "$Y-$M-$D_$d_$h-$m-$s.nc"
+    # assert driverobj.output["paths"] == [
+    #     path("2024-02-01_032_18-00-00.nc"),
+    #     path("2024-02-01_032_19-00-00.nc"),
+    # ]
+"""
 
 
 def test_MPASInit_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -333,5 +333,11 @@ def test_MPASInit__filename_interval_timestamps(driverobj, dtargs, interval, ref
     )
 
 
+def test_MPASInit__initial_and_final_ts(driverobj):
+    initial = datetime(2024, 2, 1, 18, tzinfo=timezone.utc)
+    final = initial + timedelta(hours=1)
+    assert driverobj._initial_and_final_ts == (initial, final)
+
+
 def test_MPASInit__streams_fn(driverobj):
     assert driverobj._streams_fn == "streams.init_atmosphere"

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -92,6 +92,11 @@ def driverobj(config, cycle):
     return MPASInit(config=config, cycle=cycle, batch=True)
 
 
+@fixture
+def outpath(driverobj):
+    return lambda fn: driverobj.rundir / fn
+
+
 # Tests
 
 
@@ -193,26 +198,24 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
     assert logged("Not ready [external asset]")
 
 
-def test_MPASInit_output__filename_interval_none(driverobj):
-    path = lambda fn: driverobj.rundir / fn
+def test_MPASInit_output__filename_interval_none(driverobj, outpath):
     driverobj._config["streams"]["output"].update(
         {
             "filename_interval": "none",
             "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
         },
     )
-    assert driverobj.output["paths"] == [path("2024-02-01_032_18-00-00.nc")]
+    assert driverobj.output["paths"] == [outpath("2024-02-01_032_18-00-00.nc")]
 
 
-def test_MPASInit_output__initial_only(driverobj):
-    path = lambda fn: driverobj.rundir / fn
+def test_MPASInit_output__initial_only(driverobj, outpath):
     driverobj._config["streams"]["output"].update(
         {
-            "filename_template": "conus.init.nc",
+            "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
             "output_interval": "initial_only",
         }
     )
-    assert driverobj.output["paths"] == [path("conus.init.nc")]
+    assert driverobj.output["paths"] == [outpath("2024-02-01_032_18-00-00.nc")]
 
 
 def test_MPASInit_output__output_interval_none_default(driverobj):
@@ -241,15 +244,6 @@ def test_MPASInit_output__non_output_stream(driverobj):
         }
     )
     assert driverobj.output["paths"] == []
-
-
-"""
-    # driverobj._config["streams"]["output"]["filename_template"] = "$Y-$M-$D_$d_$h-$m-$s.nc"
-    # assert driverobj.output["paths"] == [
-    #     path("2024-02-01_032_18-00-00.nc"),
-    #     path("2024-02-01_032_19-00-00.nc"),
-    # ]
-"""
 
 
 def test_MPASInit_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -195,9 +195,15 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
 
 def test_MPASInit_output(driverobj):
     path = lambda fn: driverobj.rundir / fn
-    assert driverobj.output["paths"] == [path("conus.init.nc")]
     driverobj._config["streams"]["output"]["filename_template"] = "$Y-$M-$D_$d_$h-$m-$s.nc"
-    assert driverobj.output["paths"] == [path("2024-02-01_032_18-00-00.nc")]
+    driverobj._config["boundary_conditions"]["length"] = 1
+    assert driverobj.output["paths"] == [
+        path("2024-02-01_032_18-00-00.nc"),
+        path("2024-02-01_032_19-00-00.nc"),
+    ]
+    driverobj._config["streams"]["output"]["filename_template"] = "conus.init.nc"
+    driverobj._config["boundary_conditions"]["length"] = 0
+    assert driverobj.output["paths"] == [path("conus.init.nc")]
 
 
 def test_MPASInit_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -208,7 +208,7 @@ def test_MPASInit_output__filename_interval_none(driverobj, outpath):
     assert driverobj.output["paths"] == [outpath("2024-02-01_032_18-00-00.nc")]
 
 
-def test_MPASInit_output__initial_only(driverobj, outpath):
+def test_MPASInit_output__filename_interval_output_interval_initial_only(driverobj, outpath):
     driverobj._config["streams"]["output"].update(
         {
             "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
@@ -218,22 +218,12 @@ def test_MPASInit_output__initial_only(driverobj, outpath):
     assert driverobj.output["paths"] == [outpath("2024-02-01_032_18-00-00.nc")]
 
 
-def test_MPASInit_output__output_interval_none_default(driverobj):
-    driverobj._config["streams"]["output"].update(
-        {
-            "output_interval": "none",
-        }
-    )
-    assert driverobj.output["paths"] == []
-
-
-def test_MPASInit_output__output_interval_none_explicit(driverobj):
-    driverobj._config["streams"]["output"].update(
-        {
-            "filename_interval": "output_interval",
-            "output_interval": "none",
-        }
-    )
+@mark.parametrize("explicit", [True, False])
+def test_MPASInit_output__filename_interval_output_interval_none(driverobj, explicit):
+    updates = {"output_interval": "none"}
+    if explicit:
+        updates["filename_interval"] = "output_interval"  # also the default value
+    driverobj._config["streams"]["output"].update(updates)
     assert driverobj.output["paths"] == []
 
 

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -193,6 +193,17 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
     assert logged("Not ready [external asset]")
 
 
+def test_MPASInit_output__filename_interval_none(driverobj):
+    path = lambda fn: driverobj.rundir / fn
+    driverobj._config["streams"]["output"].update(
+        {
+            "filename_interval": "none",
+            "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc",
+        },
+    )
+    assert driverobj.output["paths"] == [path("2024-02-01_032_18-00-00.nc")]
+
+
 def test_MPASInit_output__initial_only(driverobj):
     path = lambda fn: driverobj.rundir / fn
     driverobj._config["streams"]["output"].update(
@@ -204,28 +215,31 @@ def test_MPASInit_output__initial_only(driverobj):
     assert driverobj.output["paths"] == [path("conus.init.nc")]
 
 
-def test_MPASInit_output__filename_interval_none(driverobj):
-    path = lambda fn: driverobj.rundir / fn
-    driverobj._config["streams"]["output"].update(
-        {"filename_interval": "none", "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc"},
-    )
-    assert driverobj.output["paths"] == [path("2024-02-01_032_18-00-00.nc")]
-
-
 def test_MPASInit_output__output_interval_none_default(driverobj):
-    driverobj._config["streams"]["output"].update({"output_interval": "none"})
+    driverobj._config["streams"]["output"].update(
+        {
+            "output_interval": "none",
+        }
+    )
     assert driverobj.output["paths"] == []
 
 
 def test_MPASInit_output__output_interval_none_explicit(driverobj):
     driverobj._config["streams"]["output"].update(
-        {"filename_interval": "output_interval", "output_interval": "none"}
+        {
+            "filename_interval": "output_interval",
+            "output_interval": "none",
+        }
     )
     assert driverobj.output["paths"] == []
 
 
 def test_MPASInit_output__non_output_stream(driverobj):
-    driverobj._config["streams"]["output"].update({"type": "input"})
+    driverobj._config["streams"]["output"].update(
+        {
+            "type": "input",
+        }
+    )
     assert driverobj.output["paths"] == []
 
 

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -194,9 +194,10 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
 
 
 def test_MPASInit_output(driverobj):
-    assert driverobj.output["path"] == driverobj.rundir / "conus.init.nc"
+    path = lambda fn: driverobj.rundir / fn
+    assert driverobj.output["paths"] == [path("conus.init.nc")]
     driverobj._config["streams"]["output"]["filename_template"] = "$Y-$M-$D_$d_$h-$m-$s.nc"
-    assert driverobj.output["path"] == driverobj.rundir / "2024-02-01_032_18-00-00.nc"
+    assert driverobj.output["paths"] == [path("2024-02-01_032_18-00-00.nc")]
 
 
 def test_MPASInit_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -352,11 +352,11 @@ def test_MPASInit__interval_timestamps(driverobj, dtargs, interval, length):
     assert driverobj._interval_timestamps(interval=interval) == expected
 
 
-def test_MPASInit__path(driverobj):
+def test_MPASInit__output_path(driverobj):
     t = "out.$Y_$M_$D-$d-$h_$m_$s.nc"
     d = datetime(2025, 5, 7, 1, 2, 3, tzinfo=timezone.utc)
     expected = driverobj.rundir / "out.2025_05_07-127-01_02_03.nc"
-    assert driverobj._path(template=t, dtobj=d) == expected
+    assert driverobj._output_path(template=t, dtobj=d) == expected
 
 
 def test_MPASInit__streams_fn(driverobj):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -201,7 +201,7 @@ def test_MPASInit_output__initial_only(driverobj):
     assert driverobj.output["paths"] == [path("conus.init.nc")]
 
 
-s = """
+"""
     # driverobj._config["streams"]["output"]["filename_template"] = "$Y-$M-$D_$d_$h-$m-$s.nc"
     # assert driverobj.output["paths"] == [
     #     path("2024-02-01_032_18-00-00.nc"),

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -195,6 +195,8 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
 
 def test_MPASInit_output(driverobj):
     assert driverobj.output["path"] == driverobj.rundir / "conus.init.nc"
+    driverobj._config["streams"]["output"]["filename_template"] = "$Y-$M-$D_$d_$h-$m-$s.nc"
+    assert driverobj.output["path"] == driverobj.rundir / "2024-02-01_032_18-00-00.nc"
 
 
 def test_MPASInit_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -196,9 +196,37 @@ def test_MPASInit_namelist_file_missing_base_file(driverobj, logged):
 def test_MPASInit_output__initial_only(driverobj):
     path = lambda fn: driverobj.rundir / fn
     driverobj._config["streams"]["output"].update(
-        {"filename_template": "conus.init.nc", "output_interval": "initial_only"}
+        {
+            "filename_template": "conus.init.nc",
+            "output_interval": "initial_only",
+        }
     )
     assert driverobj.output["paths"] == [path("conus.init.nc")]
+
+
+def test_MPASInit_output__filename_interval_none(driverobj):
+    path = lambda fn: driverobj.rundir / fn
+    driverobj._config["streams"]["output"].update(
+        {"filename_interval": "none", "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc"},
+    )
+    assert driverobj.output["paths"] == [path("2024-02-01_032_18-00-00.nc")]
+
+
+def test_MPASInit_output__output_interval_none_default(driverobj):
+    driverobj._config["streams"]["output"].update({"output_interval": "none"})
+    assert driverobj.output["paths"] == []
+
+
+def test_MPASInit_output__output_interval_none_explicit(driverobj):
+    driverobj._config["streams"]["output"].update(
+        {"filename_interval": "output_interval", "output_interval": "none"}
+    )
+    assert driverobj.output["paths"] == []
+
+
+def test_MPASInit_output__non_output_stream(driverobj):
+    driverobj._config["streams"]["output"].update({"type": "input"})
+    assert driverobj.output["paths"] == []
 
 
 """

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -5,12 +5,11 @@ Ungrib driver tests.
 from unittest.mock import patch
 
 import f90nml  # type: ignore[import-untyped]
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.drivers import ungrib
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.ungrib import Ungrib
-from uwtools.exceptions import UWNotImplementedError
 
 # Fixtures
 
@@ -68,7 +67,6 @@ def driverobj(config, cycle):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "runscript",
     ],
@@ -105,9 +103,7 @@ def test_Ungrib_namelist_file(driverobj):
 
 
 def test_Ungrib_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    pass
 
 
 def test_Ungrib_provisioned_rundir(driverobj, ready_task):

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -133,6 +133,10 @@ def test_Ungrib_vtable(driverobj):
     assert dst.is_symlink()
 
 
+def test_Ungrib__end_date(driverobj, utc):
+    assert driverobj._end_date == utc(2024, 2, 2, 6)
+
+
 def test_Ungrib__gribfile(driverobj):
     src = driverobj.rundir / "GRIBFILE.AAA.in"
     src.touch()
@@ -140,6 +144,10 @@ def test_Ungrib__gribfile(driverobj):
     assert not dst.is_symlink()
     driverobj._gribfile(src, dst)
     assert dst.is_symlink()
+
+
+def test_Ungrib__interval(driverobj):
+    assert driverobj._interval == 21600
 
 
 def test__ext():

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -103,7 +103,14 @@ def test_Ungrib_namelist_file(driverobj):
 
 
 def test_Ungrib_output(driverobj):
-    pass
+    assert driverobj.output["paths"] == [
+        driverobj.rundir / f"FILE:{x}"
+        for x in (
+            "2024-02-01_18:00:00",
+            "2024-02-02_00:00:00",
+            "2024-02-02_06:00:00",
+        )
+    ]
 
 
 def test_Ungrib_provisioned_rundir(driverobj, ready_task):


### PR DESCRIPTION
**Synopsis**

Implements `output()` methods on driver classes `Ungrib` and `MPASInit`, per #625. Work on class `MPAS` will follow, but there's enough here to discuss for now, I think. Hopefully much of the work for `MPAS` will involve refactoring, as much of the logic will be similar.

**Type**

- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
