### PR TITLE
In `fs` report, change `not-ready` key to `notready`

### DIFF
--- a/docs/sections/user_guide/cli/tools/config/realize-values-needed.out
+++ b/docs/sections/user_guide/cli/tools/config/realize-values-needed.out
@@ -1,4 +1,3 @@
 [2025-01-02T03:04:05]     INFO No keys have unrendered content.
-[2025-01-02T03:04:05]     INFO 
 [2025-01-02T03:04:05]     INFO Values with unrendered content:
 [2025-01-02T03:04:05]     INFO   values.date: {{ yyyymmdd }}

--- a/docs/sections/user_guide/cli/tools/fs.rst
+++ b/docs/sections/user_guide/cli/tools/fs.rst
@@ -74,7 +74,7 @@ The ``--target-dir`` option need not be specified when all destination paths are
 .. literalinclude:: fs/copy-no-target-dir-err.out
    :language: text
 
-When the ``--report`` option is specified, a report of files not copied ("not-ready") and copied ("ready") will be printed to ``stdout`` as machine-readable JSON. For example, using a config specifying both available and unavailable source files:
+When the ``--report`` option is specified, a report of files not copied ("notready") and copied ("ready") will be printed to ``stdout`` as machine-readable JSON. For example, using a config specifying both available and unavailable source files:
 
 .. literalinclude:: fs/copy-report.yaml
    :language: yaml

