### PR TITLE
Bug workflow.log update

### DIFF
--- a/docs/sections/user_guide/cli/tools/rocoto/rocoto.yaml
+++ b/docs/sections/user_guide/cli/tools/rocoto/rocoto.yaml
@@ -9,7 +9,8 @@ workflow:
   entities:
     ACCOUNT: myaccount
     FOO: test.log
-  log: /some/path/to/&FOO;
+  log: 
+    value: /some/path/to/&FOO;
   tasks:
     task_hello:
       attrs:

--- a/docs/sections/user_guide/yaml/rocoto.rst
+++ b/docs/sections/user_guide/yaml/rocoto.rst
@@ -26,7 +26,8 @@ Starting at the top level of the UW YAML config for Rocoto, there are several re
      entities:
        ACCOUNT: myaccount
        FOO: test.log
-     log: /some/path/to/&FOO;
+     log: 
+       value: /some/path/to/&FOO;
      tasks:
        ...
 
@@ -97,8 +98,9 @@ The ``<cyclestr>`` tag in Rocoto transforms specific flags to represent componen
    entities:
      FOO: test@Y-@m-@dT@X.log
    log:
-     cyclestr:
-       value: /some/path/to/&FOO;
+     value:
+       cyclestr:
+         value: /some/path/to/&FOO;
 
 In the example, the resulting log would appear in the XML file as:
 
@@ -113,14 +115,15 @@ Wherever a ``cyclestr:`` block is accepted, a YAML sequence mixing text and ``cy
 .. code-block:: yaml
 
    log:
-     - cyclestr:
-         value: "%Y%m%d%H"
-     - -through-
-     - cyclestr:
-         attrs:
-           offset: "06:00:00"
-         value: "%Y%m%d%H"
-     - .log
+     - value:
+       - cyclestr:
+           value: "%Y%m%d%H"
+       - -through-
+       - cyclestr:
+           attrs:
+             offset: "06:00:00"
+           value: "%Y%m%d%H"
+       - .log
 
 would be rendered as
 
@@ -373,7 +376,8 @@ Defining the Workflow Log
 
 .. code-block:: yaml
 
-   log: /some/path/to/workflow.log
+   log:
+     value: /some/path/to/workflow.log
 
 .. code-block:: xml
 
@@ -384,8 +388,9 @@ A cycle string may be specified here instead.
 .. code-block:: yaml
 
    log:
-     cyclestr:
-       value: /some/path/to/workflow_@Y@m@d.log
+     value:
+       cyclestr:
+         value: /some/path/to/workflow_@Y@m@d.log
 
 .. code-block:: xml
 

--- a/docs/shared/rocoto.yaml
+++ b/docs/shared/rocoto.yaml
@@ -12,7 +12,8 @@ workflow:
   entities:
     ACCOUNT: myaccount
     FOO: test.log
-  log: /some/path/to/&FOO;
+  log: 
+    value: /some/path/to/&FOO;
   tasks:
     task_hello:
       attrs:

--- a/notebooks/fixtures/rocoto/ent-cs-workflow.yaml
+++ b/notebooks/fixtures/rocoto/ent-cs-workflow.yaml
@@ -7,8 +7,9 @@ workflow:
   entities:
     LOG: "@Y-@m-@d/test@X.log"
   log: 
-    cyclestr:
-      value: logs/&LOG;
+    value:
+      cyclestr:
+        value: logs/&LOG;
   tasks:
     task_greet:
       command: echo Hello, World!

--- a/notebooks/fixtures/rocoto/ent-workflow.yaml
+++ b/notebooks/fixtures/rocoto/ent-workflow.yaml
@@ -6,7 +6,8 @@ workflow:
     - spec: 202410290000 202410300000 06:00:00
   entities:
     LOG: "2024-10-29/test06:00:00.log"
-  log: logs/&LOG;
+  log: 
+    value: logs/&LOG;
   tasks:
     task_greet:
       command: echo Hello, World!

--- a/notebooks/fixtures/rocoto/meta-nested-workflow.yaml
+++ b/notebooks/fixtures/rocoto/meta-nested-workflow.yaml
@@ -4,7 +4,8 @@ workflow:
     scheduler: slurm
   cycledef:
     - spec: 202410290000 202410300000 06:00:00
-  log: logs/test.log
+  log: 
+    value: logs/test.log
   tasks:
     metatask_process:
       var:

--- a/notebooks/fixtures/rocoto/meta-workflow.yaml
+++ b/notebooks/fixtures/rocoto/meta-workflow.yaml
@@ -4,7 +4,8 @@ workflow:
     scheduler: slurm
   cycledef:
     - spec: 202410290000 202410300000 06:00:00
-  log: logs/test.log
+  log: 
+    value: logs/test.log
   tasks:
     metatask_breakfast:
       var:

