### PR TITLE
Better reporting of anyOf / oneOf schema-validation errors

### DIFF
--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
 from jsonschema import Draft202012Validator, validators
-from jsonschema._utils import Unset
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
 
@@ -87,11 +86,9 @@ def validate(schema: dict, desc: str, config: JSONValueT) -> bool:
             location = ".".join(str(k) for k in error.path) if error.path else "top level"
             log.error("Error at %s:", location)
             quantifiers = {"allOf": "All", "anyOf": "At least one", "oneOf": "Exactly one"}
-            if error.validator in quantifiers:
+            if error.validator in quantifiers and (items := error.context):
                 pre = quantifiers[str(error.validator)]
                 log.error("%s%s of the following must hold:", INDENT, pre)
-                items = error.context or error.validator_value
-                assert not isinstance(items, Unset)
                 for item in items:
                     msg = item.message if hasattr(item, "message") else item
                     log.error("%s%s", INDENT * 2, msg)

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -85,15 +85,11 @@ def validate(schema: dict, desc: str, config: JSONValueT) -> bool:
         for error in errors:
             location = ".".join(str(k) for k in error.path) if error.path else "top level"
             log.error("Error at %s:", location)
-            quantifiers = {
-                "allOf": "All",
-                "anyOf": "At least one",
-                "oneOf": "Exactly one",
-            }            
+            quantifiers = {"allOf": "All", "anyOf": "At least one", "oneOf": "Exactly one"}
             if error.validator in quantifiers:
+                pre = quantifiers[str(error.validator)]
                 if error.context:
-                    quantifier = quantifiers[str(error.validator)]
-                    log.error("%s%s of the following must hold:", INDENT, quantifier)
+                    log.error("%s%s of the following must hold:", INDENT, pre)
                     for item in error.context:
                         log.error("%s%s", INDENT * 2, item.message)
             else:

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -85,7 +85,17 @@ def validate(schema: dict, desc: str, config: JSONValueT) -> bool:
         for error in errors:
             location = ".".join(str(k) for k in error.path) if error.path else "top level"
             log.error("Error at %s:", location)
-            log.error("%s%s", INDENT, error.message)
+            if error.context:
+                quantifier = {
+                    "allOf": "All",
+                    "anyOf": "At least one",
+                    "oneOf": "Exactly one",
+                }[str(error.validator)]
+                log.error("%s%s of the following must hold:", INDENT, quantifier)
+                for item in error.context:
+                    log.error("%s%s", INDENT * 2, item.message)
+            else:
+                log.error("%s%s", INDENT, error.message)
     return valid
 
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -85,15 +85,17 @@ def validate(schema: dict, desc: str, config: JSONValueT) -> bool:
         for error in errors:
             location = ".".join(str(k) for k in error.path) if error.path else "top level"
             log.error("Error at %s:", location)
-            if error.context:
-                quantifier = {
-                    "allOf": "All",
-                    "anyOf": "At least one",
-                    "oneOf": "Exactly one",
-                }[str(error.validator)]
-                log.error("%s%s of the following must hold:", INDENT, quantifier)
-                for item in error.context:
-                    log.error("%s%s", INDENT * 2, item.message)
+            quantifiers = {
+                "allOf": "All",
+                "anyOf": "At least one",
+                "oneOf": "Exactly one",
+            }            
+            if error.validator in quantifiers:
+                if error.context:
+                    quantifier = quantifiers[str(error.validator)]
+                    log.error("%s%s of the following must hold:", INDENT, quantifier)
+                    for item in error.context:
+                        log.error("%s%s", INDENT * 2, item.message)
             else:
                 log.error("%s%s", INDENT, error.message)
     return valid

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -86,7 +86,7 @@ def validate(schema: dict, desc: str, config: JSONValueT) -> bool:
             location = ".".join(str(k) for k in error.path) if error.path else "top level"
             log.error("Error at %s:", location)
             log.error("%s%s", INDENT, error.message)
-            quantifiers = {"allOf": "All", "anyOf": "At least one", "oneOf": "Exactly one"}
+            quantifiers = {"anyOf": "At least one", "oneOf": "Exactly one"}
             if error.validator in quantifiers:
                 if items := error.context:
                     log.error("%sCandidate rules are:", INDENT)

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
 from jsonschema import Draft202012Validator, validators
