### PR TITLE
v2.12.0 build 2: Use iotaa 1.6

### DIFF
--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -1,12 +1,12 @@
 {
-  "build": "py_1",
-  "buildnum": 1,
+  "build": "py_2",
+  "buildnum": 2,
   "name": "uwtools",
   "packages": {
     "dev": [
       "docformatter ==1.7.*",
       "f90nml >=1.4,<1.5",
-      "iotaa ==1.5.*",
+      "iotaa ==1.6.*",
       "jinja2 >=3.1,<3.2",
       "jq ==1.8.*",
       "jsonschema >=4.17,<4.26",
@@ -26,7 +26,7 @@
     ],
     "run": [
       "f90nml >=1.4,<1.5",
-      "iotaa ==1.5.*",
+      "iotaa ==1.6.*",
       "jinja2 >=3.1,<3.2",
       "jsonschema >=4.17,<4.26",
       "lxml >=5.2,<6.1",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - setuptools
   run:
     - f90nml >=1.4,<1.5
-    - iotaa 1.5.*
+    - iotaa 1.6.*
     - jinja2 >=3.1,<3.2
     - jsonschema >=4.17,<4.26
     - lxml >=5.2,<6.1

--- a/src/uwtools/resources/info.json
+++ b/src/uwtools/resources/info.json
@@ -1,4 +1,4 @@
 {
-  "buildnum": "1",
+  "buildnum": "2",
   "version": "2.12.0"
 }


### PR DESCRIPTION
**Synopsis**

Update the v2.12.0 release to use `iotaa` v1.6.

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
