### PR TITLE
Replace jobcmd with executable in ecflow.py and test_ecflow.py (fixes…

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -252,7 +252,7 @@ class _ECFlowDef:
             else None
         )
         execution = config[STR.execution]
-        cmd = execution.get(EC.jobcmd)
+        cmd = execution.get("executable")
         es = self._ecflowscript(
             execution=[cmd],
             manual=config.get(EC.manual, f"Script to run {task.name()}"),

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -384,7 +384,7 @@ class TestECFlowDef:
         suite.add(task)
         instance._d.add(suite)
         config = {
-            "execution": {"jobcmd": "echo hello"},
+            "execution": {"executable": "echo hello"},
             "manual": "Test task",
         }
         instance._create_ecf_script(config, task)
@@ -398,7 +398,7 @@ class TestECFlowDef:
         suite.add(task)
         instance_with_scheduler._d.add(suite)
         config = {
-            "execution": {"jobcmd": "echo hello"},
+            "execution": {"executable": "echo hello"},
             "account": "myaccount",
             "rundir": "/path/to/run",
         }
@@ -534,7 +534,7 @@ class TestECFlowDef:
         suite = Suite("test")
         task = Task("t1")
         # Place script FIRST so loop must continue to process trigger afterward.
-        script_config = {"execution": {"jobcmd": "echo hi"}}
+        script_config = {"execution": {"executable": "echo hi"}}
         config = {"script": script_config, "trigger": "1==1"}
         instance._add_node(config, task, suite)
         # Verify script was created and loop continued to process trigger.
@@ -548,7 +548,7 @@ class TestECFlowDef:
         suite = Suite("test")
         task = Task("t1")
         # Place script LAST so loop exits after processing it.
-        script_config = {"execution": {"jobcmd": "echo hi"}}
+        script_config = {"execution": {"executable": "echo hi"}}
         config = {"trigger": "1==1", "script": script_config}
         instance._add_node(config, task, suite)
         # Verify both trigger and script were processed.
@@ -613,7 +613,7 @@ class TestECFlowDef:
                     "task_run": {
                         "trigger": "/test/prep/setup == complete",
                         "script": {
-                            "execution": {"jobcmd": "echo running"},
+                            "execution": {"executable": "echo running"},
                         },
                     },
                 }


### PR DESCRIPTION
… #875)


**Synopsis**

This PR closes issue #875:

All references to `jobcmd` in `ecflow.py` and `test_ecflow.py` have been replaced with `executable`.
The `jobcmd` string remains in `strings.py` (and, if present, in the JSON schema) for backward compatibility and schema completeness. No changes were made to the JSON schema or strings.py regarding the removal of `jobcmd`, as requested in the issue.

This change aligns the codebase with the updated configuration standard, ensuring that ecFlow scripts and tests use the correct field name (`executable`) for clarity and consistency.

**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [X] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [X] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [X] I have added myself and any co-authors to the PR's _Assignees_ list.
- [X] I have reviewed the documentation and have made any updates necessitated by this change.
