### PR TITLE
Better scheduler "export" support

### DIFF
--- a/docs/sections/user_guide/cli/drivers/chgres_cube/show-schema.out
+++ b/docs/sections/user_guide/cli/drivers/chgres_cube/show-schema.out
@@ -9,12 +9,12 @@
             "batchargs": {
               "additionalProperties": true,
               "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "clusters": {
+                  "type": "string"
+                },
                 "cores": {
                   "type": "integer"
-                },
-                "debug": {
-                  "type": "boolean"
-                },
-                "exclusive": {
-                  "type": "boolean"
                 },

--- a/docs/sections/user_guide/cli/drivers/global_equiv_resol/show-schema.out
+++ b/docs/sections/user_guide/cli/drivers/global_equiv_resol/show-schema.out
@@ -9,12 +9,12 @@
             "batchargs": {
               "additionalProperties": true,
               "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "clusters": {
+                  "type": "string"
+                },
                 "cores": {
                   "type": "integer"
-                },
-                "debug": {
-                  "type": "boolean"
-                },
-                "exclusive": {
-                  "type": "boolean"
                 },

--- a/docs/sections/user_guide/cli/drivers/mpassit/show-schema.out
+++ b/docs/sections/user_guide/cli/drivers/mpassit/show-schema.out
@@ -9,12 +9,12 @@
             "batchargs": {
               "additionalProperties": true,
               "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "clusters": {
+                  "type": "string"
+                },
                 "cores": {
                   "type": "integer"
-                },
-                "debug": {
-                  "type": "boolean"
-                },
-                "exclusive": {
-                  "type": "boolean"
                 },

--- a/docs/sections/user_guide/cli/drivers/orog/show-schema.out
+++ b/docs/sections/user_guide/cli/drivers/orog/show-schema.out
@@ -9,12 +9,12 @@
             "batchargs": {
               "additionalProperties": true,
               "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "clusters": {
+                  "type": "string"
+                },
                 "cores": {
                   "type": "integer"
-                },
-                "debug": {
-                  "type": "boolean"
-                },
-                "exclusive": {
-                  "type": "boolean"
                 },

--- a/docs/sections/user_guide/cli/drivers/sfc_climo_gen/show-schema.out
+++ b/docs/sections/user_guide/cli/drivers/sfc_climo_gen/show-schema.out
@@ -9,12 +9,12 @@
             "batchargs": {
               "additionalProperties": true,
               "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "clusters": {
+                  "type": "string"
+                },
                 "cores": {
                   "type": "integer"
-                },
-                "debug": {
-                  "type": "boolean"
-                },
-                "exclusive": {
-                  "type": "boolean"
                 },

