### PR TITLE
Implement driver MPAS output() method

### DIFF
--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -2,7 +2,7 @@
 A driver for the MPAS Atmosphere component.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from iotaa import asset, task, tasks
@@ -100,7 +100,9 @@ class MPAS(MPASBase):
 
     @property
     def _initial_and_final_ts(self) -> tuple[datetime, datetime]:
-        return self._cycle, self._cycle + timedelta(hours=self.config["length"])
+        initial = self._cycle.replace(tzinfo=timezone.utc)
+        final = initial + timedelta(hours=self.config["length"])
+        return initial, final
 
     @property
     def _streams_fn(self) -> str:

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -2,7 +2,7 @@
 A driver for the MPAS Atmosphere component.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from iotaa import asset, task, tasks
@@ -100,12 +100,7 @@ class MPAS(MPASBase):
 
     @property
     def _initial_and_final_ts(self) -> tuple[datetime, datetime]:
-        """
-        Initial = self._cycle.replace(tzinfo=timezone.utc) final = initial +
-        timedelta(hours=self.config["boundary_conditions"]["length"]) return initial, final.
-        """
-        now = datetime.now(tz=timezone.utc)
-        return now, now
+        return self._cycle, self._cycle + timedelta(hours=self.config["length"])
 
     @property
     def _streams_fn(self) -> str:

--- a/src/uwtools/drivers/mpas.py
+++ b/src/uwtools/drivers/mpas.py
@@ -2,7 +2,7 @@
 A driver for the MPAS Atmosphere component.
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from iotaa import asset, task, tasks
@@ -97,6 +97,15 @@ class MPAS(MPASBase):
         return STR.mpas
 
     # Private helper methods
+
+    @property
+    def _initial_and_final_ts(self) -> tuple[datetime, datetime]:
+        """
+        Initial = self._cycle.replace(tzinfo=timezone.utc) final = initial +
+        timedelta(hours=self.config["boundary_conditions"]["length"]) return initial, final.
+        """
+        now = datetime.now(tz=timezone.utc)
+        return now, now
 
     @property
     def _streams_fn(self) -> str:

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -181,8 +181,7 @@ class MPASBase(DriverCycleBased):
 
     @property
     @abstractmethod
-    def _initial_and_final_ts(self) -> tuple[datetime, datetime]:
-        pass
+    def _initial_and_final_ts(self) -> tuple[datetime, datetime]: ...
 
     def _interval_timestamps(self, interval: str) -> list[datetime]:
         kwargs = self._decode_interval(interval)

