### PR TITLE
No user-agent string overrides

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,7 +13,7 @@ clean:
 
 docs:
 	$(MAKE) html
-	linkchecker --check-extern --no-warnings --user-agent Mozilla/5.0 build/html/index.html
+	linkchecker --check-extern --no-warnings build/html/index.html
 
 examples:
 	COLUMNS=80 $(MAKE) -C sections

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@ numfig = True
 numfig_format = {"figure": "Figure %s"}
 project = "Unified Workflow Tools"
 release = _metadata["version"]
-user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
 version = _metadata["version"]
 
 extlinks = {


### PR DESCRIPTION
**Synopsis**

I previously added user-agent overrides so that Sphinx and `linkchecker` would look like web browsers to remote sites, in case those sites were rejecting connections from non-browser utilities. This seems not to be necessary now, and I'm in fact afraid that more sophisticated threat detecting might see something suspicious about this: Yesterday, my IP address got temporarily banned by the gnu.org domain, and after talking to the webmaster via email, it seems that connections from Python on my system -- which I think only could have been from our documentation-building code -- were the cause. So, in the absence of a current reason to keep these, and out out of an abundance of caution, I think we should remove them. (It's also good netiquette to tell the truth whenever you can.)

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
