### PR TITLE
Concise local execution message

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -426,7 +426,7 @@ class Driver(Assets):
         path = self.rundir / self._runscript_done_file
         yield Asset(path, path.is_file)
         yield self.provisioned_rundir()
-        cmd = "{x} >{x}.out 2>&1".format(x=self._runscript_path.name)
+        cmd = "./{x} >{x}.out 2>&1".format(x=self._runscript_path.name)
         run_shell_cmd(cmd=cmd, cwd=self.rundir, log_output=True)
 
     # Public methods

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -524,7 +524,7 @@ def test_Driver__run_via_local_execution(driverobj, node):
     ):
         driverobj._run_via_local_execution()
         run_shell_cmd.assert_called_once_with(
-            cmd="{x} >{x}.out 2>&1".format(x=driverobj._runscript_path.name),
+            cmd="./{x} >{x}.out 2>&1".format(x=driverobj._runscript_path.name),
             cwd=driverobj.rundir,
             log_output=True,
         )


### PR DESCRIPTION
**Synopsis**

A [previous PR](https://github.com/ufs-community/uwtools/pull/842) make the log messages relating to batch-job submission more concise, but those for local execution remained lengthy. This PR updates local-execution messages from e.g.
```
[2026-03-24T20:09:21]     INFO Running in /scratch4/BMC/gsdh-pcs/Paul.Madden/EAGLE/src/run/default/vx/prewxvx/global:
[2026-03-24T20:09:21]     INFO   /scratch4/BMC/gsd-hpcs/Paul.Madden/EAGLE/src/run/default/vx/prewxvx/global/runscript.prewxvx-global >/scratch4/BMC/gsd-hpcs/Paul.Madden/EAGLE/src/run/default/vx/prewxvx/global/runscript.prewxvx-global.out 2>&1
```

to
```
[2026-03-24T20:40:35]     INFO Running in /scratch4/BMC/gsd-hpcs/Paul.Madden/EAGLE/src/run/default/vx/prewxvx/global:
[2026-03-24T20:40:35]     INFO   ./runscript.prewxvx-global >runscript.prewxvx-global.out 2>&1
```

This removes repetition of potentially very long paths, making the log messages IMO easier to parse.

**Type**

- [x] Enhancement (adds new functionality) -- if conciseness is an enhancement

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
