### PR TITLE
Remove unneeded lint suppressors

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.coverage.report]
 exclude_also = [
-"if TYPE_CHECKING:"
+  "if TYPE_CHECKING:"
 ]
 fail_under = 100
 show_missing = true
@@ -25,7 +25,7 @@ warn_return_any = true
 
 [tool.pytest.ini_options]
 filterwarnings = [
-"ignore:jsonschema.RefResolver is deprecated:DeprecationWarning"
+  "ignore:jsonschema.RefResolver is deprecated:DeprecationWarning"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
**Synopsis**

After a periodic review of the lint suppressors in `pyproject.toml`, I found two that were no longer needed.

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