--- a/notebooks/fixtures/rocoto/simple-workflow.yaml
+++ b/notebooks/fixtures/rocoto/simple-workflow.yaml
@@ -4,7 +4,8 @@ workflow:
     scheduler: slurm
   cycledef:
     - spec: 202410290000 202410300000 06:00:00
-  log: logs/test.log
+  log: 
+    value: logs/test.log
   tasks:
     task_greet:
       command: echo Hello, World!

--- a/notebooks/fixtures/rocoto/tasks-deps-workflow.yaml
+++ b/notebooks/fixtures/rocoto/tasks-deps-workflow.yaml
@@ -4,7 +4,8 @@ workflow:
     scheduler: slurm
   cycledef:
     - spec: 202410290000 202410300000 06:00:00
-  log: logs/test.log
+  log: 
+    value: logs/test.log
   tasks:
     task_bacon:
       command: "echo Cooking bacon..."

--- a/notebooks/fixtures/rocoto/tasks-workflow.yaml
+++ b/notebooks/fixtures/rocoto/tasks-workflow.yaml
@@ -4,7 +4,8 @@ workflow:
     scheduler: slurm
   cycledef:
     - spec: 202410290000 202410300000 06:00:00
-  log: logs/test.log
+  log: 
+    value: logs/test.log
   tasks:
     task_bacon:
       command: "echo Cooking bacon..."

--- a/notebooks/rocoto.ipynb
+++ b/notebooks/rocoto.ipynb
@@ -355,8 +355,8 @@
       "    - spec: 202410290000 202410300000 06:00:00\n",
       "  entities:\n",
       "    LOG: \"@Y-@m-@d/test@X.log\"\n",
-      "  log: \n",
-      "    value:
+      "  log:\n",
+      "    value:\n",
       "      cyclestr:\n",
       "        value: logs/&LOG;\n",
       "  tasks:\n",
@@ -483,7 +483,7 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: 
+      "  log:\n", 
       "    value: logs/test.log\n",
       "  tasks:\n",
       "    task_bacon:\n",
@@ -529,7 +529,7 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: 
+      "  log:\n", 
       "    value: logs/test.log\n",
       "  tasks:\n",
       "    task_bacon:\n",
@@ -690,7 +690,7 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: 
+      "  log:\n", 
       "    value: logs/test.log\n",
       "  tasks:\n",
       "    metatask_breakfast:\n",
@@ -817,7 +817,7 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: 
+      "  log:\n", 
       "    value: logs/test.log\n",
       "  tasks:\n",
       "    metatask_process:\n",

--- a/notebooks/rocoto.ipynb
+++ b/notebooks/rocoto.ipynb
@@ -104,7 +104,8 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: logs/test.log\n",
+      "  log: 
+      "    value: logs/test.log\n",
       "  tasks:\n",
       "    task_greet:\n",
       "      command: echo Hello, World!\n",
@@ -312,7 +313,8 @@
       "    - spec: 202410290000 202410300000 06:00:00\n",
       "  entities:\n",
       "    LOG: \"2024-10-29/test06:00:00.log\"\n",
-      "  log: logs/&LOG;\n",
+      "  log: 
+      "    value: logs/&LOG;\n",
       "  tasks:\n",
       "    task_greet:\n",
       "      command: echo Hello, World!\n",
@@ -354,8 +356,9 @@
       "  entities:\n",
       "    LOG: \"@Y-@m-@d/test@X.log\"\n",
       "  log: \n",
-      "    cyclestr:\n",
-      "      value: logs/&LOG;\n",
+      "    value:
+      "      cyclestr:\n",
+      "        value: logs/&LOG;\n",
       "  tasks:\n",
       "    task_greet:\n",
       "      command: echo Hello, World!\n",
@@ -480,7 +483,8 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: logs/test.log\n",
+      "  log: 
+      "    value: logs/test.log\n",
       "  tasks:\n",
       "    task_bacon:\n",
       "      command: \"echo Cooking bacon...\"\n",
@@ -525,7 +529,8 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: logs/test.log\n",
+      "  log: 
+      "    value: logs/test.log\n",
       "  tasks:\n",
       "    task_bacon:\n",
       "      command: \"echo Cooking bacon...\"\n",
@@ -685,7 +690,8 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: logs/test.log\n",
+      "  log: 
+      "    value: logs/test.log\n",
       "  tasks:\n",
       "    metatask_breakfast:\n",
       "      var:\n",
@@ -811,7 +817,8 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: logs/test.log\n",
+      "  log: 
+      "    value: logs/test.log\n",
       "  tasks:\n",
       "    metatask_process:\n",
       "      var:\n",

--- a/notebooks/rocoto.ipynb
+++ b/notebooks/rocoto.ipynb
@@ -104,7 +104,7 @@
       "    scheduler: slurm\n",
       "  cycledef:\n",
       "    - spec: 202410290000 202410300000 06:00:00\n",