--- a/src/uwtools/drivers/mpas_base.py
+++ b/src/uwtools/drivers/mpas_base.py
@@ -2,9 +2,17 @@
 A base class for MPAS drivers.
 """
 
-from abc import abstractmethod
-from pathlib import Path
+from __future__ import annotations
 
+import re
+from abc import abstractmethod
+from datetime import datetime, timezone
+from functools import reduce
+from itertools import islice
+from pathlib import Path
+from typing import cast
+
+from dateutil.relativedelta import relativedelta
 from iotaa import asset, task, tasks
 from lxml import etree
 from lxml.etree import Element, SubElement
@@ -99,7 +107,106 @@ class MPASBase(DriverCycleBased):
         xml = etree.tostring(streams, pretty_print=True, encoding="utf-8").decode()
         path.write_text(xml)
 
+    # Public helper methods
+
+    @property
+    def output(self) -> dict[str, list[Path]]:
+        """
+        Returns a description of the file(s) created when this component runs.
+        """
+        paths = []
+        for stream in self.config["streams"].values():
+            if stream["type"] not in ("output", "input;output"):
+                continue
+            filename_interval = self._filename_interval(stream)
+            template = stream["filename_template"]
+            if filename_interval == "none":
+                paths.append(self._output_path(template, self._cycle))
+            elif filename_interval in ("input_interval", "output_interval"):
+                interval = stream[filename_interval]
+                if interval == "none":
+                    continue  # stream will not be written
+                if interval == "initial_only":
+                    paths.append(self._output_path(template, self._cycle))
+                else:  # interval is a timestamp
+                    tss = self._interval_timestamps(interval)
+                    paths.extend(self._output_path(template, ts) for ts in tss)
+            else:  # filename_interval is a timestamp
+                reference_time = stream.get("reference_time")
+                tss = self._filename_interval_timestamps(filename_interval, reference_time)
+                paths.extend(self._output_path(template, ts) for ts in tss)
+        return {"paths": sorted(set(paths))}
+
     # Private helper methods
+
+    @staticmethod
+    def _decode_interval(interval: str) -> dict[str, int]:
+        # See MPAS User Guide section 5 in re: interval format and semantics, but the general form
+        # is years-months-days_hours:minutes:seconds, e.g. 1-2-3_4:5:6 means 1 year, 2 months, 3
+        # days, 4 hours, 5 minutes, 6 seconds. Leading components can be omitted, so reverse for an
+        # ascending seconds -> years order, pad with trailing zeros as needed, then reverse again
+        # for a natural descending years -> seconds order.
+        keys = ["years", "months", "days", "hours", "minutes", "seconds"]
+        components = re.sub(r"[-_:]", " ", interval).split()[::-1]
+        vals = [next(islice(components, i, i + 1), 0) for i in range(len(keys))][::-1]
+        return dict(zip(keys, map(int, vals)))
+
+    @staticmethod
+    def _decode_timestamp(timestamp: str) -> datetime:
+        return datetime.strptime(timestamp, "%Y-%m-%d_%H:%M:%S").replace(tzinfo=timezone.utc)
+
+    @staticmethod
+    def _filename_interval(stream: dict) -> str:
+        # See MPAS User Guide section 5.2 in re: filename_interval logic.
+        assert stream["type"] in ("output", "input;output")
+        filename_interval = "output_interval"
+        if stream["type"] == "input;output" and stream["input_interval"] != "initial_only":
+            filename_interval = "input_interval"
+        return cast(str, stream.get("filename_interval", filename_interval))
+
+    def _filename_interval_timestamps(
+        self, interval: str, reference_time: str | None
+    ) -> list[datetime]:
+        # See MPAS User Guide sections 5.2 and 5.3.3 in re: the semantics of reference_time.
+        # First, create a timestamp for each expected output file, per the timestamp-pattern value
+        # of filename_interval. By default, the first timestamp will match the model start time, but
+        # reference_time, if present, shifts it to a different time. In this case, the number of
+        # output files does not change, but their timestamps and contents do.
+        tss = self._interval_timestamps(interval)
+        if reference_time:
+            initial_ts, _ = self._initial_and_final_ts
+            delta = initial_ts - self._decode_timestamp(reference_time)
+            tss = [ts - delta for ts in tss]
+        return tss
+
+    @property
+    @abstractmethod
+    def _initial_and_final_ts(self) -> tuple[datetime, datetime]:
+        pass
+
+    def _interval_timestamps(self, interval: str) -> list[datetime]:
+        kwargs = self._decode_interval(interval)
+        delta = relativedelta(**kwargs)  # type: ignore[arg-type]
+        ts, final_ts = self._initial_and_final_ts
+        tss = []
+        while ts <= final_ts:
+            tss.append(ts)
+            ts = ts + delta
+        return tss
+
+    def _output_path(self, template: str, dtobj: datetime) -> Path:
+        # See MPAS User Guide section 5.1 in re: filename_template logic.
+        kvs = [
+            ("$Y", "%Y"),
+            ("$M", "%m"),
+            ("$D", "%d"),
+            ("$d", "%j"),
+            ("$h", "%H"),
+            ("$m", "%M"),
+            ("$s", "%S"),
+        ]
+        template = reduce(lambda m, e: m.replace(e[0], e[1]), kvs, template)
+        return self.rundir / dtobj.strftime(template)
 
     @property
     @abstractmethod

--- a/src/uwtools/drivers/mpas_init.py
+++ b/src/uwtools/drivers/mpas_init.py
@@ -2,16 +2,9 @@
 A driver for the MPAS Init component.
 """
 
-from __future__ import annotations
-
-import re
 from datetime import datetime, timedelta, timezone
-from functools import reduce
-from itertools import islice
 from pathlib import Path
-from typing import cast
 
-from dateutil.relativedelta import relativedelta
 from iotaa import asset, task, tasks
 
 from uwtools.config.formats.nml import NMLConfig
