### PR TITLE
Add info on filesystem paths to fs.rst doc page

### DIFF
--- a/docs/sections/user_guide/cli/tools/fs.rst
+++ b/docs/sections/user_guide/cli/tools/fs.rst
@@ -21,7 +21,7 @@ The ``uw`` mode for handling filesystem items (files and directories).
 
 The ``copy`` action stages files in a target directory by copying files. Any ``KEY`` positional arguments are used to navigate, in the order given, from the top of the config to the :ref:`file block <files_yaml>`.
 
-Source paths prefixed with ``http://``, ``https://``, ``hsi://``, or ``htar://`` will be copied from their upstream network locations to the local filesystem.
+Source paths prefixed with ``file://``, ``http://``, ``https://``, ``hsi://``, or ``htar://``, as well as regular filesystem paths, will be copied from their upstream network locations to the local filesystem.
 
 .. literalinclude:: fs/copy-help.cmd
    :language: text

--- a/docs/sections/user_guide/cli/tools/fs.rst
+++ b/docs/sections/user_guide/cli/tools/fs.rst
@@ -21,7 +21,9 @@ The ``uw`` mode for handling filesystem items (files and directories).
 
 The ``copy`` action stages files in a target directory by copying files. Any ``KEY`` positional arguments are used to navigate, in the order given, from the top of the config to the :ref:`file block <files_yaml>`.
 
-Source paths prefixed with ``file://``, ``http://``, ``https://``, ``hsi://``, or ``htar://``, as well as regular filesystem paths, will be copied from their upstream network locations to the local filesystem.
+Source paths prefixed with ``http://``, ``https://``, ``hsi://``, or ``htar://`` will be copied from their upstream network locations to the local filesystem.
+
+Source paths prefixed with ``file://`` will be treated as local-filesystem paths.
 
 .. literalinclude:: fs/copy-help.cmd
    :language: text


### PR DESCRIPTION
**Synopsis**

Add info on `file://` and normal filesystem paths to `fs.rst`.

**Type**

- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
