### PR TITLE
Support `total` check + `values-needed`, improve accuracy of `values-needed` output

### DIFF
--- a/docs/sections/user_guide/cli/tools/config/realize-help.out
+++ b/docs/sections/user_guide/cli/tools/config/realize-help.out
@@ -34,7 +34,7 @@ Optional arguments:
   --leadtime LEADTIME
       The leadtime as hours[:minutes[:seconds]]
   --values-needed
-      Print report of values needed to realize config
+      Report values needed to realize config, then exit
   --total
       Require rendering of all Jinja2 variables/expressions
   --dry-run

--- a/docs/sections/user_guide/cli/tools/config/realize-values-needed.out
+++ b/docs/sections/user_guide/cli/tools/config/realize-values-needed.out
@@ -6,5 +6,4 @@
 [2025-01-02T03:04:05]     INFO   values.repeat
 [2025-01-02T03:04:05]     INFO 
 [2025-01-02T03:04:05]     INFO Keys with unrendered Jinja2 variables/expressions:
-[2025-01-02T03:04:05]     INFO   values: {'date': '{{ yyyymmdd }}', 'empty': None, 'greeting': 'Hello', 'message': 'Hello World', 'recipient': 'World', 'repeat': 1}
 [2025-01-02T03:04:05]     INFO   values.date: {{ yyyymmdd }}

--- a/docs/sections/user_guide/cli/tools/config/realize-values-needed.out
+++ b/docs/sections/user_guide/cli/tools/config/realize-values-needed.out
@@ -1,5 +1,4 @@
 [2025-01-02T03:04:05]     INFO Keys that are complete:
-[2025-01-02T03:04:05]     INFO   values
 [2025-01-02T03:04:05]     INFO   values.empty
 [2025-01-02T03:04:05]     INFO   values.greeting
 [2025-01-02T03:04:05]     INFO   values.message
@@ -7,4 +6,5 @@
 [2025-01-02T03:04:05]     INFO   values.repeat
 [2025-01-02T03:04:05]     INFO 
 [2025-01-02T03:04:05]     INFO Keys with unrendered Jinja2 variables/expressions:
+[2025-01-02T03:04:05]     INFO   values: {'date': '{{ yyyymmdd }}', 'empty': None, 'greeting': 'Hello', 'message': 'Hello World', 'recipient': 'World', 'repeat': 1}
 [2025-01-02T03:04:05]     INFO   values.date: {{ yyyymmdd }}

--- a/docs/sections/user_guide/cli/tools/template/render-help.out
+++ b/docs/sections/user_guide/cli/tools/template/render-help.out
@@ -30,7 +30,7 @@ Optional arguments:
   --search-path PATH[:PATH:...]
       Colon-separated paths to search for extra templates
   --values-needed
-      Print report of values needed to render template
+      Report values needed to render template, then exit
   --dry-run
       Only log info, making no changes
   --quiet, -q

--- a/notebooks/config.ipynb
+++ b/notebooks/config.ipynb
@@ -744,7 +744,6 @@
       "[2000-01-01T00:00:00]     INFO   memo.sent\n",
       "[2000-01-01T00:00:00]     INFO \n",
       "[2000-01-01T00:00:00]     INFO Keys with unrendered Jinja2 variables/expressions:\n",
-      "[2000-01-01T00:00:00]     INFO   memo: Namelist([('sender_id', '{{ id }}'), ('message', '{{ greeting }}, {{ recipient }}!'), ('sent', False)])\n",
       "[2000-01-01T00:00:00]     INFO   memo.sender_id: {{ id }}\n",
       "[2000-01-01T00:00:00]     INFO   memo.message: {{ greeting }}, {{ recipient }}!\n"
      ]