@@ -100,105 +93,13 @@ class MPASInit(MPASBase):
         """
         return STR.mpasinit
 
-    @property
-    def output(self) -> dict[str, list[Path]]:
-        """
-        Returns a description of the file(s) created when this component runs.
-        """
-        paths = []
-        for stream in self.config["streams"].values():
-            if stream["type"] not in ("output", "input;output"):
-                continue
-            filename_interval = self._filename_interval(stream)
-            template = stream["filename_template"]
-            if filename_interval == "none":
-                paths.append(self._output_path(template, self._cycle))
-            elif filename_interval in ("input_interval", "output_interval"):
-                interval = stream[filename_interval]
-                if interval == "none":
-                    continue  # stream will not be written
-                if interval == "initial_only":
-                    paths.append(self._output_path(template, self._cycle))
-                else:  # interval is a timestamp
-                    tss = self._interval_timestamps(interval)
-                    paths.extend(self._output_path(template, ts) for ts in tss)
-            else:  # filename_interval is a timestamp
-                reference_time = stream.get("reference_time")
-                tss = self._filename_interval_timestamps(filename_interval, reference_time)
-                paths.extend(self._output_path(template, ts) for ts in tss)
-        return {"paths": sorted(set(paths))}
-
     # Private helper methods
-
-    @staticmethod
-    def _decode_interval(interval: str) -> dict[str, int]:
-        # See MPAS User Guide section 5 in re: interval format and semantics, but the general form
-        # is years-months-days_hours:minutes:seconds, e.g. 1-2-3_4:5:6 means 1 year, 2 months, 3
-        # days, 4 hours, 5 minutes, 6 seconds. Leading components can be omitted, so reverse for an
-        # ascending seconds -> years order, pad with trailing zeros as needed, then reverse again
-        # for a natural descending years -> seconds order.
-        keys = ["years", "months", "days", "hours", "minutes", "seconds"]
-        components = re.sub(r"[-_:]", " ", interval).split()[::-1]
-        vals = [next(islice(components, i, i + 1), 0) for i in range(len(keys))][::-1]
-        return dict(zip(keys, map(int, vals)))
-
-    @staticmethod
-    def _decode_timestamp(timestamp: str) -> datetime:
-        return datetime.strptime(timestamp, "%Y-%m-%d_%H:%M:%S").replace(tzinfo=timezone.utc)
-
-    @staticmethod
-    def _filename_interval(stream: dict) -> str:
-        # See MPAS User Guide section 5.2 in re: filename_interval logic.
-        assert stream["type"] in ("output", "input;output")
-        filename_interval = "output_interval"
-        if stream["type"] == "input;output" and stream["input_interval"] != "initial_only":
-            filename_interval = "input_interval"
-        return cast(str, stream.get("filename_interval", filename_interval))
-
-    def _filename_interval_timestamps(
-        self, interval: str, reference_time: str | None
-    ) -> list[datetime]:
-        # See MPAS User Guide sections 5.2 and 5.3.3 in re: the semantics of reference_time.
-        # First, create a timestamp for each expected output file, per the timestamp-pattern value
-        # of filename_interval. By default, the first timestamp will match the model start time, but
-        # reference_time, if present, shifts it to a different time. In this case, the number of
-        # output files does not change, but their timestamps and contents do.
-        tss = self._interval_timestamps(interval)
-        if reference_time:
-            initial_ts, _ = self._initial_and_final_ts
-            delta = initial_ts - self._decode_timestamp(reference_time)
-            tss = [ts - delta for ts in tss]
-        return tss
 
     @property
     def _initial_and_final_ts(self) -> tuple[datetime, datetime]:
         initial = self._cycle.replace(tzinfo=timezone.utc)
         final = initial + timedelta(hours=self.config["boundary_conditions"]["length"])
         return initial, final
-
-    def _interval_timestamps(self, interval: str) -> list[datetime]:
-        kwargs = self._decode_interval(interval)
-        delta = relativedelta(**kwargs)  # type: ignore[arg-type]
-        ts, final_ts = self._initial_and_final_ts
-        tss = []
-        while ts <= final_ts:
-            tss.append(ts)
-            ts = ts + delta
-        return tss
-
-    def _output_path(self, template: str, dtobj: datetime) -> Path:
-        # See MPAS User Guide section 5.1 in re: filename_template logic.
-        kvs = [
-            ("$Y", "%Y"),
-            ("$M", "%m"),
-            ("$D", "%d"),
-            ("$d", "%j"),
-            ("$h", "%H"),
-            ("$m", "%M"),
-            ("$s", "%S"),
-        ]
-        template = reduce(lambda m, e: m.replace(e[0], e[1]), kvs, template)
-        return self.rundir / dtobj.strftime(template)
 
     @property
     def _streams_fn(self) -> str:

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -2,7 +2,7 @@
 MPAS driver tests.
 """
 
