### PR TITLE
Add 'datetime' JSON Schema type

### DIFF
--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -5,6 +5,7 @@ Support for validating a config using JSON Schema.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
@@ -197,7 +198,7 @@ def _validation_errors(config: JSONValueT, schema: dict) -> list[ValidationError
     base = Draft202012Validator
     type_checker = base.TYPE_CHECKER.redefine(
         "fs_src", lambda _, x: any(isinstance(x, t) for t in [str, UWYAMLGlob])
-    )
+    ).redefine("datetime", lambda _, x: isinstance(x, datetime))
     uwvalidator = validators.extend(base, type_checker=type_checker)
     validator = uwvalidator(schema, registry=_registry())
     return list(validator.iter_errors(config))

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -6,7 +6,7 @@ import json
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
 
 from pytest import fixture, mark, raises
@@ -15,6 +15,9 @@ from uwtools.config import validator
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.exceptions import UWConfigError
 from uwtools.utils.file import resource_path
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 # Fixtures
 
@@ -78,10 +81,14 @@ def rocoto_assets():
 @fixture
 def schema() -> dict[str, Any]:
     return {
+        "additionalProperties": False,
         "properties": {
             "color": {
                 "enum": ["blue", "red"],
                 "type": "string",
+            },
+            "cycle": {
+                "type": "datetime",
             },
             "dir": {
                 "format": "uri",
@@ -257,5 +264,7 @@ def test_config_validator__validation_errors_bad_number_value(config, schema):
     assert len(validator._validation_errors(config, schema)) == 1
 
 
-def test_config_validator__validation_errors_pass(config, schema):
+def test_config_validator__validation_errors_pass(config, schema, utc):
+    cycle: datetime = utc(2025, 6, 3, 12)
+    config["cycle"] = cycle
     assert not validator._validation_errors(config, schema)

--- a/src/uwtools/tests/conftest.py
+++ b/src/uwtools/tests/conftest.py
@@ -36,10 +36,10 @@ def ready_task():
 
 @fixture
 def utc():
-    def datetime_utc(*args, **kwargs) -> datetime:
+    def utc(*args, **kwargs) -> datetime:
         # See https://github.com/python/mypy/issues/6799
         tz = timezone.utc
         dt = datetime(*args, **kwargs, tzinfo=tz) if args or kwargs else datetime.now(tz=tz)  # type: ignore[misc]
         return dt.replace(tzinfo=None)
 
-    return datetime_utc
+    return utc


### PR DESCRIPTION
**Synopsis**

Add a JSON Schema `datetime` type. There's no current use case inside `uwtools` itself, but this will be useful in client applications that use `uwtools` for config validation. For example, [wxvx](https://github.com/maddenp-cu/wxvx) calls on `uwtools` to validate [its config](https://github.com/maddenp-cu/wxvx/blob/main/src/wxvx/resources/config.yaml). Currently, lines in the `wxvx` config like
```
start: "2024-04-01T02:00:00"
```
require the value to be quoted so that it is parsed as a Python `str` rather than a `datetime` object, since the corresponding JSON Schema in `wxvx` says
```
"datetime": {
  "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$",
  "type": "string"
},
```
If the value is unquoted, it is parsed as a `datetime` object and then rejected by the schema.

With this enhancement, `wxvx` will be able to update its schema to
```
"datetime": {
  "anyOf": [
    {
      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$",
      "type": "string"
    },
    {
      "type": "datetime"
    }
  ]
},
```
to accept either quoted or unquoted values. Quoted values would be parsed and validated as before. Unquoted values would be parsed as `datetime` objects, if recognized as such, and validated by the second `anyOf` schema item.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
