### PR TITLE
Chunked HTTP get to avoid memory issues

### DIFF
--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -112,7 +112,7 @@ def test_utils_tasks_filecopy__source_http(code, expected, src, tmp_path):
         with patch.object(tasks, "requests") as requests:
             response = requests.get()
             response.status_code = code
-            response.iter_content.return_value = iter([b"foo", b"bar", b"baz"])
+            response.iter_content.return_value = iter([b"f", b"o", b"o"])
             tasks.filecopy(src=src, dst=dst)
         requests.get.assert_called_with(src, allow_redirects=True, stream=True, timeout=3)
     assert dst.is_file() is expected
@@ -239,12 +239,12 @@ def test_utils_tasks_filecopy_http(ready_task, tmp_path):
         patch.object(tasks, "existing_http", wraps=ready_task) as existing_http,
     ):
         response = Mock(status_code=200)
-        response.iter_content.return_value = iter([b"foo", b"bar", b"baz"])
+        response.iter_content.return_value = iter([b"f", b"o", b"o"])
         get.return_value = response
         tasks.filecopy_http(url=url, dst=dst)
     existing_http.assert_called_once_with(url)
     get.assert_called_once_with(url, allow_redirects=True, stream=True, timeout=3)
-    assert dst.read_bytes() == b"foobarbaz"
+    assert dst.read_bytes() == b"foo"
 
 
 def test_utils_tasks_filecopy_local(tmp_path):

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -112,9 +112,9 @@ def test_utils_tasks_filecopy__source_http(code, expected, src, tmp_path):
         with patch.object(tasks, "requests") as requests:
             response = requests.get()
             response.status_code = code
-            response.content = b"data"
+            response.iter_content.return_value = iter([b"foo", b"bar", b"baz"])
             tasks.filecopy(src=src, dst=dst)
-        requests.get.assert_called_with(src, allow_redirects=True, timeout=3)
+        requests.get.assert_called_with(src, allow_redirects=True, stream=True, timeout=3)
     assert dst.is_file() is expected
 
 
@@ -238,12 +238,13 @@ def test_utils_tasks_filecopy_http(ready_task, tmp_path):
         patch.object(tasks.requests, "get") as get,
         patch.object(tasks, "existing_http", wraps=ready_task) as existing_http,
     ):
-        response = Mock(status_code=200, content=b"data")
+        response = Mock(status_code=200)
+        response.iter_content.return_value = iter([b"foo", b"bar", b"baz"])
         get.return_value = response
         tasks.filecopy_http(url=url, dst=dst)
     existing_http.assert_called_once_with(url)
-    get.assert_called_once_with(url, allow_redirects=True, timeout=3)
-    assert dst.exists()
+    get.assert_called_once_with(url, allow_redirects=True, stream=True, timeout=3)
+    assert dst.read_bytes() == b"foobarbaz"
 
 
 def test_utils_tasks_filecopy_local(tmp_path):

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -182,9 +182,11 @@ def filecopy_http(url: str, dst: Path, check: bool = True):
     yield asset(dst, dst.is_file)
     yield existing_http(url) if check else None
     dst.parent.mkdir(parents=True, exist_ok=True)
-    response = requests.get(url, allow_redirects=True, timeout=3)
+    response = requests.get(url, allow_redirects=True, stream=True, timeout=3)
     if (code := response.status_code) == HTTPStatus.OK:
-        dst.write_bytes(response.content)
+        with dst.open(mode="wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
     else:
         log.error("Could not get '%s', HTTP status was: %s", url, code)
 


### PR DESCRIPTION
**Synopsis**

To avoid out-of-memory issues when fetching large remote files via HTTP, use streaming, chunked reads/writes instead of reading the entire file into memory and _then_ writing it to disk. This should be an optimization invisible to users.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
