### PR TITLE
Fix for dereferencing when the context and the config are the same

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -7,7 +7,7 @@ from collections import UserDict
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -247,12 +247,15 @@ class Config(ABC, UserDict):
             for line in dict_to_yaml_str(self.data).split("\n"):
                 jinja2.deref_debug("%s%s" % (INDENT, line))
 
+        ctx = deepcopy(self)
+        ctx.update_from(deepcopy(context or {}))
         while True:
             logstate("current")
-            new = jinja2.dereference(val=self.data, context=context or self.data)
+            new = jinja2.dereference(val=self.data, context=cast(dict, ctx))
             assert isinstance(new, dict)
             if new == self.data:
                 break
+            ctx.update_from(new)
             self.data = new
         logstate("final")
         return self

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -250,7 +250,6 @@ class Config(ABC, UserDict):
         self.update_from(context or {})
         while True:
             logstate("current")
-            # new = jinja2.dereference(val=self.data, context=context or self.data)
             new = jinja2.dereference(val=self.data, context=self.data)
             assert isinstance(new, dict)
             if new == self.data:

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -247,10 +247,9 @@ class Config(ABC, UserDict):
             for line in dict_to_yaml_str(self.data).split("\n"):
                 jinja2.deref_debug("%s%s" % (INDENT, line))
 
-        self.update_from(context or {})
         while True:
             logstate("current")
-            new = jinja2.dereference(val=self.data, context=self.data)
+            new = jinja2.dereference(val=self.data, context=context or self.data)
             assert isinstance(new, dict)
             if new == self.data:
                 break

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -250,12 +250,12 @@ class Config(ABC, UserDict):
         # Context object 'ctx', from which Jinja2 will try to retrieve values for rendering template
         # expressions found in config keys and values, starts as a deep copy of the current config,
         # so that self-references can be dereferenced. It is structurally updated from a deep copy,
-        # performed in update_from(), of the optional 'context' object to provide additional and/or
-        # overriding values. Deep copies are used to avoid sturctural sharing between 'ctx` and its
+        # performed in update_from(), of the optional 'context' object, to provide additional and/or
+        # overriding values. Deep copies are used to avoid sturctural sharing between 'ctx' and its
         # precursors.
         #
         # During each iteration of the loop, which terminates when a fixed point is found (i.e. no
-        # more template expressions can be rendered) `ctx` is updated to replace unrendered values
+        # more template expressions can be rendered), `ctx` is updated to replace unrendered values
         # with newly rendered ones, so that they can be used to render yet more values in the next
         # iteration.
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -251,7 +251,7 @@ class Config(ABC, UserDict):
         # expressions found in config keys and values, starts as a deep copy of the current config,
         # so that self-references can be dereferenced. It is structurally updated from a deep copy,
         # performed in update_from(), of the optional 'context' object, to provide additional and/or
-        # overriding values. Deep copies are used to avoid sturctural sharing between 'ctx' and its
+        # overriding values. Deep copies are used to avoid structural sharing between 'ctx' and its
         # precursors.
         #
         # During each iteration of the loop, which terminates when a fixed point is found (i.e. no

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -247,9 +247,11 @@ class Config(ABC, UserDict):
             for line in dict_to_yaml_str(self.data).split("\n"):
                 jinja2.deref_debug("%s%s" % (INDENT, line))
 
+        self.update_from(context or {})
         while True:
             logstate("current")
-            new = jinja2.dereference(val=self.data, context=context or self.data)
+            # new = jinja2.dereference(val=self.data, context=context or self.data)
+            new = jinja2.dereference(val=self.data, context=self.data)
             assert isinstance(new, dict)
             if new == self.data:
                 break

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -315,9 +315,8 @@ def test_config_base__obj_dereference__self_context(self_as_context, tmp_path):
     path = tmp_path / "config.yaml"
     path.write_text(yaml)
     config = YAMLConfig(path)
-    context = YAMLConfig(path) if self_as_context else None
+    context = YAMLConfig(path).data if self_as_context else None
     assert config.dereference(context=context).data == {"a": 2, "b": 3}
-    
 
 
 @mark.parametrize("fmt2", [FORMAT.ini, FORMAT.sh])

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -267,34 +267,33 @@ l: "22"
     with patch.dict(os.environ, {"N": "999"}, clear=True):
         retval = config.dereference()
     assert retval is config
