### PR TITLE
Add EcFlow Config Validation

### DIFF
--- a/src/uwtools/api/ecflow.py
+++ b/src/uwtools/api/ecflow.py
@@ -45,15 +45,16 @@ def realize(
 
 
 def validate(
-    yaml_file: Path | str | None = None,
+    config: _YAMLConfig | dict | Path | str | None = None,
     stdin_ok: bool = False,
 ) -> bool:
     """
-    Validate the input YAML against its schema.
+    Validate an ecFlow config against its schema.
 
-    :param yaml_file: Path to YAML file (``None`` or unspecified => read ``stdin``).
+    :param config: An ecFlow config as a ``dict``, a ``YAMLConfig``, a path to a YAML file
+        (``Path`` or ``str``), or ``None`` (read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if the YAML conforms to the schema.
+    :return: ``True`` if the config conforms to the schema.
     :raises: ``UWConfigError`` if validation fails.
     """
-    return _validate(config=_ensure_data_source(_str2path(yaml_file), stdin_ok))
+    return _validate(config=_ensure_data_source(_str2path(config), stdin_ok))

--- a/src/uwtools/api/ecflow.py
+++ b/src/uwtools/api/ecflow.py
@@ -54,6 +54,6 @@ def validate(
     :param yaml_file: Path to YAML file (``None`` or unspecified => read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
     :return: ``True`` if the YAML conforms to the schema.
-    :raises: UWConfigError if validation fails.
+    :raises: ``UWConfigError`` if validation fails.
     """
     return _validate(config=_ensure_data_source(_str2path(yaml_file), stdin_ok))

--- a/src/uwtools/api/ecflow.py
+++ b/src/uwtools/api/ecflow.py
@@ -53,6 +53,7 @@ def validate(
 
     :param yaml_file: Path to YAML file (``None`` or unspecified => read ``stdin``).
     :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True`` if the YAML conforms to the schema, ``False`` otherwise.
+    :return: ``True`` if the YAML conforms to the schema.
+    :raises: UWConfigError if validation fails.
     """
     return _validate(config=_ensure_data_source(_str2path(yaml_file), stdin_ok))

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -4,7 +4,6 @@ Support for creating ecFlow suite definitions and ecf scripts.
 
 from __future__ import annotations
 
-import json
 import re
 from copy import deepcopy
 from pathlib import Path
@@ -28,7 +27,7 @@ from ecflow import (  # type: ignore[import-untyped]
 
 from uwtools.config.formats.base import Config
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.config.validator import bundle, internal_schema_file, validate_internal
+from uwtools.config.validator import validate_internal
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.scheduler import JobScheduler
@@ -385,14 +384,6 @@ def realize(
     return str(suite)
 
 
-def schema() -> dict:
-    """
-    Return the ecFlow module's internal schema.
-    """
-    path = internal_schema_file(schema_name=EC.ecflow)
-    return bundle(json.loads(path.read_text()))
-
-
 def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
     """
     Validate an ecFlow config against the internal ecFlow schema.
@@ -400,9 +391,9 @@ def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
     :param config: A ``dict``, a ``YAMLConfig``, a path to a YAML file, or ``None``
         (``None`` => read ``stdin``).
     :return: ``True`` if the config conforms to the schema.
-    :raises: UWConfigError if validation fails.
+    :raises: ``UWConfigError`` if validation fails.
     """
-    kwargs: dict = {"schema_name": EC.ecflow, "desc": "ecflow config"}
+    kwargs: dict = {"schema_name": EC.ecflow, "desc": "ecFlow config"}
     if isinstance(config, (dict, YAMLConfig)):
         kwargs["config_data"] = config
     else:

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -57,20 +57,6 @@ class _ECFlowDef:
     def __str__(self):
         return self._d.__str__()
 
-    def validate(self) -> bool:
-        """
-        Validate the ecFlow config against the internal ecFlow schema.
-
-        :return: ``True`` if the config conforms to the schema.
-        :raises: UWConfigError if validation fails.
-        """
-        validate_internal(
-            schema_name=EC.ecflow,
-            desc="ecflow config",
-            config_data={EC.ecflow: self._config},
-        )
-        return True
-
     def write_ecf_scripts(self, path: Path | str) -> None:
         """
         The ecf scripts for this workflow.
@@ -383,13 +369,19 @@ def schema() -> dict:
     return bundle(json.loads(path.read_text()))
 
 
-def validate_file(yaml_file: Path | None = None) -> bool:
+def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
     """
-    Validate an ecFlow YAML config against the internal ecFlow schema.
+    Validate an ecFlow config against the internal ecFlow schema.
 
-    :param yaml_file: Path to YAML file (``None`` => read ``stdin``).
+    :param config: A ``dict``, a ``YAMLConfig``, a path to a YAML file, or ``None``
+        (``None`` => read ``stdin``).
     :return: ``True`` if the config conforms to the schema.
     :raises: UWConfigError if validation fails.
     """
-    validate_internal(schema_name=EC.ecflow, desc="ecflow config", config_path=yaml_file)
+    kwargs: dict = {"schema_name": EC.ecflow, "desc": "ecflow config"}
+    if isinstance(config, (dict, YAMLConfig)):
+        kwargs["config_data"] = config
+    else:
+        kwargs["config_path"] = config
+    validate_internal(**kwargs)
     return True

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -4,6 +4,7 @@ Support for creating ecFlow suite definitions and ecf scripts.
 
 from __future__ import annotations
 
+import json
 import re
 from copy import deepcopy
 from pathlib import Path
@@ -27,6 +28,7 @@ from ecflow import (  # type: ignore[import-untyped]
 
 from uwtools.config.formats.base import Config
 from uwtools.config.formats.yaml import YAMLConfig
+from uwtools.config.validator import bundle, internal_schema_file, validate_internal
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.scheduler import JobScheduler
@@ -54,6 +56,20 @@ class _ECFlowDef:
 
     def __str__(self):
         return self._d.__str__()
+
+    def validate(self) -> bool:
+        """
+        Validate the ecFlow config against the internal ecFlow schema.
+
+        :return: ``True`` if the config conforms to the schema.
+        :raises: UWConfigError if validation fails.
+        """
+        validate_internal(
+            schema_name=EC.ecflow,
+            desc="ecflow config",
+            config_data={EC.ecflow: self._config},
+        )
+        return True
 
     def write_ecf_scripts(self, path: Path | str) -> None:
         """
@@ -357,3 +373,23 @@ class _ECFlowDef:
         tag = parts[0]
         name = "_".join(parts[1:]) if parts[1:] else ""
         return tag, name
+
+
+def schema() -> dict:
+    """
+    Return the ecFlow module's internal schema.
+    """
+    path = internal_schema_file(schema_name=EC.ecflow)
+    return bundle(json.loads(path.read_text()))
+
+
+def validate_file(yaml_file: Path | None = None) -> bool:
+    """
+    Validate an ecFlow YAML config against the internal ecFlow schema.
+
+    :param yaml_file: Path to YAML file (``None`` => read ``stdin``).
+    :return: ``True`` if the config conforms to the schema.
+    :raises: UWConfigError if validation fails.
+    """
+    validate_internal(schema_name=EC.ecflow, desc="ecflow config", config_path=yaml_file)
+    return True

--- a/src/uwtools/tests/api/test_ecflow.py
+++ b/src/uwtools/tests/api/test_ecflow.py
@@ -21,5 +21,5 @@ def test_api_ecflow_realize__with_scripts():
 def test_api_ecflow_validate():
     path = Path("foo")
     with patch.object(ecflow, "_validate") as _validate:
-        ecflow.validate(yaml_file=path)
+        ecflow.validate(config=path)
     _validate.assert_called_once_with(config=path)

--- a/src/uwtools/tests/api/test_ecflow.py
+++ b/src/uwtools/tests/api/test_ecflow.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from unittest.mock import patch
 
+from pytest import raises
+
 from uwtools.api import ecflow
+from uwtools.config.formats.yaml import YAMLConfig
+from uwtools.exceptions import UWError
 
 
 def test_api_ecflow_realize():
@@ -18,8 +22,40 @@ def test_api_ecflow_realize__with_scripts():
     _realize.assert_called_once_with(config=path1, output_path=path2, scripts_path=path3)
 
 
-def test_api_ecflow_validate():
+def test_api_ecflow_validate__path():
     path = Path("foo")
     with patch.object(ecflow, "_validate") as _validate:
         ecflow.validate(config=path)
     _validate.assert_called_once_with(config=path)
+
+
+def test_api_ecflow_validate__str():
+    with patch.object(ecflow, "_validate") as _validate:
+        ecflow.validate(config="foo")
+    _validate.assert_called_once_with(config=Path("foo"))
+
+
+def test_api_ecflow_validate__dict():
+    cfg: dict = {"ecflow": {}}
+    with patch.object(ecflow, "_validate") as _validate:
+        ecflow.validate(config=cfg)
+    _validate.assert_called_once_with(config=cfg)
+
+
+def test_api_ecflow_validate__yamlconfig():
+    cfg = YAMLConfig({"ecflow": {}})
+    with patch.object(ecflow, "_validate") as _validate:
+        ecflow.validate(config=cfg)
+    _validate.assert_called_once_with(config=cfg)
+
+
+def test_api_ecflow_validate__stdin():
+    with patch.object(ecflow, "_validate") as _validate:
+        ecflow.validate(stdin_ok=True)
+    _validate.assert_called_once_with(config=None)
+
+
+def test_api_ecflow_validate__no_stdin_no_config():
+    with raises(UWError) as e:
+        ecflow.validate()
+    assert "Set stdin_ok=True to permit read from stdin" in str(e.value)

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -2,6 +2,7 @@
 Tests for uwtools.ecflow module.
 """
 
+import json
 from pathlib import Path
 from unittest.mock import Mock, call, patch
 
@@ -255,6 +256,24 @@ class TestECFlowDef:
         config: dict = {"not_ecflow": {}}
         with raises(KeyError):
             _ECFlowDef(config=config)
+
+    def test_validate(self, instance):
+        assert instance.validate() is True
+
+    def test_validate__wraps_inner_config(self, instance):
+        with patch.object(ecflow, "validate_internal") as validate_internal:
+            assert instance.validate() is True
+        validate_internal.assert_called_once_with(
+            schema_name="ecflow",
+            desc="ecflow config",
+            config_data={"ecflow": instance._config},
+        )
+
+    def test_validate__invalid(self):
+        config = {"ecflow": {"scheduler": "bogus"}}
+        ecf = _ECFlowDef(config=config)
+        with raises(UWConfigError, match="YAML validation errors"):
+            ecf.validate()
 
     # _add_workflow_components tests
 
@@ -644,3 +663,39 @@ class TestECFlowDef:
         assert "task member_01" in suite_def
         assert "task member_02" in suite_def
         assert "task member_03" in suite_def
+
+
+def test_schema(tmp_path):
+    schema_file = tmp_path / "ecflow.jsonschema"
+    expected = {"type": "object"}
+    schema_file.write_text(json.dumps(expected))
+    with (
+        patch.object(ecflow, "internal_schema_file", return_value=schema_file),
+        patch.object(ecflow, "bundle", side_effect=lambda schema: schema) as bundle,
+    ):
+        actual = ecflow.schema()
+    assert actual == expected
+    bundle.assert_called_once_with(expected)
+
+
+def test_validate_file__path(tmp_path):
+    yaml_file = tmp_path / "ecflow.yaml"
+    yaml_file.write_text("ecflow: {}\n")
+    assert ecflow.validate_file(yaml_file)
+
+
+def test_validate_file__stdin():
+    with patch.object(ecflow, "validate_internal") as validate_internal:
+        assert ecflow.validate_file()
+    validate_internal.assert_called_once_with(
+        schema_name="ecflow",
+        desc="ecflow config",
+        config_path=None,
+    )
+
+
+def test_validate_file__invalid(tmp_path):
+    yaml_file = tmp_path / "ecflow.yaml"
+    yaml_file.write_text("not_ecflow: {}\n")
+    with raises(UWConfigError, match="YAML validation errors"):
+        ecflow.validate_file(yaml_file)

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -2,10 +2,12 @@
 Tests for uwtools.ecflow module.
 """
 
-import json
+import sys
+from io import StringIO
 from pathlib import Path
 from unittest.mock import Mock, call, patch
 
+import yaml
 from ecflow import Defs, DState, Suite, Task  # type: ignore[import-untyped]
 from pytest import fixture, mark, raises
 
@@ -13,6 +15,7 @@ from uwtools import ecflow
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.ecflow import _ECFlowDef
 from uwtools.exceptions import UWConfigError
+from uwtools.utils.file import _stdinproxy
 
 # Fixtures
 
@@ -685,58 +688,29 @@ def test_ecflow_realize__write_scripts(capsys, assets):
     assert capsys.readouterr().out == expected
 
 
-def test_schema(tmp_path):
-    schema_file = tmp_path / "ecflow.jsonschema"
-    expected = {"type": "object"}
-    schema_file.write_text(json.dumps(expected))
-    with (
-        patch.object(ecflow, "internal_schema_file", return_value=schema_file),
-        patch.object(ecflow, "bundle", side_effect=lambda schema: schema) as bundle,
-    ):
-        actual = ecflow.schema()
-    assert actual == expected
-    bundle.assert_called_once_with(expected)
-
-
-def test_validate__path(tmp_path):
-    yaml_file = tmp_path / "ecflow.yaml"
-    yaml_file.write_text("ecflow: {}\n")
-    assert ecflow.validate(yaml_file)
+def test_validate__path(tmp_path, minimal_config):
+    path = tmp_path / "config.yaml"
+    YAMLConfig(minimal_config).dump(path)
+    assert ecflow.validate(path)
 
 
 def test_validate__dict(minimal_config):
-    with patch.object(ecflow, "validate_internal") as validate_internal:
-        assert ecflow.validate(minimal_config)
-    validate_internal.assert_called_once_with(
-        schema_name="ecflow",
-        desc="ecflow config",
-        config_data=minimal_config,
-    )
+    assert ecflow.validate(minimal_config)
 
 
 def test_validate__yamlconfig(minimal_config):
-    cfg = YAMLConfig(minimal_config)
-    with patch.object(ecflow, "validate_internal") as validate_internal:
-        assert ecflow.validate(cfg)
-    validate_internal.assert_called_once_with(
-        schema_name="ecflow",
-        desc="ecflow config",
-        config_data=cfg,
-    )
+    assert ecflow.validate(YAMLConfig(minimal_config))
 
 
-def test_validate__stdin():
-    with patch.object(ecflow, "validate_internal") as validate_internal:
+def test_validate__stdin(minimal_config):
+    _stdinproxy.cache_clear()
+    with StringIO(yaml.safe_dump(minimal_config)) as sio, patch.object(sys, "stdin", new=sio):
         assert ecflow.validate()
-    validate_internal.assert_called_once_with(
-        schema_name="ecflow",
-        desc="ecflow config",
-        config_path=None,
-    )
 
 
 def test_validate__invalid(tmp_path):
     yaml_file = tmp_path / "ecflow.yaml"
     yaml_file.write_text("not_ecflow: {}\n")
-    with raises(UWConfigError, match="YAML validation errors"):
+    with raises(UWConfigError) as e:
         ecflow.validate(yaml_file)
+    assert "YAML validation errors" in str(e.value)

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -257,24 +257,6 @@ class TestECFlowDef:
         with raises(KeyError):
             _ECFlowDef(config=config)
 
-    def test_validate(self, instance):
-        assert instance.validate() is True
-
-    def test_validate__wraps_inner_config(self, instance):
-        with patch.object(ecflow, "validate_internal") as validate_internal:
-            assert instance.validate() is True
-        validate_internal.assert_called_once_with(
-            schema_name="ecflow",
-            desc="ecflow config",
-            config_data={"ecflow": instance._config},
-        )
-
-    def test_validate__invalid(self):
-        config = {"ecflow": {"scheduler": "bogus"}}
-        ecf = _ECFlowDef(config=config)
-        with raises(UWConfigError, match="YAML validation errors"):
-            ecf.validate()
-
     # _add_workflow_components tests
 
     def test__add_workflow_components__extern(self, instance):
@@ -678,15 +660,36 @@ def test_schema(tmp_path):
     bundle.assert_called_once_with(expected)
 
 
-def test_validate_file__path(tmp_path):
+def test_validate__path(tmp_path):
     yaml_file = tmp_path / "ecflow.yaml"
     yaml_file.write_text("ecflow: {}\n")
-    assert ecflow.validate_file(yaml_file)
+    assert ecflow.validate(yaml_file)
 
 
-def test_validate_file__stdin():
+def test_validate__dict(minimal_config):
     with patch.object(ecflow, "validate_internal") as validate_internal:
-        assert ecflow.validate_file()
+        assert ecflow.validate(minimal_config)
+    validate_internal.assert_called_once_with(
+        schema_name="ecflow",
+        desc="ecflow config",
+        config_data=minimal_config,
+    )
+
+
+def test_validate__yamlconfig(minimal_config):
+    cfg = YAMLConfig(minimal_config)
+    with patch.object(ecflow, "validate_internal") as validate_internal:
+        assert ecflow.validate(cfg)
+    validate_internal.assert_called_once_with(
+        schema_name="ecflow",
+        desc="ecflow config",
+        config_data=cfg,
+    )
+
+
+def test_validate__stdin():
+    with patch.object(ecflow, "validate_internal") as validate_internal:
+        assert ecflow.validate()
     validate_internal.assert_called_once_with(
         schema_name="ecflow",
         desc="ecflow config",
@@ -694,8 +697,8 @@ def test_validate_file__stdin():
     )
 
 
-def test_validate_file__invalid(tmp_path):
+def test_validate__invalid(tmp_path):
     yaml_file = tmp_path / "ecflow.yaml"
     yaml_file.write_text("not_ecflow: {}\n")
     with raises(UWConfigError, match="YAML validation errors"):
-        ecflow.validate_file(yaml_file)
+        ecflow.validate(yaml_file)


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

Adds programmatic and file-based validation for ecFlow configs in the core
`uwtools.ecflow` module. Replaces the placeholder `validate_file()` introduced
in #872 with a real implementation, and broadens the input contract to accept
a `dict`, `YAMLConfig`, `Path`, or `None` (read `stdin`).

Fixes #866 & NOAA-EMC/global-workflow/#4797

**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [X] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [X] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [X] I have added myself and any co-authors to the PR's _Assignees_ list.
- [X] I have reviewed the documentation and have made any updates necessitated by this change.

**Self-Review Comment**

This PR builds on #872 and addresses the follow-up question raised by
@maddenp-cu in that review: *"I wonder if we should support validating a `dict`
or `YAMLConfig` here, too."* The answer here is yes — the new `validate()`
accepts all of `dict`, `YAMLConfig`, `Path`, and `None`.

#872 has now merged into `ecflow_tool`. This branch has been merged with the
new `ecflow_tool`, and `src/uwtools/api/ecflow.py` (plus its test) has been
updated to import and call `validate(config=...)` instead of the placeholder
`validate_file(yaml_file=...)`.

## Follow-ups discovered while implementing

While testing fail-fast validation (ultimately not adopted in this PR), two
pre-existing issues in the ecFlow module surfaced and should be filed
separately:

1. **Schema / runtime mismatch on `execution`.** `execution-serial.jsonschema` requires `executable`, but `_ecflowscript_for_task` in `ecflow.py` reads `jobcmd`.
2. **Schema rejects single-key `expand` blocks.** `test_integration__with_expand` uses an `expand`-only block, which violates the schema's `minProperties: 2` rule on `expander`. Either the test or the schema should be updated.
