### PR TITLE
YAML-key -> driver-class map

### DIFF
--- a/src/uwtools/api/driver.py
+++ b/src/uwtools/api/driver.py
@@ -2,6 +2,10 @@
 API access to the ``uwtools`` driver base classes.
 """
 
+from importlib import import_module
+from inspect import getmembers, isclass
+from pkgutil import iter_modules
+
 from uwtools.drivers.driver import (
     Assets,
     AssetsCycleBased,
@@ -13,6 +17,26 @@ from uwtools.drivers.driver import (
     DriverTimeInvariant,
 )
 
+
+def yaml_keys_to_classes() -> dict[str, type]:
+    """
+    Returns a mapping from UW YAML driver-block keys to their associated driver classes.
+    """
+    pkgname = "uwtools.api"
+    mapping = {}
+    for modinfo in iter_modules(import_module(pkgname).__path__):
+        module = import_module(f"{pkgname}.{modinfo.name}")
+        for driver_class in {obj for _, obj in getmembers(module) if isclass(obj)}:
+            try:
+                yaml_key = driver_class.driver_name()
+            except AttributeError:  # noqa: PERF203
+                pass
+            else:
+                if yaml_key:
+                    mapping[yaml_key] = driver_class
+    return mapping
+
+
 __all__ = [
     "Assets",
     "AssetsCycleBased",
@@ -22,4 +46,5 @@ __all__ = [
     "DriverCycleBased",
     "DriverCycleLeadtimeBased",
     "DriverTimeInvariant",
+    "yaml_keys_to_classes",
 ]

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -10,7 +10,10 @@ import stat
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import partial
+from importlib import import_module
+from inspect import getmembers, isclass
 from pathlib import Path
+from pkgutil import iter_modules
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Union
 
@@ -692,3 +695,14 @@ _add_docstring(Driver)
 _add_docstring(DriverCycleBased, omit=[STR.leadtime])
 _add_docstring(DriverCycleLeadtimeBased)
 _add_docstring(DriverTimeInvariant, omit=[STR.cycle, STR.leadtime])
+
+
+def config_blocks_to_classes():
+    pkgname = "uwtools.api"
+    for x in iter_modules(import_module(pkgname).__path__):
+        module = import_module(f"{pkgname}.{x.name}")
+        members = getmembers(module)
+        classes = {obj for _, obj in members if isclass(obj)}
+        for c in classes:
+            if hasattr(c, "driver_name"):
+                print(c.driver_name(), c)

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -10,10 +10,7 @@ import stat
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import partial
-from importlib import import_module
-from inspect import getmembers, isclass
 from pathlib import Path
-from pkgutil import iter_modules
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Union
 
@@ -695,14 +692,3 @@ _add_docstring(Driver)
 _add_docstring(DriverCycleBased, omit=[STR.leadtime])
 _add_docstring(DriverCycleLeadtimeBased)
 _add_docstring(DriverTimeInvariant, omit=[STR.cycle, STR.leadtime])
-
-
-def config_blocks_to_classes():
-    pkgname = "uwtools.api"
-    for x in iter_modules(import_module(pkgname).__path__):
-        module = import_module(f"{pkgname}.{x.name}")
-        members = getmembers(module)
-        classes = {obj for _, obj in members if isclass(obj)}
-        for c in classes:
-            if hasattr(c, "driver_name"):
-                print(c.driver_name(), c)

--- a/src/uwtools/tests/api/test_driver.py
+++ b/src/uwtools/tests/api/test_driver.py
@@ -17,5 +17,13 @@ from uwtools.drivers import driver as driver_lib
         "DriverTimeInvariant",
     ],
 )
-def test_driver(classname):
+def test_api_driver(classname):
     assert getattr(driver_api, classname) is getattr(driver_lib, classname)
+
+
+def test_api_driver_yaml_keys_to_classes():
+    mapping = driver_api.yaml_keys_to_classes()
+    assert mapping
+    for k, v in mapping.items():
+        assert isinstance(k, str)
+        assert issubclass(v, driver_api.Assets)


### PR DESCRIPTION
**Synopsis**

Provide an API routine that returns a `dict` mapping UW YAML driver-block keys (e.g. `mpas_init`, `upp`) to the associated classes (e.g. `MPASInit`, `UPP`). An immediate use case involves `mpas_app` [Issue 49](https://github.com/orgs/NOAA-GSL/projects/43?pane=issue&itemId=108287277&issue=NOAA-GSL%7Cmpas_planning%7C49) where, given an experiment-YAML keypath leading to a driver-config block with a UW-mandated key, application code needs to obtain a driver class object to instantiate a driver instance to validate the config block.

For example:

```
>>> from pprint import pprint
>>> from uwtools.api import driver
>>> pprint(driver.yaml_keys_to_classes())
{'cdeps': <class 'uwtools.drivers.cdeps.CDEPS'>,
 'chgres_cube': <class 'uwtools.drivers.chgres_cube.ChgresCube'>,
 'esg_grid': <class 'uwtools.drivers.esg_grid.ESGGrid'>,
 'filter_topo': <class 'uwtools.drivers.filter_topo.FilterTopo'>,
 'fv3': <class 'uwtools.drivers.fv3.FV3'>,
 'global_equiv_resol': <class 'uwtools.drivers.global_equiv_resol.GlobalEquivResol'>,
 'ioda': <class 'uwtools.drivers.ioda.IODA'>,
 'jedi': <class 'uwtools.drivers.jedi.JEDI'>,
 'make_hgrid': <class 'uwtools.drivers.make_hgrid.MakeHgrid'>,
 'make_solo_mosaic': <class 'uwtools.drivers.make_solo_mosaic.MakeSoloMosaic'>,
 'mpas': <class 'uwtools.drivers.mpas.MPAS'>,
 'mpas_init': <class 'uwtools.drivers.mpas_init.MPASInit'>,
 'orog': <class 'uwtools.drivers.orog.Orog'>,
 'orog_gsl': <class 'uwtools.drivers.orog_gsl.OrogGSL'>,
 'schism': <class 'uwtools.drivers.schism.SCHISM'>,
 'sfc_climo_gen': <class 'uwtools.drivers.sfc_climo_gen.SfcClimoGen'>,
 'shave': <class 'uwtools.drivers.shave.Shave'>,
 'ungrib': <class 'uwtools.drivers.ungrib.Ungrib'>,
 'upp': <class 'uwtools.drivers.upp.UPP'>,
 'upp_assets': <class 'uwtools.drivers.upp_assets.UPPAssets'>,
 'ww3': <class 'uwtools.drivers.ww3.WaveWatchIII'>}
```

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
