### PR TITLE
Improve `!int` YAML tag

### DIFF
--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -160,13 +160,15 @@ Converts the tagged node to a Python ``int`` value. For example, given ``input.y
    f1: 3
    f2: 11
    f3: !int "{{ (f1 + f2) * 10 }}"
+   f4: !int '{{ leadtime.total_seconds() / 3600 }}'
 
 .. code-block:: text
 
-   $ uw config realize -i input.yaml --output-format yaml
+   $ uw config realize -i input.yaml --leadtime 6
    f1: 3
    f2: 11
-   f2: 140
+   f3: 140
+   f4: 6
 
 ``!list``
 ^^^^^^^^^

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -68,7 +68,7 @@ class Config(ABC, UserDict):
         def jinja2val(val: Any) -> str | None:
             try:
                 s = str(val)
-            except ValueError:
+            except (yaml.constructor.ConstructorError, ValueError):
                 assert isinstance(val, UWYAMLConvert)
                 s = val.tagged_string
             return s if "{{" in s or "{%" in s else None

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -225,8 +225,8 @@ class UWYAMLConvert(UWYAMLTaggedStr):
             partial(load_as, bool),  # !bool
             to_datetime,  # !datetime
             partial(load_as, dict),  # !dict
-            float,  # !float
-            int,  # !int
+            partial(load_as, float),  # !float
+            partial(load_as, int),  # !int
             partial(load_as, list),  # !list
             to_timedelta,  # !timedelta
         ]

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -266,6 +266,7 @@ i: 2024-10-10 00:19:00
 j: !dict "{ b0: 0, b1: 1, b2: 2,}"
 k: !list "[ a0, a1, a2, ]"
 l: "22"
+m: !int "22.0"
 
 """.strip()
     path = tmp_path / "config.yaml"
@@ -301,6 +302,7 @@ l: "22"
     assert config["j"] == {"b0": 0, "b1": 1, "b2": 2}
     assert config["k"] == ["a0", "a1", "a2"]
     assert config["l"] == "22"
+    assert config["m"] == 22
 
 
 @mark.parametrize("self_as_context", [False, True])


### PR DESCRIPTION
**Synopsis**

Current behavior:
```
$ echo '{hours: !int "{{ leadtime.total_seconds() / 3600 }}"}' | uw config realize --leadtime 6
hours: !int "{{ leadtime.total_seconds() / 3600 }}"
```
i.e. conversion fails.

This can be accomplished somewhat awkwardly with
```
$ echo '{hours: !int "{{ (leadtime.total_seconds() / 3600) | int }}"}' | uw config realize --leadtime 6
hours: 6
```
New behavior:
```
$ echo '{hours: !int "{{ leadtime.total_seconds() / 3600 }}"}' | uw config realize --leadtime 6
hours: 6
```

**Type**

- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