-      "  log: 
+      "  log:\n", 
       "    value: logs/test.log\n",
       "  tasks:\n",
       "    task_greet:\n",
@@ -313,7 +313,7 @@
       "    - spec: 202410290000 202410300000 06:00:00\n",
       "  entities:\n",
       "    LOG: \"2024-10-29/test06:00:00.log\"\n",
-      "  log: 
+      "  log:\n", 
       "    value: logs/&LOG;\n",
       "  tasks:\n",
       "    task_greet:\n",

--- a/src/uwtools/resources/jsonschema/rocoto.jsonschema
+++ b/src/uwtools/resources/jsonschema/rocoto.jsonschema
@@ -566,6 +566,7 @@
         },
         "log": {
           "properties": {
+            "$ref": "#/$defs/compoundTimeString",
             "attrs": {
               "additionalProperties": false,
               "properties": {
@@ -574,10 +575,9 @@
                 }
               },
               "type": "object"
-            },
-            "$ref": "#/$defs/compoundTimeString"
+            }
           },
-	  "type": "object"
+          "type": "object"
         },
         "tasks": {
           "additionalProperties": false,

--- a/src/uwtools/resources/jsonschema/rocoto.jsonschema
+++ b/src/uwtools/resources/jsonschema/rocoto.jsonschema
@@ -565,8 +565,8 @@
           "type": "object"
         },
         "log": {
+          "additionalProperties": false,
           "properties": {
-            "$ref": "#/$defs/compoundTimeString",
             "attrs": {
               "additionalProperties": false,
               "properties": {
@@ -575,8 +575,14 @@
                 }
               },
               "type": "object"
+            },
+            "value": {
+              "$ref": "#/$defs/compoundTimeString"
             }
           },