-import datetime as dt
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -146,16 +146,14 @@ def test_MPAS(method):
 def test_MPAS_boundary_files(driverobj, cycle):
     ns = (0, 1)
     links = [
-        driverobj.rundir / f"lbc.{(cycle + dt.timedelta(hours=n)).strftime('%Y-%m-%d_%H.%M.%S')}.nc"
+        driverobj.rundir / f"lbc.{(cycle + timedelta(hours=n)).strftime('%Y-%m-%d_%H.%M.%S')}.nc"
         for n in ns
     ]
     assert not any(link.is_file() for link in links)
     infile_path = Path(driverobj.config["lateral_boundary_conditions"]["path"])
     infile_path.mkdir()
     for n in ns:
-        path = (
-            infile_path / f"lbc.{(cycle + dt.timedelta(hours=n)).strftime('%Y-%m-%d_%H.%M.%S')}.nc"
-        )
+        path = infile_path / f"lbc.{(cycle + timedelta(hours=n)).strftime('%Y-%m-%d_%H.%M.%S')}.nc"
         path.touch()
     driverobj.boundary_files()
     assert all(link.is_symlink() for link in links)
@@ -253,6 +251,12 @@ def test_MPAS_provisioned_rundir(domain, driverobj, ready_task):
 
 def test_MPAS_streams_file(config, driverobj):
     streams_file(config, driverobj, "mpas")
