### PR TITLE
Add MPASSIT runcmd

### DIFF
--- a/src/uwtools/drivers/mpassit.py
+++ b/src/uwtools/drivers/mpassit.py
@@ -50,9 +50,8 @@ class MPASSIT(DriverCycleLeadtimeBased):
         """
         The namelist file.
         """
-        fn = "fort.41"
-        yield self.taskname(fn)
-        path = self.rundir / fn
+        path = self._input_config_path
+        yield self.taskname(path.name)
         yield asset(path, path.is_file)
         base_file = self.config[STR.namelist].get(STR.basefile)
         yield file(Path(base_file)) if base_file else None
@@ -91,7 +90,7 @@ class MPASSIT(DriverCycleLeadtimeBased):
         Returns a description of the file(s) created when this component runs.
         """
         with TemporaryDirectory() as path:
-            nml = Path(path, "fort.41")
+            nml = Path(path, self._input_config_path.name)
             self.create_user_updated_config(
                 config_class=NMLConfig,
                 config_values=self.config[STR.namelist],
@@ -100,3 +99,20 @@ class MPASSIT(DriverCycleLeadtimeBased):
             )
             namelist = get_nml_config(nml)
         return {"path": self.rundir / namelist["config"]["output_file"]}
+
+    # Private helper methods
+
+    @property
+    def _input_config_path(self) -> Path:
+        """
+        Path to the input config file.
+        """
+        return self.rundir / "mpassit.nml"
+
+    @property
+    def _runcmd(self) -> str:
+        """
+        The full command-line component invocation.
+        """
+        executable = self.config[STR.execution][STR.executable]
+        return "%s %s" % (executable, self._input_config_path.name)

--- a/src/uwtools/tests/drivers/test_mpassit.py
+++ b/src/uwtools/tests/drivers/test_mpassit.py
@@ -60,7 +60,7 @@ def test_MPASSIT_files_copied_and_linked(config, cycle, key, leadtime, task, tes
 
 
 def test_MPASSIT_namelist_file(driverobj, logged, ready_task):
-    dst = driverobj.rundir / "fort.41"
+    dst = driverobj._input_config_path
     assert not dst.is_file()
     with patch.object(mpassit, "file", new=ready_task):
         path = Path(driverobj.namelist_file().ref)
@@ -93,3 +93,11 @@ def test_MPASSIT_provisioned_rundir(driverobj, ready_task):
         driverobj.provisioned_rundir()
     for m in mocks:
         mocks[m].assert_called_once_with()
+
+
+def test_MPASSIT__input_config_path(driverobj, tmp_path):
+    assert driverobj._input_config_path == tmp_path / "mpassit.nml"
+
+
+def test_MPASSIT__runcmd(driverobj):
+    assert driverobj._runcmd == "/path/to/mpassit mpassit.nml"


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->
Adds MPASSIT Driver run command that accepts the namelist name as a command line argument.

Fixes #774 

**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