+from jsonschema._utils import Unset
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
 
@@ -88,10 +89,12 @@ def validate(schema: dict, desc: str, config: JSONValueT) -> bool:
             quantifiers = {"allOf": "All", "anyOf": "At least one", "oneOf": "Exactly one"}
             if error.validator in quantifiers:
                 pre = quantifiers[str(error.validator)]
-                if error.context:
-                    log.error("%s%s of the following must hold:", INDENT, pre)
-                    for item in error.context:
-                        log.error("%s%s", INDENT * 2, item.message)
+                log.error("%s%s of the following must hold:", INDENT, pre)
+                items = error.context or error.validator_value
+                assert not isinstance(items, Unset)
+                for item in items:
+                    msg = item.message if hasattr(item, "message") else item
+                    log.error("%s%s", INDENT * 2, msg)
             else:
                 log.error("%s%s", INDENT, error.message)
     return valid

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -85,15 +85,15 @@ def validate(schema: dict, desc: str, config: JSONValueT) -> bool:
         for error in errors:
             location = ".".join(str(k) for k in error.path) if error.path else "top level"
             log.error("Error at %s:", location)
+            log.error("%s%s", INDENT, error.message)
             quantifiers = {"allOf": "All", "anyOf": "At least one", "oneOf": "Exactly one"}
-            if error.validator in quantifiers and (items := error.context):
-                pre = quantifiers[str(error.validator)]
-                log.error("%s%s of the following must hold:", INDENT, pre)
-                for item in items:
-                    msg = item.message if hasattr(item, "message") else item
-                    log.error("%s%s", INDENT * 2, msg)
-            else:
-                log.error("%s%s", INDENT, error.message)
+            if error.validator in quantifiers:
+                if items := error.context:
+                    log.error("%sCandidate rules are:", INDENT)
+                    for item in items:
+                        msg = item.message if hasattr(item, "message") else item
+                        log.error("%s%s", INDENT * 2, msg)
+                log.error("%s%s must match.", INDENT, quantifiers[str(error.validator)])
     return valid
 
 

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -227,18 +227,23 @@ def test_config_validator_validate__fail_quantifier_any_of(caplog):
     bad: dict
     for bad in [{}]:
         assert not ok(bad)
-        expected = """
+        expected = (
+            """
         1 schema-validation error found in test
         Error at top level:
-          At least one of the following must hold:
+          %s is not valid under any of the given schemas
+          Candidate rules are:
             'color' is a required property
             'flower' is a required property
+          At least one must match.
         """
+            % bad
+        )
         assert messages() == dedent(expected).strip()
         caplog.clear()
 
 
-def test_config_validator_validate__fail_quantifier_all_of(caplog):
+def test_config_validator_validate__fail_quantifier_one_of(caplog):
     log.setLevel(logging.DEBUG)
     schema = {
         "additionalProperties": False,
@@ -259,6 +264,7 @@ def test_config_validator_validate__fail_quantifier_all_of(caplog):
         1 schema-validation error found in test
         Error at top level:
           %s is valid under each of {'required': ['flower']}, {'required': ['color']}
+          Exactly one must match.
         """
             % bad
         )
@@ -266,13 +272,18 @@ def test_config_validator_validate__fail_quantifier_all_of(caplog):
         caplog.clear()
     for bad in [{}]:
         assert not ok(bad)
-        expected = """
+        expected = (
+            """
         1 schema-validation error found in test
         Error at top level:
-          Exactly one of the following must hold:
+          %s is not valid under any of the given schemas
+          Candidate rules are:
             'color' is a required property
             'flower' is a required property
