### PR TITLE
Rocoto sh dependency attrs are optional

### DIFF
--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -254,6 +254,8 @@ class _RocotoXML:
         :param name_attr: XML name attribute for element.
         """
         e = self._add_compound_time_string(e, config[STR.command], STR.sh)
+        if STR.attrs not in config:
+            config[STR.attrs] = {}
         config[STR.attrs][STR.name] = name_attr
         self._set_attrs(e, config)
 

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -304,7 +304,19 @@ class TestRocotoXML:
         assert e.tag == "timedep"
         assert e.text == str(value)
 
-    def test__add_task_dependency_sh(self, instance, root):
+    def test__add_task_dependency_sh__no_attrs(self, instance, root):
+        config = {"sh_foo": {"command": "ls"}}
+        errors = schema_validator("rocoto", "$defs", "dependency")
+        assert not errors(config)
+        instance._add_task_dependency(e=root, config=config)
+        dependency = root[0]
+        assert dependency.tag == "dependency"
+        sh = dependency[0]
+        assert sh.tag == "sh"
+        assert sh.get("name") == "foo"
+        assert sh.text == "ls"
+
+    def test__add_task_dependency_sh__with_attrs(self, instance, root):
         config = {"sh_foo": {"attrs": {"runopt": "-c", "shell": "/bin/bash"}, "command": "ls"}}
         errors = schema_validator("rocoto", "$defs", "dependency")
         assert not errors(config)


### PR DESCRIPTION
**Synopsis**

I believe this fixes a bug whereby Python code mistakenly assumes that an `attrs:` block exists under a `sh:` dependency, while this is not required by the schema and appears not to be required by Rocoto.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
