### PR TITLE
Bugfix: Do not modify user-provided configs via drivers

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -30,10 +30,10 @@ class Config(ABC, UserDict):
         super().__init__()
         if isinstance(config, dict):
             self._config_file = None
-            self.update(config)
+            self.update(deepcopy(config))
         elif isinstance(config, Config):
             self._config_file = config._config_file  # noqa: SLF001
-            self.update(config.data)
+            self.update(deepcopy(config.data))
         else:
             self._config_file = str2path(config) if config else None
             self.data = self._load(self._config_file)

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -55,15 +55,15 @@ class Assets(ABC):
         schema_file: Path | None = None,
         controller: list[YAMLKey] | None = None,
     ) -> None:
-        config_input = config if isinstance(config, YAMLConfig) else YAMLConfig(config=config)
-        config_input.dereference(
+        config_copy = YAMLConfig(config)
+        config_copy.dereference(
             context={
                 **({STR.cycle: cycle} if cycle else {}),
                 **({STR.leadtime: leadtime} if leadtime is not None else {}),
-                **config_input.data,
+                **config_copy.data,
             }
         )
-        self._config_full: dict = config_input.data
+        self._config_full: dict = config_copy.data
         self._config_intermediate, _ = walk_key_path(self._config_full, key_path or [])
         try:
             self._config: dict = self._config_intermediate[self.driver_name()]

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -3,6 +3,7 @@ Tests for the uwtools.config.base module.
 """
 
 import os
+from copy import deepcopy
 from datetime import datetime
 from textwrap import dedent
 from typing import cast
@@ -188,6 +189,18 @@ def test_compare_config_ini(logged, salad_base):
 def test_config_from_config(config):
     assert config.config_file.name == "config.yaml"
     assert ConcreteConfig(config).data == config.data
+
+
+@mark.parametrize("f", [dict, ConcreteConfig])
+def test_config_from_config_immutable(f):
+    sub = {"shared": 1}
+    original = {"foo": "bar", "baz": sub}
+    config = f(deepcopy(original))
+    c = ConcreteConfig(config)
+    assert c.data == original
+    assert config == original
+    config["baz"]["shared"] = 2
+    assert c.data == original
 
 
 def test_config_from_file(config):

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+from copy import deepcopy
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock, PropertyMock, patch
@@ -145,6 +146,20 @@ def test_Assets_fail_bad_config(config):
     with raises(UWConfigError) as e:
         ConcreteAssetsTimeInvariant(config=config["concrete"])
     assert str(e.value) == "Required 'concrete' block missing in config"
+
+
+def test_Assets_config_copy_from_dict(config):
+    original = deepcopy(config)
+    ConcreteAssetsTimeInvariant(config)
+    assert config == original
+
+
+def test_Assets_config_copy_from_yaml_config(config):
+    original = deepcopy(config)
+    yaml_config = YAMLConfig(config)
+    ConcreteAssetsTimeInvariant(yaml_config)
+    assert config == original
+    assert yaml_config.data == original
 
 
 def test_Assets___repr___cycle_based(config, utc):


### PR DESCRIPTION
**Synopsis**

Fixes a bug whereby dereferencing a config in a driver's initializer affected a `YAMLConfig` object passed to the driver. Ensure that drivers have an independent deep copy of the user-provided config, insulating both parties from unexpected changes.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