+
+
+def test_MPAS__initial_and_final_ts(driverobj):
+    initial = driverobj._cycle
+    final = initial + timedelta(hours=1)
+    assert driverobj._initial_and_final_ts == (initial, final)
 
 
 def test_MPAS__streams_fn(driverobj):

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -116,6 +116,12 @@ def driverobj(config, cycle):
 @mark.parametrize(
     "method",
     [
+        "_decode_interval",
+        "_decode_timestamp",
+        "_filename_interval",
+        "_filename_interval_timestamps",
+        "_interval_timestamps",
+        "_output_path",
         "_run_resources",
         "_run_via_batch_submission",
         "_run_via_local_execution",
@@ -126,6 +132,7 @@ def driverobj(config, cycle):
         "_scheduler",
         "_validate",
         "_write_runscript",
+        "output",
         "run",
         "runscript",
         "streams_file",

--- a/src/uwtools/tests/drivers/test_mpas.py
+++ b/src/uwtools/tests/drivers/test_mpas.py
@@ -9,11 +9,10 @@ from unittest.mock import patch
 import f90nml  # type: ignore[import-untyped]
 import yaml
 from lxml import etree
-from pytest import fixture, mark, raises
+from pytest import fixture, mark
 
 from uwtools.drivers.mpas import MPAS
 from uwtools.drivers.mpas_base import MPASBase
-from uwtools.exceptions import UWNotImplementedError
 from uwtools.tests.support import fixture_path
 
 # Helpers
@@ -127,7 +126,6 @@ def driverobj(config, cycle):
         "_scheduler",
         "_validate",
         "_write_runscript",
-        "output",
         "run",
         "runscript",
         "streams_file",
@@ -222,9 +220,7 @@ def test_MPAS_namelist_file_missing_base_file(driverobj, logged):
 
 
 def test_MPAS_output(driverobj):
-    with raises(UWNotImplementedError) as e:
-        assert driverobj.output
-    assert str(e.value) == "The output() method is not yet implemented for this driver"
+    pass
 
 
 @mark.parametrize("domain", ["global", "regional"])

--- a/src/uwtools/tests/drivers/test_mpas_base.py
+++ b/src/uwtools/tests/drivers/test_mpas_base.py
@@ -1,0 +1,44 @@
+"""
+uwtools.drivers.mpas_base tests.
+"""
+
+from datetime import datetime, timezone
+
+from pytest import mark
+
+from uwtools.drivers.mpas_base import MPASBase
+
+
+@mark.parametrize(
+    ("interval", "vals"),
+    [
+        ("1-2-3_04:05:06", [1, 2, 3, 4, 5, 6]),
+        ("1-2-3_4:5:6", [1, 2, 3, 4, 5, 6]),
+        ("2-3_4:5:6", [0, 2, 3, 4, 5, 6]),
+        ("3_4:5:6", [0, 0, 3, 4, 5, 6]),
+        ("4:5:6", [0, 0, 0, 4, 5, 6]),
+        ("5:6", [0, 0, 0, 0, 5, 6]),
+        ("6", [0, 0, 0, 0, 0, 6]),
+    ],
+)
+def test_mpas_base__decode_interval(interval, vals):
+    keys = ("years", "months", "days", "hours", "minutes", "seconds")
+    assert MPASBase._decode_interval(interval=interval) == dict(zip(keys, vals))
+
+
+def test_mpas_base__decode_timestamp():
+    expected = datetime(2025, 5, 7, 15, 6, 1, tzinfo=timezone.utc)
+    assert MPASBase._decode_timestamp("2025-05-07_15:06:01") == expected
+
+
+@mark.parametrize(
+    ("expected", "stream"),
+    [
+        ("1_00:00:00", {"type": "output", "filename_interval": "1_00:00:00"}),
+        ("input_interval", {"type": "input;output", "input_interval": "none"}),
+        ("output_interval", {"type": "input;output", "input_interval": "initial_only"}),
+        ("output_interval", {"type": "output"}),
+    ],
+)
+def test_mpas_base__filename_interval(expected, stream):
+    assert MPASBase._filename_interval(stream) == expected

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -103,6 +103,12 @@ def outpath(driverobj):
 @mark.parametrize(
     "method",
     [
+        "_decode_interval",
+        "_decode_timestamp",
+        "_filename_interval",
+        "_filename_interval_timestamps",
+        "_interval_timestamps",
+        "_output_path",
         "_run_resources",
         "_run_via_batch_submission",
         "_run_via_local_execution",
@@ -113,6 +119,7 @@ def outpath(driverobj):
         "_scheduler",
         "_validate",
         "_write_runscript",
+        "output",
         "run",
         "runscript",
         "streams_file",

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -287,41 +287,6 @@ def test_MPASInit_streams_file(config, driverobj):
 
 
 @mark.parametrize(
-    ("interval", "vals"),
-    [
-        ("1-2-3_04:05:06", [1, 2, 3, 4, 5, 6]),
-        ("1-2-3_4:5:6", [1, 2, 3, 4, 5, 6]),
-        ("2-3_4:5:6", [0, 2, 3, 4, 5, 6]),
-        ("3_4:5:6", [0, 0, 3, 4, 5, 6]),
-        ("4:5:6", [0, 0, 0, 4, 5, 6]),
-        ("5:6", [0, 0, 0, 0, 5, 6]),
-        ("6", [0, 0, 0, 0, 0, 6]),
-    ],
-)
-def test_MPASInit__decode_interval(interval, vals):
-    keys = ("years", "months", "days", "hours", "minutes", "seconds")
-    assert MPASInit._decode_interval(interval=interval) == dict(zip(keys, vals))
-
-
-def test_MPASInit__decode_timestamp():
-    expected = datetime(2025, 5, 7, 15, 6, 1, tzinfo=timezone.utc)
-    assert MPASInit._decode_timestamp("2025-05-07_15:06:01") == expected
-
-
-@mark.parametrize(
-    ("expected", "stream"),
-    [
-        ("1_00:00:00", {"type": "output", "filename_interval": "1_00:00:00"}),
-        ("input_interval", {"type": "input;output", "input_interval": "none"}),
-        ("output_interval", {"type": "input;output", "input_interval": "initial_only"}),
-        ("output_interval", {"type": "output"}),
-    ],
-)
-def test_MPASInit__filename_interval(expected, stream):
-    assert MPASInit._filename_interval(stream) == expected
-
-
-@mark.parametrize(
     ("dtargs", "interval", "reference_time"),
     [
         ([(2024, 2, 1), (2024, 2, 2)], "1_00:00:00", "2024-02-01_00:00:00"),

--- a/src/uwtools/tests/drivers/test_mpas_init.py
+++ b/src/uwtools/tests/drivers/test_mpas_init.py
@@ -168,6 +168,43 @@ def test_MPASInit_files_copied_and_files_linked(config, cycle, key, task, test, 
     assert all(getattr(dst, test)() for dst in [atm_dst, sfc_dst])
 
 
+def test_MPASInit_namelist_file(driverobj, logged):
+    dst = driverobj.rundir / "namelist.init_atmosphere"
+    assert not dst.is_file()
+    path = Path(driverobj.namelist_file().refs)
+    assert dst.is_file()
+    assert logged(f"Wrote config to {path}")
+    assert isinstance(f90nml.read(dst), f90nml.Namelist)
+
+
+def test_MPASInit_namelist_file__contents(cycle, driverobj):
+    dst = driverobj.rundir / "namelist.init_atmosphere"
+    assert not dst.is_file()
+    driverobj.namelist_file()
+    assert dst.is_file()
+    nml = f90nml.read(dst)
+    stop_time = cycle + timedelta(hours=1)
+    f = "%Y-%m-%d_%H:00:00"
+    assert nml["nhyd_model"]["config_start_time"] == cycle.strftime(f)
+    assert nml["nhyd_model"]["config_stop_time"] == stop_time.strftime(f)
+
+
+def test_MPASInit_namelist_file__fails_validation(driverobj, logged):
+    driverobj._config["namelist"]["update_values"]["nhyd_model"]["foo"] = None
+    path = Path(driverobj.namelist_file().refs)
+    assert not path.exists()
+    assert logged(f"Failed to validate {path}")
+    assert logged("  None is not of type 'array', 'boolean', 'number', 'string'")
+
+
+def test_MPASInit_namelist_file__missing_base_file(driverobj, logged):
+    base_file = str(Path(driverobj.config["rundir"], "missing.nml"))
+    driverobj._config["namelist"]["base_file"] = base_file
+    path = Path(driverobj.namelist_file().refs)
+    assert not path.exists()
+    assert logged("Not ready [external asset]")
+
+
 def test_MPASInit_output__filename_interval_none(driverobj, outpath):
     driverobj._config["streams"]["output"].update(
         {"filename_interval": "none", "filename_template": "$Y-$M-$D_$d_$h-$m-$s.nc"},
@@ -235,43 +272,6 @@ def test_MPASInit_output__filename_interval_timestamp_reference_time(driverobj, 
 def test_MPASInit_output__non_output_stream(driverobj):
     driverobj._config["streams"]["output"].update({"type": "input"})
     assert driverobj.output["paths"] == []
-
-
-def test_MPASInit_namelist_file(driverobj, logged):
-    dst = driverobj.rundir / "namelist.init_atmosphere"
-    assert not dst.is_file()
-    path = Path(driverobj.namelist_file().refs)
-    assert dst.is_file()
-    assert logged(f"Wrote config to {path}")
-    assert isinstance(f90nml.read(dst), f90nml.Namelist)
-
-
-def test_MPASInit_namelist_file__contents(cycle, driverobj):
-    dst = driverobj.rundir / "namelist.init_atmosphere"
-    assert not dst.is_file()
-    driverobj.namelist_file()
-    assert dst.is_file()
-    nml = f90nml.read(dst)
-    stop_time = cycle + timedelta(hours=1)
-    f = "%Y-%m-%d_%H:00:00"
-    assert nml["nhyd_model"]["config_start_time"] == cycle.strftime(f)
-    assert nml["nhyd_model"]["config_stop_time"] == stop_time.strftime(f)
-
-
-def test_MPASInit_namelist_file__fails_validation(driverobj, logged):
-    driverobj._config["namelist"]["update_values"]["nhyd_model"]["foo"] = None
-    path = Path(driverobj.namelist_file().refs)
-    assert not path.exists()
-    assert logged(f"Failed to validate {path}")
-    assert logged("  None is not of type 'array', 'boolean', 'number', 'string'")
-
-
-def test_MPASInit_namelist_file__missing_base_file(driverobj, logged):
-    base_file = str(Path(driverobj.config["rundir"], "missing.nml"))
-    driverobj._config["namelist"]["base_file"] = base_file
-    path = Path(driverobj.namelist_file().refs)
-    assert not path.exists()
-    assert logged("Not ready [external asset]")
 
 
 def test_MPASInit_provisioned_rundir(driverobj, ready_task):


### PR DESCRIPTION
**Synopsis**

Fixes #625.

This mostly refactors methods previously implemented on class `MPASInit` to class `MPASBase` so that they are also inherited by class `MPAS. A new `test_mpas_base` module is added to test static methods. Tests are added to module `test_mpas` to exercise concrete methods now implemented in class `MPAS`, as well as inherited methods that behave subtly differently in class `MPAS` vs `MPASInit` due to differences in configuration data. There is a little duplication, but I think the result is more straightforward than trying to work around the differences in the two driver classes via more complex, albeit DRYer, tests.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