--- a/notebooks/config.ipynb
+++ b/notebooks/config.ipynb
@@ -741,10 +741,10 @@
      "output_type": "stream",
      "text": [
       "[2000-01-01T00:00:00]     INFO Keys that are complete:\n",
-      "[2000-01-01T00:00:00]     INFO   memo\n",
       "[2000-01-01T00:00:00]     INFO   memo.sent\n",
       "[2000-01-01T00:00:00]     INFO \n",
       "[2000-01-01T00:00:00]     INFO Keys with unrendered Jinja2 variables/expressions:\n",
+      "[2000-01-01T00:00:00]     INFO   memo: Namelist([('sender_id', '{{ id }}'), ('message', '{{ greeting }}, {{ recipient }}!'), ('sent', False)])\n",
       "[2000-01-01T00:00:00]     INFO   memo.sender_id: {{ id }}\n",
       "[2000-01-01T00:00:00]     INFO   memo.message: {{ greeting }}, {{ recipient }}!\n"
      ]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -44,6 +44,7 @@ ignore = [
   "ANN401",  # any-type
   "B010",    # set-attr-with-constant
   "C408",    # unnecessary-collection-call
+  "C901",    # complex-structure
   "COM812",  # missing-trailing-comma
   "D100",    # undocumented-public-module
   "D101",    # undocumented-public-class

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -192,7 +192,7 @@ def _add_subparser_config_realize(subparsers: Subparsers) -> ActionChecks:
     _add_arg_key_path(optional, helpmsg="Dot-separated path of keys to the block to be output")
     _add_arg_cycle(optional)
     _add_arg_leadtime(optional)
-    _add_arg_values_needed(optional, helpmsg="Print report of values needed to realize config")
+    _add_arg_values_needed(optional, helpmsg="Report values needed to realize config, then exit")
     _add_arg_total(optional)
     _add_arg_dry_run(optional)
     return [
@@ -697,7 +697,7 @@ def _add_subparser_template_render(subparsers: Subparsers) -> ActionChecks:
     _add_arg_leadtime(optional)
     _add_arg_env(optional)
     _add_arg_search_path(optional)
-    _add_arg_values_needed(optional, helpmsg="Print report of values needed to render template")
+    _add_arg_values_needed(optional, helpmsg="Report values needed to render template, then exit")
     _add_arg_dry_run(optional)
     checks = _add_args_verbosity(optional)
     _add_arg_key_eq_val_pairs(optional)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -287,8 +287,10 @@ def _dispatch_config_realize(args: Args) -> bool:
             stdin_ok=True,
         )
     except UWConfigRealizeError:
-        msg = "Config could not be realized. Try with %s for details."
-        log.error(msg, _switch(STR.valsneeded))
+        msg = "Config could not be realized."
+        if not args[STR.valsneeded]:
+            msg += " Try with %s for details." % _switch(STR.valsneeded)
+        log.error(msg)
         return False
     return True
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -56,7 +56,7 @@ class Config(ABC, UserDict):
 
     # Private methods
 
-    def _characterize_values(self, values: dict, parent: str) -> tuple[list, list]:
+    def _characterize_values(self, values: dict, parent: str) -> tuple[list[str], list[str]]:
         """
         Characterize values as complete or as template placeholders.
 

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -58,11 +58,11 @@ class Config(ABC, UserDict):
 
     def _characterize_values(self, values: dict, parent: str) -> tuple[list[str], list[str]]:
         """
-        Characterize values as complete or as template placeholders.
+        Characterize values as either complete or as incomplete template placeholders.
 
         :param values: The dictionary to examine.
         :param parent: Parent key.
-        :return: Lists of of complete and template-placeholder values.
+        :return: Lists of complete and incomplete-template-placeholder values.
         """
 
         def jinja2val(val: Any) -> str | None:
@@ -74,26 +74,26 @@ class Config(ABC, UserDict):
             return s if "{{" in s or "{%" in s else None
 
         complete: list[str] = []
-        template: list[str] = []
+        incomplete: list[str] = []
         for key, val in values.items():
             if isinstance(val, dict):
                 complete.append(f"{INDENT}{parent}{key}")
                 c, t = self._characterize_values(val, f"{parent}{key}.")
-                complete, template = complete + c, template + t
+                complete, incomplete = complete + c, incomplete + t
             elif isinstance(val, list):
                 for item in val:
                     if isinstance(item, dict):
                         c, t = self._characterize_values(item, parent)
-                        complete, template = complete + c, template + t
+                        complete, incomplete = complete + c, incomplete + t
                         complete.append(f"{INDENT}{parent}{key}")
                     elif val := jinja2val(val):
-                        template.append(f"{INDENT}{parent}{key}: {val}")
+                        incomplete.append(f"{INDENT}{parent}{key}: {val}")
                         break
             elif val := jinja2val(val):
-                template.append(f"{INDENT}{parent}{key}: {val}")
+                incomplete.append(f"{INDENT}{parent}{key}: {val}")
             else:
                 complete.append(f"{INDENT}{parent}{key}")
-        return complete, template
+        return complete, incomplete
 
     @staticmethod
     def _compare_config_get_lines(d: dict) -> list[str]:

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -78,17 +78,16 @@ class Config(ABC, UserDict):
         for key, val in values.items():
             if isinstance(val, dict):
                 c, i = self._characterize_values(val, f"{parent}{key}.")
-                if i:
-                    incomplete.append(f"{INDENT}{parent}{key}: {val}")
-                else:
+                if not i:
                     complete.append(f"{INDENT}{parent}{key}")
                 complete, incomplete = complete + c, incomplete + i
             elif isinstance(val, list):
-                for item in val:
+                if not jinja2val(val):
+                    complete.append(f"{INDENT}{parent}{key}")
+                for _, item in enumerate(val):
                     if isinstance(item, dict):
                         c, i = self._characterize_values(item, parent)
                         complete, incomplete = complete + c, incomplete + i
-                        complete.append(f"{INDENT}{parent}{key}")
                     elif val := jinja2val(val):
                         incomplete.append(f"{INDENT}{parent}{key}: {val}")
                         break

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -77,14 +77,17 @@ class Config(ABC, UserDict):
         incomplete: list[str] = []
         for key, val in values.items():
             if isinstance(val, dict):
-                complete.append(f"{INDENT}{parent}{key}")
-                c, t = self._characterize_values(val, f"{parent}{key}.")
-                complete, incomplete = complete + c, incomplete + t
+                c, i = self._characterize_values(val, f"{parent}{key}.")
+                if i:
+                    incomplete.append(f"{INDENT}{parent}{key}: {val}")
+                else:
+                    complete.append(f"{INDENT}{parent}{key}")
+                complete, incomplete = complete + c, incomplete + i
             elif isinstance(val, list):
                 for item in val:
                     if isinstance(item, dict):
-                        c, t = self._characterize_values(item, parent)
-                        complete, incomplete = complete + c, incomplete + t
+                        c, i = self._characterize_values(item, parent)
+                        complete, incomplete = complete + c, incomplete + i
                         complete.append(f"{INDENT}{parent}{key}")
                     elif val := jinja2val(val):
                         incomplete.append(f"{INDENT}{parent}{key}: {val}")

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -326,13 +326,14 @@ def _realize_update(
     return input_obj
 
 
-def _realize_values_needed(input_obj: Config) -> dict:
+def _realize_values_needed(input_obj: Config) -> dict[str, list[str]]:
     """
-    Print a report characterizing input values as complete, empty, or template placeholders.
+    Report values as fully-rendered (complete) or as template placeholders (incomplete).
 
-    :param input_obj: The config to update.
+    :param input_obj: The config whose values to report on..
+    :return: A dict of complete and incomplete keys.
     """
-    complete, template = input_obj._characterize_values(  # noqa: SLF001
+    complete, incomplete = input_obj._characterize_values(  # noqa: SLF001
         input_obj.data, parent=""
     )
     if complete:
@@ -342,13 +343,13 @@ def _realize_values_needed(input_obj: Config) -> dict:
     else:
         log.info("No keys are complete.")
     log.info("")
-    if template:
+    if incomplete:
         log.info("Keys with unrendered Jinja2 variables/expressions:")
-        for var in template:
+        for var in incomplete:
             log.info(var)
     else:
         log.info("No keys have unrendered Jinja2 variables/expressions.")
-    return {}
+    return {"complete": complete, "incomplete": incomplete}
 
 
 def _validate_format(other_fmt_desc: str, other_fmt: str, input_fmt: str) -> None:

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -154,12 +154,12 @@ def realize(
         input_obj, output_file, output_format, key_path
     )
     if values_needed:
-        values_status = _realize_values_needed(input_obj)
+        _realize_values_needed(input_obj)
     if total and unrendered(str(input_obj)):
         msg = "Config could not be totally realized"
         raise UWConfigRealizeError(msg)
     if values_needed:
-        return values_status
+        return {}
     if dry_run:
         for line in str(input_obj).strip().split("\n"):
             log.info(line)

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -330,7 +330,7 @@ def _realize_values_needed(input_obj: Config) -> dict[str, list[str]]:
     """
     Report values as fully-rendered (complete) or as template placeholders (incomplete).
 
-    :param input_obj: The config whose values to report on..
+    :param input_obj: The config whose values to report on.
     :return: A dict of complete and incomplete keys.
     """
     complete, incomplete = input_obj._characterize_values(  # noqa: SLF001

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -153,16 +153,17 @@ def realize(
     output_data, output_format = _realize_output_setup(
         input_obj, output_file, output_format, key_path
     )
+    if values_needed:
+        values_status = _realize_values_needed(input_obj)
+    if total and unrendered(str(input_obj)):
+        msg = "Config could not be totally realized"
+        raise UWConfigRealizeError(msg)
+    if values_needed:
+        return values_status
     if dry_run:
         for line in str(input_obj).strip().split("\n"):
             log.info(line)
         return {}
-    if values_needed:
-        _realize_values_needed(input_obj)
-        return {}
-    if total and unrendered(str(input_obj)):
-        msg = "Config could not be totally realized"
-        raise UWConfigRealizeError(msg)
     output_class = cast(Config, format_to_config(output_format))
     output_class.dump_dict(cfg=output_data, path=output_file)
     return input_obj.data
@@ -325,7 +326,7 @@ def _realize_update(
     return input_obj
 
 
-def _realize_values_needed(input_obj: Config) -> None:
+def _realize_values_needed(input_obj: Config) -> dict:
     """
     Print a report characterizing input values as complete, empty, or template placeholders.
 
@@ -347,6 +348,7 @@ def _realize_values_needed(input_obj: Config) -> None:
             log.info(var)
     else:
         log.info("No keys have unrendered Jinja2 variables/expressions.")
+    return {}
 
 
 def _validate_format(other_fmt_desc: str, other_fmt: str, input_fmt: str) -> None:

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -75,29 +75,32 @@ def test_config_base__characterize_values(config):
         7: "{% for n in range(3) %}{{ n }}{% endfor %}",
         8: ["{{ 1 + 1 }}"],
         9: [42],
+        10: {"c": "{{ n }}"},
     }