--- a/docs/sections/user_guide/cli/drivers/upp/show-schema.out
+++ b/docs/sections/user_guide/cli/drivers/upp/show-schema.out
@@ -12,9 +12,9 @@
             "batchargs": {
               "additionalProperties": true,
               "properties": {
-                "cores": {
-                  "type": "integer"
+                "account": {
+                  "type": "string"
                 },
-                "debug": {
-                  "type": "boolean"
+                "clusters": {
+                  "type": "string"
                 },

--- a/docs/sections/user_guide/yaml/components/execution.rst
+++ b/docs/sections/user_guide/yaml/components/execution.rst
@@ -44,9 +44,86 @@ These entries map to job-scheduler directives sent to e.g. Slurm when a batch jo
 
 Shorthand names are provided for certain directives for each scheduler, and can be specified as-so along with appropriate values. Recognized names for each scheduler are:
 
-* LSF: ``jobname``, ``memory``, ``nodes``, ``queue``, ``shell``, ``stdout``, ``tasks_per_node``, ``walltime``
-* PBS: ``debug``, ``jobname``, ``memory``, ``nodes``, ``queue``, ``shell``, ``stdout``, ``tasks_per_node``, ``walltime``
-* Slurm: ``cores``, ``exclusive``, ``export``, ``jobname``, ``memory``, ``nodes``, ``partition``, ``queue``, ``rundir``, ``stderr``, ``stdout``, ``tasks_per_node``, ``walltime``
+.. list-table::
+   :widths: 10 30 30 30
+   :header-rows: 1
+
+   * - Shorthand
+     - Slurm
+     - PBS
+     - LSF
+   * - ``account``
+     - ``--account``
+     - ``-A``
+     - ``-P``
+   * - ``clusters``
+     - ``--clusters``
+     -
+     -
+   * - ``cores``
+     - ``--ntasks``
+     -
+     -
+   * - ``debug``
+     - ``verbose``
+     - ``-l debug``
+     -
+   * - ``exclusive``
+     - ``--exclusive``
+     -
+     -
+   * - ``export``
+     - ``--export``
+     - ``-V``
+     -
+   * - ``jobname``
+     - ``--job-name``
+     - ``-N``
+     - ``-J``
+   * - ``memory``
+     - ``--mem``
+     - ``mem``
+     - ``-R rusage[mem=]``
+   * - ``nodes``
+     - ``--nodes``
+     - ``-l select``
+     - ``-n``
+   * - ``partition``
+     - ``--partition``
+     -
+     -
+   * - ``queue``
+     - ``--qos``
+     - ``-q``
+     - ``-q``
+   * - ``rundir``
+     - ``--chdir``
+     -
+     -
+   * - ``shell``
+     -
+     - ``-S``
+     - ``-L``
+   * - ``stderr``
+     - ``--error``
+     -
+     -
+   * - ``stdout``
+     - ``--output``
+     - ``-o``
+     - ``-o``
+   * - ``tasks_per_node``
+     - ``--ntasks-per-node``
+     - ``mpiprocs``
+     - ``-R span[ptile=]``
+   * - ``threads``
+     -
+     -
+     - ``-R affinity[core()]``
+   * - ``walltime``
+     - ``--time``
+     - ``-l walltime``
+     - ``-W``
 
 **NB** To enable threading when running components compiled with OpenMP support, set the ``execution:`` block's  ``threads:`` item (see below). Then ``uwtools`` will set the appropriate scheduler flag when making a batch request, and will set the ``OMP_NUM_THREADS`` environment variable in the execution environment.
 

--- a/docs/sections/user_guide/yaml/components/execution.rst
+++ b/docs/sections/user_guide/yaml/components/execution.rst
@@ -42,7 +42,7 @@ batchargs:
 
 These entries map to job-scheduler directives sent to e.g. Slurm when a batch job is submitted via the ``--batch`` CLI switch or the ``batch=True`` API argument. The only **required** entry is ``walltime``.
 
-Shorthand names are provided for certain directives for each scheduler, and can be specified as-so along with appropriate values. Recognized names for each scheduler are:
+Shorthand names are provided for certain directives for each scheduler, and can be specified as-so along with appropriate values. Except where noted below, values provided for shorthand names should be strings. Supported shorthand names for each scheduler are:
 
 .. list-table::
    :widths: 10 30 30 30
@@ -65,7 +65,7 @@ Shorthand names are provided for certain directives for each scheduler, and can 
      -
      -
    * - ``debug``
-     - ``verbose``
+     - ``--verbose``
      - ``-l debug``
      -
    * - ``exclusive``
@@ -82,8 +82,8 @@ Shorthand names are provided for certain directives for each scheduler, and can 
      - ``-J``
    * - ``memory``
      - ``--mem``
-     - ``mem``
-     - ``-R rusage[mem=]``
+     - ``-l mem``
+     - ``-R rusage[mem]``
    * - ``nodes``
      - ``--nodes``
      - ``-l select``
@@ -115,7 +115,7 @@ Shorthand names are provided for certain directives for each scheduler, and can 
    * - ``tasks_per_node``
      - ``--ntasks-per-node``
      - ``mpiprocs``
-     - ``-R span[ptile=]``
+     - ``-R span[ptile]``
    * - ``threads``
      -
      -
@@ -125,7 +125,10 @@ Shorthand names are provided for certain directives for each scheduler, and can 
      - ``-l walltime``
      - ``-W``
 
-**NB** To enable threading when running components compiled with OpenMP support, set the ``execution:`` block's  ``threads:`` item (see below). Then ``uwtools`` will set the appropriate scheduler flag when making a batch request, and will set the ``OMP_NUM_THREADS`` environment variable in the execution environment.
+* ``export``: Values should be YAML booleans. A ``true`` value means that all environment variables from the head-node shell will be propagated to the batch environment; ``false`` means that none will.
+* ``memory``: Values should be strings in a form acceptable by the underlying scheduler (consult your scheduler's documentation).
+* ``tasks_per_node``: Values should be integers.
+* ``walltime``: Values should be strings in ``hours:minutes:seconds`` form, e.g. ``01:30:00`` for one and a half hours.
 
 Other, arbitrary directive key-value pairs can be provided exactly as they should appear in the batch runscript. For example
 
@@ -140,6 +143,8 @@ could be specified to have the Slurm directive
    #SBATCH --nice=100
 
 included in the batch runscript.
+
+**NB** To enable threading when running components compiled with OpenMP support, set the ``execution:`` block's  ``threads:`` item (see below). Then ``uwtools`` will set the appropriate scheduler flag when making a batch request, and will set the ``OMP_NUM_THREADS`` environment variable in the execution environment.
 
 envcmds:
 """"""""

--- a/docs/sections/user_guide/yaml/components/execution.rst
+++ b/docs/sections/user_guide/yaml/components/execution.rst
@@ -14,7 +14,7 @@ Example block:
        cores: 40
        debug: True
        exclusive: True
-       export: NONE
+       export: false
        jobname: my-job
        memory: 4GB
        nodes: 1

--- a/docs/shared/drivers/mpassit.yaml
+++ b/docs/shared/drivers/mpassit.yaml
@@ -1,7 +1,7 @@
 mpassit:
   execution:
     batchargs:
-      export: NONE
+      export: false
       nodes: 1
       stdout: /path/to/file
       walltime: 00:02:00

--- a/docs/shared/drivers/sfc_climo_gen.yaml
+++ b/docs/shared/drivers/sfc_climo_gen.yaml
@@ -1,7 +1,7 @@
 sfc_climo_gen:
   execution:
     batchargs:
-      export: NONE
+      export: false
       nodes: 1
       stdout: /path/to/runscript.out
       walltime: "00:02:00"

--- a/docs/shared/drivers/upp.yaml
+++ b/docs/shared/drivers/upp.yaml
@@ -2,7 +2,7 @@ upp:
   control_file: /path/to/postxconfig-NT.txt
   execution:
     batchargs:
-      export: NONE
+      export: false
       nodes: 1
       walltime: "00:05:00"
     envcmds:

--- a/src/uwtools/resources/jsonschema/batchargs.jsonschema
+++ b/src/uwtools/resources/jsonschema/batchargs.jsonschema
@@ -1,6 +1,12 @@
 {
   "additionalProperties": true,
   "properties": {
+    "account": {
+      "type": "string"
+    },
+    "clusters": {
+      "type": "string"
+    },
     "cores": {
       "type": "integer"
     },

--- a/src/uwtools/resources/jsonschema/batchargs.jsonschema
+++ b/src/uwtools/resources/jsonschema/batchargs.jsonschema
@@ -11,7 +11,7 @@
       "type": "boolean"
     },
     "export": {
-      "type": "string"
+      "type": "boolean"
     },
     "jobname": {
       "type": "string"

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -247,6 +247,7 @@ class PBS(JobScheduler):
         """
         return {
             _DirectivesOptional.DEBUG: lambda x: f"-l debug={str(x).lower()}",
+            _DirectivesOptional.EXPORT: "-V",
             _DirectivesOptional.JOB_NAME: "-N",
             _DirectivesOptional.MEMORY: "mem",
             _DirectivesOptional.NODES: lambda x: f"-l select={x}",
@@ -348,9 +349,9 @@ class Slurm(JobScheduler):
         return {
             _DirectivesOptional.CLUSTERS: "--clusters",
             _DirectivesOptional.CORES: "--ntasks",
-            _DirectivesOptional.DEBUG: lambda b: "--verbose" if b else None,
-            _DirectivesOptional.EXCLUSIVE: lambda b: "--exclusive" if b else None,
-            _DirectivesOptional.EXPORT: "--export",
+            _DirectivesOptional.DEBUG: lambda x: "--verbose" if x else None,
+            _DirectivesOptional.EXCLUSIVE: lambda x: "--exclusive" if x else None,
+            _DirectivesOptional.EXPORT: lambda x: "--export=%s" % ("ALL" if x else "NONE"),
             _DirectivesOptional.JOB_NAME: "--job-name",
             _DirectivesOptional.MEMORY: "--mem",
             _DirectivesOptional.NODES: "--nodes",

--- a/src/uwtools/tests/drivers/test_chgres_cube.py
+++ b/src/uwtools/tests/drivers/test_chgres_cube.py
@@ -29,7 +29,7 @@ def config(tmp_path):
         "chgres_cube": {
             "execution": {
                 "batchargs": {
-                    "export": "NONE",
+                    "export": False,
                     "nodes": 1,
                     "stdout": "/path/to/file",
                     "walltime": "00:02:00",

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -84,7 +84,7 @@ def config(tmp_path):
             "base_file": str(write(tmp_path / "base.yaml", {"a": 11, "b": 22})),
             "execution": {
                 "batchargs": {
-                    "export": "NONE",
+                    "export": False,
                     "nodes": 1,
                     "stdout": "{{ concrete.rundir }}/out",
                     "walltime": "00:05:00",

--- a/src/uwtools/tests/drivers/test_esg_grid.py
+++ b/src/uwtools/tests/drivers/test_esg_grid.py
@@ -19,7 +19,7 @@ def config(tmp_path):
         "esg_grid": {
             "execution": {
                 "batchargs": {
-                    "export": "NONE",
+                    "export": False,
                     "nodes": 1,
                     "stdout": "/path/to/file",
                     "walltime": "00:02:00",

--- a/src/uwtools/tests/drivers/test_ioda.py
+++ b/src/uwtools/tests/drivers/test_ioda.py
@@ -20,7 +20,7 @@ def config(tmp_path):
         "ioda": {
             "execution": {
                 "batchargs": {
-                    "export": "NONE",
+                    "export": False,
                     "cores": 1,
                     "stdout": "/path/to/file",
                     "walltime": "00:02:00",

--- a/src/uwtools/tests/drivers/test_jedi.py
+++ b/src/uwtools/tests/drivers/test_jedi.py
@@ -25,7 +25,7 @@ def config(tmp_path):
         "jedi": {
             "execution": {
                 "batchargs": {
-                    "export": "NONE",
+                    "export": False,
                     "nodes": 1,
                     "stdout": "/path/to/file",
                     "walltime": "00:02:00",

--- a/src/uwtools/tests/drivers/test_sfc_climo_gen.py
+++ b/src/uwtools/tests/drivers/test_sfc_climo_gen.py
@@ -20,7 +20,7 @@ def config(tmp_path):
         "sfc_climo_gen": {
             "execution": {
                 "batchargs": {
-                    "export": "NONE",
+                    "export": False,
                     "nodes": 1,
                     "stdout": "/path/to/file",
                     "walltime": "00:02:00",

--- a/src/uwtools/tests/drivers/test_shave.py
+++ b/src/uwtools/tests/drivers/test_shave.py
@@ -18,7 +18,7 @@ def config(tmp_path):
         "shave": {
             "execution": {
                 "batchargs": {
-                    "export": "NONE",
+                    "export": False,
                     "nodes": 1,
                     "stdout": "/path/to/file",
                     "walltime": "00:02:00",

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -289,7 +289,8 @@ def test_Slurm__managed_directives(slurm):
     assert mds["debug"](False) is None
     assert mds["exclusive"](True) == "--exclusive"
     assert mds["exclusive"](False) is None
-    assert mds["export"] == "--export"
+    assert mds["export"](False) == "--export=NONE"
+    assert mds["export"](True) == "--export=ALL"
     assert mds["jobname"] == "--job-name"
     assert mds["memory"] == "--mem"
     assert mds["nodes"] == "--nodes"

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -226,6 +226,7 @@ def test_PBS__managed_directives(pbs):
     mds = pbs._managed_directives
     assert mds["account"] == "-A"
     assert mds["debug"](True) == "-l debug=true"
+    assert mds["export"] == "-V"
     assert mds["jobname"] == "-N"
     assert mds["memory"] == "mem"
     assert mds["nodes"](2) == "-l select=2"

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -401,6 +401,8 @@ def test_schema_batchargs():
         assert "is not of type 'integer'\n" in errors({key: None})
     # Some keys require string values:
     for key in [
+        "account",
+        "clusters",
         "jobname",
         "memory",
         "partition",

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -394,14 +394,13 @@ def test_schema_batchargs():
     # The "threads" argument is not allowed: It will be propagated, if set, from execution.threads.
     assert "should not be valid" in errors({"threads": 4, "walltime": "00:05:00"})
     # Some keys require boolean values:
-    for key in ["debug", "exclusive"]:
+    for key in ["debug", "exclusive", "export"]:
         assert "is not of type 'boolean'\n" in errors({key: None})
     # Some keys require integer values:
     for key in ["cores", "nodes"]:
         assert "is not of type 'integer'\n" in errors({key: None})
     # Some keys require string values:
     for key in [
-        "export",
         "jobname",
         "memory",
         "partition",


### PR DESCRIPTION
**Synopsis**

This PR proposes to both improve, and limit, support for the "export" feature of PBS and Slurm. The existing implementation only supported Slurm, and took an arbitrary string value and passed it through as the value of an `#SBATCH --export=` directive. The updated version accepts, in UW YAML, a boolean value: If the value is true, then all environment variables are propagated from the head node to the batch node (inadvisable practice, but maybe useful in some context), as `#PBS -V` for PBS, or `--export=ALL` for Slurm. If the value is false, then no environment variables are propagated, which is the default for PBS so no directive in provided, or `--export=NONE` for Slurm.

Mainly, I want this feature for EAGLE so that I can set `export: false` to get a Slurm `--export=NONE` to suppress propagation of the head-node environment. And since EAGLE may need to run of PBS systems, the `export` key needed support for that scheduler.

Both schedulers support propagating one or more arbitrary `VAR=value` pairs, but UW YAML has separate support for environment variables in its drivers, and I might argue that users would be better served by adding explicit `export` statements to their batch scripts than relying on non-portable scheduler directives for this. If we found that we needed to support `VAR=value` via directives, we could add a schema-checked option for, as an alternative to the boolean value, a mapping from keys to values, and construct the directive from this, rather than having users provide a pre-formatted string, as this would be portable between schedulers (i.e. the UW YAML would be the same for Slurm or for PBS).

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality) -- users supplying arbitrary strings would have to make other arrangements.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