+          "required": [
+            "value"
+          ],
           "type": "object"
         },
         "tasks": {

--- a/src/uwtools/resources/jsonschema/rocoto.jsonschema
+++ b/src/uwtools/resources/jsonschema/rocoto.jsonschema
@@ -565,7 +565,20 @@
           "type": "object"
         },
         "log": {
-          "$ref": "#/$defs/compoundTimeString"
+	  "additionalProperties": false,
+          "properties": {
+            "attrs": {
+              "additionalProperties": false,
+              "properties": {
+	        "verbosity": {
+		  "type": "integer"
+		}
+	      }
+	    }, 
+	    "value": {
+              "$ref": "#/$defs/compoundTimeString"
+            }
+	  }  
         },
         "tasks": {
           "additionalProperties": false,

--- a/src/uwtools/resources/jsonschema/rocoto.jsonschema
+++ b/src/uwtools/resources/jsonschema/rocoto.jsonschema
@@ -565,20 +565,18 @@
           "type": "object"
         },
         "log": {
-	  "additionalProperties": false,
+          "$ref": "#/$defs/compoundTimeString",
           "properties": {
             "attrs": {
               "additionalProperties": false,
               "properties": {
-	        "verbosity": {
-		  "type": "integer"
-		}
-	      }
-	    }, 
-	    "value": {
-              "$ref": "#/$defs/compoundTimeString"
+                "verbosity": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
             }
-	  }  
+          }
         },
         "tasks": {
           "additionalProperties": false,

--- a/src/uwtools/resources/jsonschema/rocoto.jsonschema
+++ b/src/uwtools/resources/jsonschema/rocoto.jsonschema
@@ -565,7 +565,6 @@
           "type": "object"
         },
         "log": {
-          "$ref": "#/$defs/compoundTimeString",
           "properties": {
             "attrs": {
               "additionalProperties": false,
@@ -575,8 +574,10 @@
                 }
               },
               "type": "object"
-            }
-          }
+            },
+            "$ref": "#/$defs/compoundTimeString"
+          },
+	  "type": "object"
         },
         "tasks": {
           "additionalProperties": false,

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -339,7 +339,8 @@ class _RocotoXML:
         :param logfile: The path to the log file.
         """
         tag = STR.log
-        self._add_compound_time_string(e, config[tag], tag)
+        e = self._add_compound_time_string(e, config[tag][STR.value], tag)
+        self._set_attrs(e, config[tag])
 
     def _add_workflow_tasks(self, e: _Element, config: dict) -> None:
         """

--- a/src/uwtools/tests/fixtures/hello_workflow.yaml
+++ b/src/uwtools/tests/fixtures/hello_workflow.yaml
@@ -10,7 +10,8 @@ workflow:
   entities:
     ACCOUNT: myaccount
     FOO: test.log
-  log: /some/path/to/&FOO;
+  log: 
+    value: /some/path/to/&FOO;
   tasks:
     task_hello:
       attrs:

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -436,7 +436,7 @@ class TestRocotoXML:
             "workflow": {
                 "attrs": {"realtime": True, "scheduler": "slurm"},
                 "cycledef": [],
-                "log": "1",
+                "log": {"value": "1"},
                 "tasks": {
                     "task_foo": {
                         "command": "echo hello",
@@ -475,14 +475,14 @@ class TestRocotoXML:
 
     def test__add_workflow_log_basic(self, instance, root):
         val = "/path/to/logfile"
-        instance._add_workflow_log(e=root, config={"log": val})
+        instance._add_workflow_log(e=root, config={"log": {"value": val}})
         log = root[0]
         assert log.tag == "log"
         assert log.text == val
 
     def test__add_workflow_log_cyclestr(self, instance, root):
         val = "/path/to/logfile-@Y@m@d@H"
-        instance._add_workflow_log(e=root, config={"log": {"cyclestr": {"value": val}}})
+        instance._add_workflow_log(e=root, config={"log": {"value": {"cyclestr": {"value": val}}}})
         log = root[0]
         assert log.tag == "log"
         assert log.xpath("cyclestr")[0].text == val

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1970,10 +1970,12 @@ def test_schema_rocoto_task_resources():
 def test_schema_rocoto_workflow_log():
     errors = schema_validator("rocoto", "properties", "workflow", "properties", "log")
     # Basic spec:
-    assert not errors({"value": {"cyclestr": {"value": "foo"}}, "attrs": {"verbosity": 10}})
+    assert not errors({"value": "foo"})
     # The "value" property is mandatory:
     assert "'value' is a required property" in errors({"attrs": {"verbosity": 10}})
-    # Optional attribute "verbosity" is supported:
+    # Optional "verbosity" attribute is supported:
+    assert not errors({"value": {"cyclestr": {"value": "foo"}}, "attrs": {"verbosity": 10}})
+    # Optional "cyclestr" property is supported
     assert not errors({"value": {"cyclestr": {"value": "foo"}}})
 
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1970,11 +1970,11 @@ def test_schema_rocoto_task_resources():
 def test_schema_rocoto_workflow_log():
     errors = schema_validator("rocoto", "properties", "workflow", "properties", "log")
     # Basic spec:
-    assert not errors({"log": {"cyclestr": {"value": "foo"}}, "verbosity": 10})
-    # The "cyclestr" property is mandatory:
-    assert "cyclestr' is a required property" in errors({"log": {"verbosity": 10}})
+    assert not errors({"value": {"cyclestr": {"value": "foo"}}, "attrs": {"verbosity": 10}})
+    # The "value" property is mandatory:
+    assert "'value' is a required property" in errors({"attrs": {"verbosity": 10}})
     # Optional attribute "verbosity" is supported:
-    assert not errors({"log": {"cyclestr": {"value": "foo"}}})
+    assert not errors({"value": {"cyclestr": {"value": "foo"}}})
 
 
 # schism

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1967,6 +1967,16 @@ def test_schema_rocoto_task_resources():
     assert not errors([{"native": "abc", "nodes": "1:ppn=12"}])
 
 
+def test_schema_rocoto_workflow_log():
+    errors = schema_validator("rocoto", "properties", "workflow", "properties", "log")
+    # Basic spec:
+    assert not errors({"log": {"cyclestr": {"value": "foo"}}, "verbosity": 10})
+    # The "cyclestr" property is mandatory:
+    assert "cyclestr' is a required property" in errors({"log": {"verbosity": 10}})
+    # Optional attribute "verbosity" is supported:
+    assert not errors({"log": {"cyclestr": {"value": "foo"}}})
+
+
 # schism
 
 


### PR DESCRIPTION
**Synopsis**

- The `log` property has an optional `verbosity` attribute that was not included in the `rocoto/jsonschema`. To correct this issue an update to the structure of the `workflow.log` property was made.


Previous functionality
```
workflow:
.....
  log: /some/path/to/&FOO;
.....
```
or 
```
workflow:
.....
  log: 
    cyclestr:
      value: /some/path/to/&FOO;
.....
```

- The new functionality allows for an `attrs` property that will include an optional `verbosity` attribute.
- With the new `attrs` property, we will add a `value` property at the same level to store a `path` or dict `cyclestr.value` as seen before.

New functionality
```
workflow:
.....
  log: 
    value: /some/path/to/&FOO;
.....
```
or 
```
workflow:
.....
  log: 
    value:
      cyclestr:
        value: /some/path/to/&FOO;
.....
```

- Passes with 100% test coverage
- `notebooks/rocoto` and `notebooks/fixtures/rocoto` were updated
- RtD were updated
- Added new test case to account for this update to log
- Updated `tests/fixtures` YAMLs
- Test cases were updated for new `workflow.log` structure

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
