### PR TITLE
Accept timedelta hours as float or string representation of float

### DIFF
--- a/src/uwtools/tests/utils/test_time.py
+++ b/src/uwtools/tests/utils/test_time.py
@@ -31,7 +31,9 @@ def test_utils_time_to_timedelta():
         ("01:02:03", timedelta(hours=1, minutes=2, seconds=3)),
         ("168:00:00", timedelta(days=7)),
         (6, timedelta(hours=6)),
+        ("6", timedelta(hours=6)),
         (6.25, timedelta(hours=6, minutes=15)),
+        ("6.25", timedelta(hours=6, minutes=15)),
         (timedelta(seconds=1), timedelta(seconds=1)),
     ]:
         assert time.to_timedelta(value=value) == expected  # type: ignore[arg-type]

--- a/src/uwtools/utils/time.py
+++ b/src/uwtools/utils/time.py
@@ -25,5 +25,5 @@ def to_timedelta(value: int | str | timedelta) -> timedelta:
     if isinstance(value, (float, int)):
         return timedelta(hours=value)
     keys = ["hours", "minutes", "seconds"]
-    args = dict(zip(keys, map(int, value.split(":")), strict=False))
+    args = dict(zip(keys, map(float, value.split(":")), strict=False))
     return timedelta(**args)


### PR DESCRIPTION
**Synopsis**

Given `config.yaml`
```
init: !datetime 2025-12-23T00
step: !timedelta 1.5
fcst: !datetime '{{ init + step }}'
```
Previously:
```
$ uw config realize -i config.yaml 
init: 2025-12-23T00:00:00
step: !timedelta '1.5'
fcst: !datetime '{{ init + step }}'
```
i.e. `fcst` could not be calculated because `step` could not be parsed to a `timedelta` and remains a `str`.

Now:
```
$ uw config realize -i config.yaml 
init: 2025-12-23T00:00:00
step: !timedelta '1:30:00'
fcst: 2025-12-23T01:30:00
```

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