-    complete, template = config._characterize_values(values=values, parent="p.")
+    complete, incomplete = config._characterize_values(values=values, parent="p.")
     assert complete == [
         "  p.1",
         "  p.2",
         "  p.4",
         "  p.4.a",
-        "  p.b",
         "  p.5",
+        "  p.b",
         "  p.6",
+        "  p.9",
     ]
-    assert template == [
+    assert incomplete == [
         "  p.3: {{ n }}",
         "  p.7: {% for n in range(3) %}{{ n }}{% endfor %}",
         "  p.8: ['{{ 1 + 1 }}']",
+        "  p.10.c: {{ n }}",
     ]
 
 
 def test_config_base__characterize_values__tagged_convert(config):
     d = yaml.load("1: !int '{{ foo }}'", uw_yaml_loader())
-    complete, template = config._characterize_values(values=d, parent="p.")
+    complete, incomplete = config._characterize_values(values=d, parent="p.")
     assert complete == []
-    assert template == ["  p.1: !int '{{ foo }}'"]
+    assert incomplete == ["  p.1: !int '{{ foo }}'"]
 
 
 def test_config_base__depth(config):

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -849,11 +849,9 @@ def test_config_tools_realize__values_needed_ini(logged):
       dessert.servings
 
     Keys with unrendered Jinja2 variables/expressions:
-      salad: {'base': 'kale', 'fruit': 'banana', 'vegetable': 'tomato', 'how_many': '{{ amount }}', 'dressing': 'balsamic', 'toppings': '', 'meat': ''}
       salad.how_many: {{ amount }}
-      dessert: {'type': 'pie', 'flavor': '{{ flavor }}', 'side': 'False', 'servings': '0'}
       dessert.flavor: {{ flavor }}
-    """  # noqa: E501
+    """
     assert logged(dedent(expected), multiline=True)
 
 
@@ -877,11 +875,7 @@ def test_config_tools_realize__values_needed_yaml(logged):
       FV3GFS.nomads.testempty
 
     Keys with unrendered Jinja2 variables/expressions:
-      FV3GFS: {'nomads': {'protocol': 'download', 'url': 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos', 'file_names': {'grib2': {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}, 'nemsio': None, 'testfalse': False, 'testzero': 0}, 'testempty': None}}
-      FV3GFS.nomads: {'protocol': 'download', 'url': 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos', 'file_names': {'grib2': {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}, 'nemsio': None, 'testfalse': False, 'testzero': 0}, 'testempty': None}
       FV3GFS.nomads.url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos
-      FV3GFS.nomads.file_names: {'grib2': {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}, 'nemsio': None, 'testfalse': False, 'testzero': 0}
-      FV3GFS.nomads.file_names.grib2: {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}
       FV3GFS.nomads.file_names.grib2.anl: ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio']
       FV3GFS.nomads.file_names.grib2.fcst: ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']
     """  # noqa: E501

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -838,22 +838,22 @@ def test_config_tools_realize__values_needed_ini(logged):
     )
     expected = """
     Keys that are complete:
-      salad
       salad.base
       salad.fruit
       salad.vegetable
       salad.dressing
       salad.toppings
       salad.meat
-      dessert
       dessert.type
       dessert.side
       dessert.servings
 
     Keys with unrendered Jinja2 variables/expressions:
+      salad: {'base': 'kale', 'fruit': 'banana', 'vegetable': 'tomato', 'how_many': '{{ amount }}', 'dressing': 'balsamic', 'toppings': '', 'meat': ''}
       salad.how_many: {{ amount }}
+      dessert: {'type': 'pie', 'flavor': '{{ flavor }}', 'side': 'False', 'servings': '0'}
       dessert.flavor: {{ flavor }}
-    """
+    """  # noqa: E501
     assert logged(dedent(expected), multiline=True)
 
 
@@ -870,18 +870,18 @@ def test_config_tools_realize__values_needed_yaml(logged):
     )
     expected = """
     Keys that are complete:
-      FV3GFS
-      FV3GFS.nomads
       FV3GFS.nomads.protocol
-      FV3GFS.nomads.file_names
-      FV3GFS.nomads.file_names.grib2
       FV3GFS.nomads.file_names.nemsio
       FV3GFS.nomads.file_names.testfalse
       FV3GFS.nomads.file_names.testzero
       FV3GFS.nomads.testempty
 
     Keys with unrendered Jinja2 variables/expressions:
+      FV3GFS: {'nomads': {'protocol': 'download', 'url': 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos', 'file_names': {'grib2': {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}, 'nemsio': None, 'testfalse': False, 'testzero': 0}, 'testempty': None}}
+      FV3GFS.nomads: {'protocol': 'download', 'url': 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos', 'file_names': {'grib2': {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}, 'nemsio': None, 'testfalse': False, 'testzero': 0}, 'testempty': None}
       FV3GFS.nomads.url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos
+      FV3GFS.nomads.file_names: {'grib2': {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}, 'nemsio': None, 'testfalse': False, 'testzero': 0}
+      FV3GFS.nomads.file_names.grib2: {'anl': ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio'], 'fcst': ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']}
       FV3GFS.nomads.file_names.grib2.anl: ['gfs.t{{ hh }}z.atmanl.nemsio', 'gfs.t{{ hh }}z.sfcanl.nemsio']
       FV3GFS.nomads.file_names.grib2.fcst: ['gfs.t{{ hh }}z.pgrb2.0p25.f{{ fcst_hr03d }}']
     """  # noqa: E501
@@ -1145,9 +1145,12 @@ def test_config_tools__realize_values_needed(logged, tmp_path):
     with writable(path) as f:
         yaml.dump({1: "complete", 2: "{{ jinja2 }}", 3: ""}, f)
     c = YAMLConfig(config=path)
-    tools._realize_values_needed(input_obj=c)
+    result = tools._realize_values_needed(input_obj=c)
     assert logged("Keys that are complete:\n  1", multiline=True)
     assert logged("Keys with unrendered Jinja2 variables/expressions:\n  2", multiline=True)
+    # assert result["complete"] == ["1"]
+    # assert result["incomplete"] == ["2"]
+    assert result
 
 
 def test_config_tools__realize_values_needed__negative_results(logged, tmp_path):

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -1145,12 +1145,9 @@ def test_config_tools__realize_values_needed(logged, tmp_path):
     with writable(path) as f:
         yaml.dump({1: "complete", 2: "{{ jinja2 }}", 3: ""}, f)
     c = YAMLConfig(config=path)
-    result = tools._realize_values_needed(input_obj=c)
+    tools._realize_values_needed(input_obj=c)
     assert logged("Keys that are complete:\n  1", multiline=True)
     assert logged("Keys with unrendered Jinja2 variables/expressions:\n  2", multiline=True)
-    # assert result["complete"] == ["1"]
-    # assert result["incomplete"] == ["2"]
-    assert result
 
 
 def test_config_tools__realize_values_needed__negative_results(logged, tmp_path):

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -379,10 +379,14 @@ def test_cli__dispatch_config_realize(args_config_realize, utc):
     )
 
 
-def test_cli__dispatch_config_realize_fail(args_config_realize, logged):
+@mark.parametrize("values_needed_requested", [True, False])
+def test_cli__dispatch_config_realize_fail(args_config_realize, caplog, values_needed_requested):
+    args_config_realize[STR.valsneeded] = values_needed_requested
     with patch.object(cli.uwtools.api.config, "realize", side_effect=UWConfigRealizeError):
         assert cli._dispatch_config_realize(args_config_realize) is False
-    assert logged("Config could not be realized")
+    assert "Config could not be realized." in caplog.text
+    present = f"Try with {cli._switch(STR.valsneeded)} for details." in caplog.text
+    assert not present if values_needed_requested else present
 
 
 def test_cli__dispatch_config_validate_config_obj():


### PR DESCRIPTION
**Synopsis**

Currently, if `--values-needed` is used with `uw config realize`, the `total` check is not performed, as `uw` exits immediately after the values-needed report. This PR lets `uw` proceed to the `total` check, so that users can get error exit status if rendering is incomplete.

Also currently, the values-needed report lists a key whose value is a dict that, at some depth, contains unrendered content as complete, but this seems incorrect: The value should be incomplete if it contains any unrendered content.

Old behavior:

```
$ echo '{a: "{{ x }}", b: {c: "{{ x }}"}, c: 1}' | uw config realize --values-needed --total ; echo $?
[2026-04-23T14:05:03]     INFO Keys that are complete:
[2026-04-23T14:05:03]     INFO   b
[2026-04-23T14:05:03]     INFO   c
[2026-04-23T14:05:03]     INFO 
[2026-04-23T14:05:03]     INFO Keys with unrendered Jinja2 variables/expressions:
[2026-04-23T14:05:03]     INFO   a: {{ x }}
[2026-04-23T14:05:03]     INFO   b.c: {{ x }}
0
```
It seems wrong that `b` would be considered complete.

New behavior:

```
$ echo '{a: "{{ x }}", b: {c: "{{ x }}"}, c: 1}' | uw config realize --values-needed --total ; echo $?
[2026-04-23T17:53:42]     INFO Keys that are complete:
[2026-04-23T17:53:42]     INFO   c
[2026-04-23T17:53:42]     INFO 
[2026-04-23T17:53:42]     INFO Keys with unrendered Jinja2 variables/expressions:
[2026-04-23T17:53:42]     INFO   a: {{ x }}
[2026-04-23T17:53:42]     INFO   b.c: {{ x }}
[2026-04-23T17:53:42]    ERROR Config could not be realized.
1
```

Also, without `--values-needed`:
```
$ echo '{a: "{{ x }}", b: {c: "{{ x }}"}, c: 1}' | uw config realize --total ; echo $?
[2026-04-23T14:31:32]    ERROR Config could not be realized. Try with --values-needed for details.
1
```

Necessary doc and notebook updates have been made.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

If a user was counting on `--total` being ignored when `--values-needed` is set, this is a breaking change, but this seems unlikely.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