--- a/docs/sections/user_guide/cli/tools/fs/copy-glob.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-glob.out
@@ -7,7 +7,7 @@
 [2025-01-02T03:04:05]     INFO Local src/bar -> dst/copy-glob/dst/bar: Ready
 [2025-01-02T03:04:05]     INFO File copies: Ready
 {
-  "not-ready": [],
+  "notready": [],
   "ready": [
     "dst/copy-glob/dst/foo",
     "dst/copy-glob/dst/bar"

--- a/docs/sections/user_guide/cli/tools/fs/copy-report.out
+++ b/docs/sections/user_guide/cli/tools/fs/copy-report.out
@@ -11,7 +11,7 @@
 [2025-01-02T03:04:05]  WARNING File copies: ✔ Local src/foo -> dst/copy-report/foo
 [2025-01-02T03:04:05]  WARNING File copies: ✖ Local src/qux -> dst/copy-report/qux
 {
-  "not-ready": [
+  "notready": [
     "dst/copy-report/qux"
   ],
   "ready": [

--- a/notebooks/config.ipynb
+++ b/notebooks/config.ipynb
@@ -747,7 +747,6 @@
      "output_type": "stream",
      "text": [
       "[2000-01-01T00:00:00]     INFO No keys have unrendered content.\n",
-      "[2000-01-01T00:00:00]     INFO \n",
       "[2000-01-01T00:00:00]     INFO Values with unrendered content:\n",
       "[2000-01-01T00:00:00]     INFO   memo.sender_id: {{ id }}\n",
       "[2000-01-01T00:00:00]     INFO   memo.message: {{ greeting }}, {{ recipient }}!\n"

--- a/notebooks/fs.ipynb
+++ b/notebooks/fs.ipynb
@@ -126,7 +126,7 @@
    "id": "5885fd76-78de-4814-ad7b-dfd6df18a07d",
    "metadata": {},
    "source": [
-    "With these instructions, `copy()` creates a copy of each given file with the given name and in the given subdirectory. Copies are created in the directory indicated by `target_dir`. Paths can be provided either as a string or <a href=\"https://docs.python.org/3/library/pathlib.html#pathlib.Path\">Path</a> object. Any directories in the targeted paths for copying will be created if they don't already exist. The return value of `copy()` is a `dict` reporting files that were created (`ready`) and not created (`not-ready`)."
+    "With these instructions, `copy()` creates a copy of each given file with the given name and in the given subdirectory. Copies are created in the directory indicated by `target_dir`. Paths can be provided either as a string or <a href=\"https://docs.python.org/3/library/pathlib.html#pathlib.Path\">Path</a> object. Any directories in the targeted paths for copying will be created if they don't already exist. The return value of `copy()` is a `dict` reporting files that were created (`ready`) and not created (`notready`)."
    ]
   },
   {
@@ -156,7 +156,7 @@
        "{'ready': ['tmp/copy-target/file1-copy.nml',\n",
        "  'tmp/copy-target/data/file2-copy.txt',\n",
        "  'tmp/copy-target/data/file3-copy.csv'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 4,
@@ -239,7 +239,7 @@
     {
      "data": {
       "text/plain": [
-       "{'ready': [], 'not-ready': ['tmp/copy-target/missing-copy.nml']}"
+       "{'ready': [], 'notready': ['tmp/copy-target/missing-copy.nml']}"
       ]
      },
      "execution_count": 6,
@@ -356,7 +356,7 @@
        "{'ready': ['tmp/copy-keys-target/file1-copy.nml',\n",
        "  'tmp/copy-keys-target/data/file2-copy.txt',\n",
        "  'tmp/copy-keys-target/data/file3-copy.csv'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 9,
@@ -641,7 +641,7 @@
    "id": "1acd36eb-a5e7-4451-9d22-bfe8798cb4b0",
    "metadata": {},
    "source": [
-    "With these instructions, `link()` creates a symbolic link of each given file with the given name and in the given subdirectory. Links are created in the directory indicated by `target_dir`. Paths can be provided either as a string or <a href=\"https://docs.python.org/3/library/pathlib.html#pathlib.Path\">Path</a> object. Any directories in the targeted paths will be created if they don't already exist. The return value of `link()` is a `dict` reporting files that were created (`ready`) and not created (`not-ready`)."
+    "With these instructions, `link()` creates a symbolic link of each given file with the given name and in the given subdirectory. Links are created in the directory indicated by `target_dir`. Paths can be provided either as a string or <a href=\"https://docs.python.org/3/library/pathlib.html#pathlib.Path\">Path</a> object. Any directories in the targeted paths will be created if they don't already exist. The return value of `link()` is a `dict` reporting files that were created (`ready`) and not created (`notready`)."
    ]
   },
   {
@@ -671,7 +671,7 @@
        "{'ready': ['tmp/link-target/file1-link.nml',\n",
        "  'tmp/link-target/file2-link.txt',\n",
        "  'tmp/link-target/data/file3-link.csv'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 16,
@@ -754,7 +754,7 @@
     {
      "data": {
       "text/plain": [
-       "{'ready': [], 'not-ready': ['tmp/link-target/missing-link.nml']}"
+       "{'ready': [], 'notready': ['tmp/link-target/missing-link.nml']}"
       ]
      },
      "execution_count": 18,
@@ -871,7 +871,7 @@
        "{'ready': ['tmp/link-keys-target/file1-link.nml',\n",
        "  'tmp/link-keys-target/file2-link.txt',\n",
        "  'tmp/link-keys-target/data/file3-link.csv'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 21,
@@ -1028,7 +1028,7 @@
     {
      "data": {
       "text/plain": [
-       "File links <281472566035648>"
+       "File links <281472696931168>"
       ]
      },
      "execution_count": 24,
@@ -1154,7 +1154,7 @@
    "id": "eec8938c-1e2a-482b-aa0e-9e6e89dcf200",
    "metadata": {},
    "source": [
-    "With these instructions, `makedirs()` creates each directory in the list within the directory indicated by `target_dir`. Paths can be provided either as a string or <a href=\"https://docs.python.org/3/library/pathlib.html#pathlib.Path\">Path</a> object.  The return value of `makedirs()` is a `dict` reporting directories that were created (`ready`) and not created (`not-ready`)."
+    "With these instructions, `makedirs()` creates each directory in the list within the directory indicated by `target_dir`. Paths can be provided either as a string or <a href=\"https://docs.python.org/3/library/pathlib.html#pathlib.Path\">Path</a> object.  The return value of `makedirs()` is a `dict` reporting directories that were created (`ready`) and not created (`notready`)."
    ]
   },
   {
@@ -1179,7 +1179,7 @@
     {
      "data": {
       "text/plain": [
-       "{'ready': ['tmp/dir-target/foo', 'tmp/dir-target/bar/baz'], 'not-ready': []}"
+       "{'ready': ['tmp/dir-target/foo', 'tmp/dir-target/bar/baz'], 'notready': []}"
       ]
      },
      "execution_count": 28,
@@ -1292,7 +1292,7 @@
      "data": {
       "text/plain": [
        "{'ready': ['tmp/dir-keys-target/foo/bar', 'tmp/dir-keys-target/baz'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 31,
@@ -1582,7 +1582,7 @@
        "{'ready': ['tmp/glob-copy/file3.csv',\n",
        "  'tmp/glob-copy/file1.nml',\n",
        "  'tmp/glob-copy/file2.txt'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 38,
@@ -1686,7 +1686,7 @@
        "{'ready': ['tmp/glob-copy-recursive/file1.nml',\n",
        "  'tmp/glob-copy-recursive/subdir1/file4.nml',\n",
        "  'tmp/glob-copy-recursive/subdir2/file5.nml'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 41,
@@ -1783,7 +1783,7 @@
     {
      "data": {
       "text/plain": [
-       "{'ready': [], 'not-ready': []}"
+       "{'ready': [], 'notready': []}"
       ]
      },
      "execution_count": 44,
@@ -1852,7 +1852,7 @@
        "{'ready': ['tmp/glob-link-recursive/file1.nml',\n",
        "  'tmp/glob-link-recursive/subdir1/file4.nml',\n",
        "  'tmp/glob-link-recursive/subdir2/file5.nml'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 46,
@@ -1944,7 +1944,7 @@
      "data": {
       "text/plain": [
        "{'ready': ['tmp/glob-link-dirs/subdir1', 'tmp/glob-link-dirs/subdir2'],\n",
-       " 'not-ready': []}"
+       " 'notready': []}"
       ]
      },
      "execution_count": 49,
@@ -2034,7 +2034,7 @@
     {
      "data": {
       "text/plain": [
-       "{'ready': ['tmp/licenses/gpl'], 'not-ready': []}"
+       "{'ready': ['tmp/licenses/gpl'], 'notready': []}"
       ]
      },
      "execution_count": 52,

--- a/notebooks/tests/test_fs.py
+++ b/notebooks/tests/test_fs.py
@@ -32,10 +32,10 @@ def test_fs_copy(load, tb):
         "{'ready': ['tmp/copy-target/file1-copy.nml',"
         "\n  'tmp/copy-target/data/file2-copy.txt',"
         "\n  'tmp/copy-target/data/file3-copy.csv'],"
-        "\n 'not-ready': []}" in tb.cell_output_text(7)
+        "\n 'notready': []}" in tb.cell_output_text(7)
     )
     assert (
-        "{'ready': [], 'not-ready': ['tmp/copy-target/missing-copy.nml']}"
+        "{'ready': [], 'notready': ['tmp/copy-target/missing-copy.nml']}"
         in tb.cell_output_text(11)
     )
     assert tb.cell_output_text(13) == tb.cell_output_text(9)
@@ -44,7 +44,7 @@ def test_fs_copy(load, tb):
         "{'ready': ['tmp/copy-keys-target/file1-copy.nml',"
         "\n  'tmp/copy-keys-target/data/file2-copy.txt',"
         "\n  'tmp/copy-keys-target/data/file3-copy.csv'],"
-        "\n 'not-ready': []}" in tb.cell_output_text(17)
+        "\n 'notready': []}" in tb.cell_output_text(17)
     )
 
 
@@ -72,10 +72,10 @@ def test_fs_link(load, tb):
         "{'ready': ['tmp/link-target/file1-link.nml',"
         "\n  'tmp/link-target/file2-link.txt',"
         "\n  'tmp/link-target/data/file3-link.csv'],"
-        "\n 'not-ready': []}"
+        "\n 'notready': []}"
     ) in tb.cell_output_text(31)
     assert (
-        "{'ready': [], 'not-ready': ['tmp/link-target/missing-link.nml']}"
+        "{'ready': [], 'notready': ['tmp/link-target/missing-link.nml']}"
         in tb.cell_output_text(35)
     )
     assert tb.cell_output_text(37) == tb.cell_output_text(33)
@@ -84,7 +84,7 @@ def test_fs_link(load, tb):
         "{'ready': ['tmp/link-keys-target/file1-link.nml',"
         "\n  'tmp/link-keys-target/file2-link.txt',"
         "\n  'tmp/link-keys-target/data/file3-link.csv'],"
-        "\n 'not-ready': []}"
+        "\n 'notready': []}"
     ) in tb.cell_output_text(41)
 
 
@@ -101,12 +101,12 @@ def test_fs_makedirs(load, tb):
     # Ensure that cell output text matches expectations.
     assert tb.cell_output_text(53) == config_str
     assert (
-        "{'ready': ['tmp/dir-target/foo', 'tmp/dir-target/bar/baz'], 'not-ready': []}"
+        "{'ready': ['tmp/dir-target/foo', 'tmp/dir-target/bar/baz'], 'notready': []}"
         in tb.cell_output_text(55)
     )
     assert tb.cell_output_text(59) == config_keys_str
     assert (
-        "{'ready': ['tmp/dir-keys-target/foo/bar', 'tmp/dir-keys-target/baz'],\n 'not-ready': []}"
+        "{'ready': ['tmp/dir-keys-target/foo/bar', 'tmp/dir-keys-target/baz'],\n 'notready': []}"
     ) in tb.cell_output_text(61)
 
 
@@ -119,7 +119,7 @@ def test_fs_glob_copy_basic(load, report, tb):
     assert tb.cell_output_text(73) == load(base / "glob-copy.yaml")
     r = report(74)
     assert {*r["ready"]} == set(map(str, expected))
-    assert not r["not-ready"]
+    assert not r["notready"]
 
 
 def test_fs_glob_copy_recursive(load, report, tb):
@@ -131,7 +131,7 @@ def test_fs_glob_copy_recursive(load, report, tb):
     assert tb.cell_output_text(78) == load(base / "glob-copy-recursive.yaml")
     r = report(79)
     assert {*r["ready"]} == set(map(str, expected))
-    assert not r["not-ready"]
+    assert not r["notready"]
 
 
 def test_fs_glob_copy_ignore_dirs(load, report, tb):
@@ -140,7 +140,7 @@ def test_fs_glob_copy_ignore_dirs(load, report, tb):
     assert tb.cell_output_text(83) == load(base / "glob-copy-ignore-dirs.yaml")
     r = report(84)
     assert not r["ready"]
-    assert not r["not-ready"]
+    assert not r["notready"]
 
 
 def test_fs_glob_link_recursive(load, report, tb):
@@ -152,7 +152,7 @@ def test_fs_glob_link_recursive(load, report, tb):
     assert tb.cell_output_text(86) == load(base / "glob-link-recursive.yaml")
     r = report(87)
     assert {*r["ready"]} == set(map(str, expected))
-    assert not r["not-ready"]
+    assert not r["notready"]
 
 
 def test_fs_glob_link_link_dirs(load, report, tb):
@@ -164,7 +164,7 @@ def test_fs_glob_link_link_dirs(load, report, tb):
     assert tb.cell_output_text(90) == load(base / "glob-link-dirs.yaml")
     r = report(91)
     assert {*r["ready"]} == set(map(str, expected))
-    assert not r["not-ready"]
+    assert not r["notready"]
 
 
 def test_fs_copy_http(load, report, tb):
@@ -175,7 +175,7 @@ def test_fs_copy_http(load, report, tb):
     assert tb.cell_output_text(94) == load(base / "copy-http.yaml")
     r = report(95)
     assert r["ready"] == [str(expected)]
-    assert not r["not-ready"]
+    assert not r["notready"]
 
 
 # Helpers

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -344,7 +344,6 @@ def _realize_values_needed(config: Config) -> dict[str, list[list]]:
             log.info("  %s" % dotted(keypath))
     else:
         log.info(no % "keys")
-    log.info("")
     if vals:
         log.info(some % "Values")
         for keypath in vals:

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -119,7 +119,7 @@ class STR:
     mpiargs: str = "mpiargs"
     mpicmd: str = "mpicmd"
     namelist: str = "namelist"
-    notready: str = "not-ready"
+    notready: str = "notready"
     orog: str = "orog"
     oroggsl: str = "orog_gsl"
     outfile: str = "output_file"

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -840,7 +840,6 @@ def test_config_tools_realize__values_needed_ini(logged):
     assert len(incomplete["vals"]) == 2
     expected = """
     No keys have unrendered content.
-
     Values with unrendered content:
       salad.how_many: {{ amount }}
       dessert.flavor: {{ flavor }}
@@ -863,7 +862,6 @@ def test_config_tools_realize__values_needed_yaml(uwcaplog):
     assert len(incomplete["vals"]) == 4
     expected = """
     No keys have unrendered content.
-
     Values with unrendered content:
       FV3GFS.nomads.url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{{ yyyymmdd }}/{{ hh }}/atmos
       FV3GFS.nomads.file_names.grib2.anl.0: gfs.t{{ hh }}z.atmanl.nemsio
@@ -1134,7 +1132,6 @@ def test_config_tools__realize_values_needed(uwcaplog):
     expected = """
     Keys with unrendered content:
       {{ x }}
-
     Values with unrendered content:
       b: {{ y }}
       c.1: {% for n in range(3) %}hi{% endfor %}
@@ -1150,7 +1147,6 @@ def test_config_tools__realize_values_needed__negative_results(uwcaplog):
     assert incomplete["vals"] == []
     expected = """
     No keys have unrendered content.
-
     No values have unrendered content.
     """
     assert dedent(expected).strip() == uwcaplog.text.strip()

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -462,7 +462,7 @@ def test_cli__dispatch_fs_report_yes(capsys):
     cli._dispatch_fs_report(report=report)
     expected = """
     {
-      "not-ready": [
+      "notready": [
         "/missing"
       ],
       "ready": [


### PR DESCRIPTION
**Synopsis**

File `bar` does not exist, so given `config.yaml`
```
foo: bar
```
Old behavior:
```
$ uw fs copy -c config.yaml --target-dir . --report 2>/dev/null | jq -r .not-ready[]
jq: error: ready/0 is not defined at <top-level>, line 1, column 6:
    .not-ready[]
         ^^^^^
jq: 1 compile error
```
It can be made to work witih some awkward quoting around the `jq` argument:
```
$ uw fs copy -c config.yaml --target-dir . --report 2>/dev/null | jq -r '."not-ready"'[]
foo
```
New behavior:
```
$ uw fs copy -c config.yaml --target-dir . --report 2>/dev/null | jq -r .notready[]
foo
```
No awkward quoting necessary.

**Type**

- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