+          Exactly one must match.
         """
+            % bad
+        )
         assert messages() == dedent(expected).strip()
         caplog.clear()
 

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -252,17 +252,18 @@ def test_config_validator_validate__fail_quantifier_all_of(caplog):
         assert ok(good)
         assert messages() == "Schema validation succeeded for test"
         caplog.clear()
-    for bad in [{"color": "blue", "flower": "rose"}]:
-        assert not ok(bad)
-        expected = """
-        1 schema-validation error found in test
-        Error at top level:
-          Exactly one of the following must hold:
-            {'required': ['color']}
-            {'required': ['flower']}
-        """
-        assert messages() == dedent(expected).strip()
-        caplog.clear()
+    bad: dict
+    # for bad in [{"color": "blue", "flower": "rose"}]:
+    #     assert not ok(bad)
+    #     expected = """
+    #     1 schema-validation error found in test
+    #     Error at top level:
+    #       Exactly one of the following must hold:
+    #         {'required': ['color']}
+    #         {'required': ['flower']}
+    #     """
+    #     assert messages() == dedent(expected).strip()
+    #     caplog.clear()
     for bad in [{}]:
         assert not ok(bad)
         expected = """

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -177,36 +177,6 @@ def test_config_validator_validate__dict(config, schema):
     assert validator.validate(schema=schema, desc="test", config=config)
 
 
-# def test_config_validator_validate__fail_quantifier_all_of(caplog):
-#     log.setLevel(logging.DEBUG)
-#     schema = {
-#         "additionalProperties": False,
-#         "allOf": [
-#             {"if": {"required": ["flower"]}, "then": {"required": ["color"]}},
-#             {"if": {"required": ["color"]}, "then": {"required": ["flower"]}},
-#         ],
-#         "properties": {"color": {"type": "string"}, "flower": {"type": "string"}},
-#         "type": "object",
-#     }
-#     messages = lambda: "\n".join(caplog.messages)
-#     ok = partial(validator.validate, schema, "test")
-#     for good in [{}, {"color": "blue", "flower": "rose"}]:
-#         assert ok(good)
-#         assert messages() == "Schema validation succeeded for test"
-#         caplog.clear()
-#     for bad in [{"color": "blue"}, {"flower": "rose"}]:
-#         assert not ok(bad)
-#         expected = """
-#         2 schema-validation errors found in test
-#         Error at top level:
-#           'flower' is a required property
-#         Error at top level:
-#           'color' is a required property
-#         """
-#         assert messages() == dedent(expected).strip()
-#         caplog.clear()
-
-
 def test_config_validator_validate__fail_quantifier_any_of(caplog):
     log.setLevel(logging.DEBUG)
     schema = {
@@ -227,8 +197,7 @@ def test_config_validator_validate__fail_quantifier_any_of(caplog):
     bad: dict
     for bad in [{}]:
         assert not ok(bad)
-        expected = (
-            """
+        expected = """
         1 schema-validation error found in test
         Error at top level:
           %s is not valid under any of the given schemas
@@ -237,9 +206,7 @@ def test_config_validator_validate__fail_quantifier_any_of(caplog):
             'flower' is a required property
           At least one must match.
         """
-            % bad
-        )
-        assert messages() == dedent(expected).strip()
+        assert messages() == dedent(expected % bad).strip()
         caplog.clear()
 
 
@@ -259,21 +226,17 @@ def test_config_validator_validate__fail_quantifier_one_of(caplog):
         caplog.clear()
     for bad in [{"color": "blue", "flower": "rose"}]:
         assert not ok(bad)
-        expected = (
-            """
+        expected = """
         1 schema-validation error found in test
         Error at top level:
           %s is valid under each of {'required': ['flower']}, {'required': ['color']}
           Exactly one must match.
         """
-            % bad
-        )
-        assert messages() == dedent(expected).strip()
+        assert messages() == dedent(expected % bad).strip()
         caplog.clear()
     for bad in [{}]:
         assert not ok(bad)
-        expected = (
-            """
+        expected = """
         1 schema-validation error found in test
         Error at top level:
           %s is not valid under any of the given schemas
@@ -282,9 +245,7 @@ def test_config_validator_validate__fail_quantifier_one_of(caplog):
             'flower' is a required property
           Exactly one must match.
         """
-            % bad
-        )
-        assert messages() == dedent(expected).strip()
+        assert messages() == dedent(expected % bad).strip()
         caplog.clear()
 
 

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -252,18 +252,18 @@ def test_config_validator_validate__fail_quantifier_all_of(caplog):
         assert ok(good)
         assert messages() == "Schema validation succeeded for test"
         caplog.clear()
-    bad: dict
-    # for bad in [{"color": "blue", "flower": "rose"}]:
-    #     assert not ok(bad)
-    #     expected = """
-    #     1 schema-validation error found in test
-    #     Error at top level:
-    #       Exactly one of the following must hold:
-    #         {'required': ['color']}
-    #         {'required': ['flower']}
-    #     """
-    #     assert messages() == dedent(expected).strip()
-    #     caplog.clear()
+    for bad in [{"color": "blue", "flower": "rose"}]:
+        assert not ok(bad)
+        expected = (
+            """
+        1 schema-validation error found in test
+        Error at top level:
+          %s is valid under each of {'required': ['flower']}, {'required': ['color']}
+        """
+            % bad
+        )
+        assert messages() == dedent(expected).strip()
+        caplog.clear()
     for bad in [{}]:
         assert not ok(bad)
         expected = """

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -238,41 +238,52 @@ def test_config_validator_validate__fail_quantifier_any_of(caplog):
         caplog.clear()
 
 
-# def test_config_validator_validate__fail_quantifier_all_of(caplog):
-#     log.setLevel(logging.DEBUG)
-#     # schema = {
-#     #     "additionalProperties": False,
-#     #     "oneOf": [
-#     #         {"allOf": [{"required": ["color"]}, {"not": {"required": ["flower"]}}]},
-#     #         {"allOf": [{"required": ["flower"]}, {"not": {"required": ["color"]}}]},
-#     #     ],
-#     #     "properties": {"color": {"type": "string"}, "flower": {"type": "string"}},
-#     #     "type": "object",
-#     # }
-#     schema = {
-#         "additionalProperties": False,
-#         "oneOf": [{"required": ["color"]}, {"required": ["flower"]}],
-#         "properties": {"color": {"type": "string"}, "flower": {"type": "string"}},
-#         "type": "object",
-#     }
-#     messages = lambda: "\n".join(caplog.messages)
-#     ok = partial(validator.validate, schema, "test")
-#     # for good in [{"color": "blue"}, {"flower": "rose"}]:
-#     #     assert ok(good)
-#     #     assert messages() == "Schema validation succeeded for test"
-#     #     caplog.clear()
-#     # for bad in [{}, {"color": "blue", "flower": "rose"}]:
-#     for bad in [{"color": "blue", "flower": "rose"}]:
-#         assert not ok(bad)
-#         expected = """
-#         1 schema-validation error found in test
-#         Error at top level:
-#           Exactly one of the following must hold:
-#             'color' is a required property
-#             'flower' is a required property
-#         """
-#         assert messages() == dedent(expected).strip()
-#         caplog.clear()
+def test_config_validator_validate__fail_quantifier_all_of(caplog):
+    log.setLevel(logging.DEBUG)
+    # schema = {
+    #     "additionalProperties": False,
+    #     "oneOf": [
+    #         {"allOf": [{"required": ["color"]}, {"not": {"required": ["flower"]}}]},
+    #         {"allOf": [{"required": ["flower"]}, {"not": {"required": ["color"]}}]},
+    #     ],
+    #     "properties": {"color": {"type": "string"}, "flower": {"type": "string"}},
+    #     "type": "object",
+    # }
+    schema = {
+        "additionalProperties": False,
+        "oneOf": [{"required": ["color"]}, {"required": ["flower"]}],
+        "properties": {"color": {"type": "string"}, "flower": {"type": "string"}},
+        "type": "object",
+    }
+    messages = lambda: "\n".join(caplog.messages)
+    ok = partial(validator.validate, schema, "test")
+    for good in [{"color": "blue"}, {"flower": "rose"}]:
+        assert ok(good)
+        assert messages() == "Schema validation succeeded for test"
+        caplog.clear()
+    bad: dict
+    for bad in [{}]:
+        assert not ok(bad)
+        expected = """
+        1 schema-validation error found in test
+        Error at top level:
+          Exactly one of the following must hold:
+            'color' is a required property
+            'flower' is a required property
+        """
+        assert messages() == dedent(expected).strip()
+        caplog.clear()
+    for bad in [{"color": "blue", "flower": "rose"}]:
+        assert not ok(bad)
+        expected = """
+        1 schema-validation error found in test
+        Error at top level:
+          Exactly one of the following must hold:
+            {'required': ['color']}
+            {'required': ['flower']}
+        """
+        assert messages() == dedent(expected).strip()
+        caplog.clear()
 
 
 def test_config_validator_validate__fail_bad_enum_val(config, logged, schema):

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -240,15 +240,6 @@ def test_config_validator_validate__fail_quantifier_any_of(caplog):
 
 def test_config_validator_validate__fail_quantifier_all_of(caplog):
     log.setLevel(logging.DEBUG)
-    # schema = {
-    #     "additionalProperties": False,
-    #     "oneOf": [
-    #         {"allOf": [{"required": ["color"]}, {"not": {"required": ["flower"]}}]},
-    #         {"allOf": [{"required": ["flower"]}, {"not": {"required": ["color"]}}]},
-    #     ],
-    #     "properties": {"color": {"type": "string"}, "flower": {"type": "string"}},
-    #     "type": "object",
-    # }
     schema = {
         "additionalProperties": False,
         "oneOf": [{"required": ["color"]}, {"required": ["flower"]}],
@@ -261,18 +252,6 @@ def test_config_validator_validate__fail_quantifier_all_of(caplog):
         assert ok(good)
         assert messages() == "Schema validation succeeded for test"
         caplog.clear()
-    bad: dict
-    for bad in [{}]:
-        assert not ok(bad)
-        expected = """
-        1 schema-validation error found in test
-        Error at top level:
-          Exactly one of the following must hold:
-            'color' is a required property
-            'flower' is a required property
-        """
-        assert messages() == dedent(expected).strip()
-        caplog.clear()
     for bad in [{"color": "blue", "flower": "rose"}]:
         assert not ok(bad)
         expected = """
@@ -281,6 +260,17 @@ def test_config_validator_validate__fail_quantifier_all_of(caplog):
           Exactly one of the following must hold:
             {'required': ['color']}
             {'required': ['flower']}
+        """
+        assert messages() == dedent(expected).strip()
+        caplog.clear()
+    for bad in [{}]:
+        assert not ok(bad)
+        expected = """
+        1 schema-validation error found in test
+        Error at top level:
+          Exactly one of the following must hold:
+            'color' is a required property
+            'flower' is a required property
         """
         assert messages() == dedent(expected).strip()
         caplog.clear()


### PR DESCRIPTION
**Synopsis**

The feedback given to users when schema validation fails and involves an `anyOf` or `oneOf` quantifier is not currently very informative. For example, given a driver schema where the `namelist:` block provides neither `base_file` or `update_values`, the current feedback is e.g.

```
$ uw sfc_climo_gen validate -c sfc_climo_gen.yaml
[2025-08-13T00:39:42]     INFO Validating config against internal schema: sfc-climo-gen
[2025-08-13T00:39:42]    ERROR 1 schema-validation error found in sfc_climo_gen config
[2025-08-13T00:39:42]    ERROR Error at sfc_climo_gen.namelist:
[2025-08-13T00:39:42]    ERROR   {'validate': True} is not valid under any of the given schemas
[2025-08-13T00:39:42]    ERROR YAML validation errors
```

With the updates in this PR:

```
$ uw sfc_climo_gen validate -c sfc_climo_gen.yaml
[2025-08-13T00:40:18]     INFO Validating config against internal schema: sfc-climo-gen
[2025-08-13T00:40:18]    ERROR 1 schema-validation error found in sfc_climo_gen config
[2025-08-13T00:40:18]    ERROR Error at sfc_climo_gen.namelist:
[2025-08-13T00:40:18]    ERROR   {'validate': True} is not valid under any of the given schemas
[2025-08-13T00:40:18]    ERROR   Candidate rules are:
[2025-08-13T00:40:18]    ERROR     'base_file' is a required property
[2025-08-13T00:40:18]    ERROR     'update_values' is a required property
[2025-08-13T00:40:18]    ERROR   At least one must match.
[2025-08-13T00:40:18]    ERROR YAML validation errors
```

Behavior for `oneOf` is similar, but handles an edge case where JSON Schema returns an error object with different properties -- see the unit tests for examples.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