-    assert config == {
-        "a": 44,
-        "b": {"c": 33},
-        "d": "{{ X }}",
-        "e": [
-            False,
-            datetime.fromisoformat("2024-10-10 00:19:00"),
-            {"b0": 0, "b1": 1, "b2": 2},
-            {"c0": 0, "c1": 1, "c2": 2},
-            3.14,
-            42,
-            ["a0", "a1", "a2"],
-        ],
-        "f": {
-            "f1": True,
-            "f2": 3.14,
-            "f3": {"b0": 0, "b1": 1, "b2": 2},
-            "f4": {"c0": 0, "c1": 1, "c2": 2},
-            "f5": 42,
-            "f6": [0, 1, 2],
-        },
-        "g": True,
-        "h": False,
-        "i": datetime.fromisoformat("2024-10-10 00:19:00"),
-        "j": {"b0": 0, "b1": 1, "b2": 2},
-        "k": ["a0", "a1", "a2"],
-        "l": "22",
+    # assert config["a"] == 44
+    assert config["b"] == {"c": 33}
+    assert config["b"]["c"] == 33
+    assert config["d"] == "{{ X }}"
+    assert config["e"] == [
+        False,
+        datetime.fromisoformat("2024-10-10 00:19:00"),
+        {"b0": 0, "b1": 1, "b2": 2},
+        {"c0": 0, "c1": 1, "c2": 2},
+        3.14,
+        42,
+        ["a0", "a1", "a2"],
+    ]
+    assert config["f"] == {
+        "f1": True,
+        "f2": 3.14,
+        "f3": {"b0": 0, "b1": 1, "b2": 2},
+        "f4": {"c0": 0, "c1": 1, "c2": 2},
+        "f5": 42,
+        "f6": [0, 1, 2],
     }
+    assert config["g"] is True
+    assert config["h"] is False
+    assert config["i"] == datetime.fromisoformat("2024-10-10 00:19:00")
+    assert config["j"] == {"b0": 0, "b1": 1, "b2": 2}
+    assert config["k"] == ["a0", "a1", "a2"]
+    assert config["l"] == "22"
 
 
 @mark.parametrize("self_as_context", [False, True])

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -267,7 +267,7 @@ l: "22"
     with patch.dict(os.environ, {"N": "999"}, clear=True):
         retval = config.dereference()
     assert retval is config
-    # assert config["a"] == 44
+    assert config["a"] == 44
     assert config["b"] == {"c": 33}
     assert config["b"]["c"] == 33
     assert config["d"] == "{{ X }}"

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -310,13 +310,14 @@ def test_config_base__obj_dereference__context_override(tmp_path, utc):
 def test_config_base__obj_dereference__self_context(self_as_context, tmp_path):
     yaml = """
     a: !int '{{ 1 + 1 }}'
-    b: !int '{{ a + 1 }}'
+    sub:
+      a: !int '{{ a + 1 }}'
     """
     path = tmp_path / "config.yaml"
     path.write_text(yaml)
     config = YAMLConfig(path)
     context = YAMLConfig(path).data if self_as_context else None
-    assert config.dereference(context=context).data == {"a": 2, "b": 3}
+    assert config.dereference(context=context).data == {"a": 2, "sub": {"a": 3}}
 
 
 @mark.parametrize("fmt2", [FORMAT.ini, FORMAT.sh])

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -306,6 +306,20 @@ def test_config_base__obj_dereference__context_override(tmp_path, utc):
     assert config["file"] == "gfs.t06z.atmanl.nc"
 
 
+@mark.parametrize("self_as_context", [False, True])
+def test_config_base__obj_dereference__self_context(self_as_context, tmp_path):
+    yaml = """
+    a: !int '{{ 1 + 1 }}'
+    b: !int '{{ a + 1 }}'
+    """
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml)
+    config = YAMLConfig(path)
+    context = YAMLConfig(path) if self_as_context else None
+    assert config.dereference(context=context).data == {"a": 2, "b": 3}
+    
+
+
 @mark.parametrize("fmt2", [FORMAT.ini, FORMAT.sh])
 def test_config_base__obj_invalid_config(fmt2, tmp_path):
     """


### PR DESCRIPTION
**Synopsis**

This PR fixes an issue that arose in dereferencing driver configs, where the config being dereferenced and the context are the same: During iterative dereferencing, values in the config would be rendered, but the rendered values never became part of the context -- which was static and never updated -- and never-rendered values in the context would prevent further rendering of config values. The revised code updates the config from the context once, then uses the config as its own context, making values rendered during one dereferencing iteration available for use in subsequent iterations, ensuring progress toward a total render.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
