### PR TITLE
In `rocoto realize`, dereference before validation, support `key_path` option

### DIFF
--- a/docs/sections/user_guide/cli/tools/rocoto/realize-help.out
+++ b/docs/sections/user_guide/cli/tools/rocoto/realize-help.out
@@ -1,5 +1,6 @@
 usage: uw rocoto realize [-h] [--version] [--config-file PATH]
-                         [--output-file PATH] [--quiet] [--verbose]
+                         [--output-file PATH] [--key-path KEY[.KEY...]]
+                         [--quiet] [--verbose]
 
 Realize a Rocoto XML workflow document
 
@@ -12,6 +13,8 @@ Optional arguments:
       Path to UW YAML config file (default: read from stdin)
   --output-file PATH, -o PATH
       Path to output file (default: write to stdout)
+  --key-path KEY[.KEY...]
+      Dot-separated path of keys to Rocoto config block
   --quiet, -q
       Print no logging messages
   --verbose, -v

--- a/notebooks/rocoto.ipynb
+++ b/notebooks/rocoto.ipynb
@@ -62,7 +62,7 @@
      "text": [
       "Help on function realize in module uwtools.api.rocoto:\n",
       "\n",
-      "realize(config: '_YAMLConfig | Path | str | None', output_file: 'Path | str | None' = None, stdin_ok: 'bool' = False) -> 'bool'\n",
+      "realize(config: '_YAMLConfig | Path | str | None', output_file: 'Path | str | None' = None, key_path: 'list[YAMLKey] | None' = None, stdin_ok: 'bool' = False) -> 'bool'\n",
       "    Realize the Rocoto workflow defined in the given YAML as XML.\n",
       "    \n",
       "    If no input file is specified, ``stdin`` is read. A ``YAMLConfig`` object may also be provided\n",
@@ -71,6 +71,7 @@
       "    \n",
       "    :param config: YAML input file or ``YAMLConfig`` object (``None`` => read ``stdin``).\n",
       "    :param output_file: XML output file path (``None`` => write to ``stdout``).\n",
+      "    :param key_path: Path of keys to the Rocoto config block.\n",
       "    :param stdin_ok: OK to read from ``stdin``?\n",
       "    :return: ``True``.\n",
       "\n"

--- a/src/uwtools/api/rocoto.py
+++ b/src/uwtools/api/rocoto.py
@@ -18,29 +18,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from uwtools.config.formats.yaml import YAMLConfig as _YAMLConfig
-
-
-def realize(
-    config: _YAMLConfig | Path | str | None,
-    output_file: Path | str | None = None,
-    stdin_ok: bool = False,
-) -> bool:
-    """
-    Realize the Rocoto workflow defined in the given YAML as XML.
-
-    If no input file is specified, ``stdin`` is read. A ``YAMLConfig`` object may also be provided
-    as input. If no output file is specified, ``stdout`` is written to. Both the input config and
-    output Rocoto XML will be validated against appropriate schemas.
-
-    :param config: YAML input file or ``YAMLConfig`` object (``None`` => read ``stdin``).
-    :param output_file: XML output file path (``None`` => write to ``stdout``).
-    :param stdin_ok: OK to read from ``stdin``?
-    :return: ``True``.
-    """
-    _realize(
-        config=_ensure_data_source(_str2path(config), stdin_ok), output_file=_str2path(output_file)
-    )
-    return True
+    from uwtools.config.support import YAMLKey
 
 
 def iterate(
@@ -66,6 +44,33 @@ def iterate(
         task=task,
         workflow=_ensure_data_source(_str2path(workflow), stdin_ok=False),
     )
+
+
+def realize(
+    config: _YAMLConfig | Path | str | None,
+    output_file: Path | str | None = None,
+    key_path: list[YAMLKey] | None = None,
+    stdin_ok: bool = False,
+) -> bool:
+    """
+    Realize the Rocoto workflow defined in the given YAML as XML.
+
+    If no input file is specified, ``stdin`` is read. A ``YAMLConfig`` object may also be provided
+    as input. If no output file is specified, ``stdout`` is written to. Both the input config and
+    output Rocoto XML will be validated against appropriate schemas.
+
+    :param config: YAML input file or ``YAMLConfig`` object (``None`` => read ``stdin``).
+    :param output_file: XML output file path (``None`` => write to ``stdout``).
+    :param key_path: Path of keys to the Rocoto config block.
+    :param stdin_ok: OK to read from ``stdin``?
+    :return: ``True``.
+    """
+    _realize(
+        config=_ensure_data_source(_str2path(config), stdin_ok),
+        output_file=_str2path(output_file),
+        key_path=key_path,
+    )
+    return True
 
 
 def validate_xml(

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -585,6 +585,7 @@ def _add_subparser_rocoto_realize(subparsers: Subparsers) -> ActionChecks:
     optional = _basic_setup(parser)
     _add_arg_config_file(optional)
     _add_arg_output_file(optional)
+    _add_arg_key_path(optional, helpmsg="Dot-separated path of keys to Rocoto config block")
     return _add_args_verbosity(optional)
 
 
@@ -638,6 +639,7 @@ def _dispatch_rocoto_realize(args: Args) -> bool:
     return uwtools.api.rocoto.realize(
         config=args[STR.cfgfile],
         output_file=args[STR.outfile],
+        key_path=args[STR.keypath],
         stdin_ok=True,
     )
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -172,7 +172,7 @@ def validate_external(
     if config_data is None:
         config = YAMLConfig(config_path).dereference().data
     elif isinstance(config_data, YAMLConfig):
-        config = config_data.data
+        config = config_data.dereference().data
     else:
         config = config_data
     if not str(schema_file).startswith(str(resource_path())):

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -215,9 +215,8 @@ class _RocotoXML:
     ) -> None:
         config = YAMLConfig(config)
         config.dereference()
-        config.data = reduce(getitem, key_path or [], config.data)
-        self._config_validate(config)
-        self._config = config.data
+        self._config = reduce(getitem, key_path or [], config.data)
+        self._config_validate(self._config)
         self._add_workflow(self._config)
 
     def __str__(self) -> str:

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -8,8 +8,10 @@ import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import timezone
+from functools import reduce
 from itertools import chain
 from math import log10
+from operator import getitem
 from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING, Any
@@ -30,6 +32,8 @@ from uwtools.utils.processing import run_shell_cmd
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from uwtools.config.support import YAMLKey
+
 
 DEFAULT_ITERATION_RATE = 10  # seconds
 
@@ -38,16 +42,21 @@ def iterate(cycle: datetime, database: Path, rate: int, task: str, workflow: Pat
     return _RocotoIterator(cycle, database, rate, task, workflow).iterate()
 
 
-def realize(config: YAMLConfig | Path | None, output_file: Path | None = None) -> str:
+def realize(
+    config: YAMLConfig | Path | None,
+    output_file: Path | None = None,
+    key_path: list[YAMLKey] | None = None,
+) -> str:
     """
     Realize the Rocoto workflow defined in the given YAML as XML, validating both the YAML input and
     XML output.
 
     :param config: Path to YAML input file (None => read stdin), or YAMLConfig object.
     :param output_file: Path to write rendered XML file (None => write to stdout).
+    :param key_path: Path of keys to the Rocoto config block.
     :return: An XML string.
     """
-    rxml = _RocotoXML(config)
+    rxml = _RocotoXML(config, key_path)
     xml_string = str(rxml).strip()
     if unrendered(xml_string):
         log.error(xml_string)
@@ -199,11 +208,16 @@ class _RocotoXML:
     Generate a Rocoto XML document from a YAML config.
     """
 
-    def __init__(self, config: dict | YAMLConfig | Path | None = None) -> None:
-        cfgobj = config if isinstance(config, YAMLConfig) else YAMLConfig(config)
-        cfgobj.dereference()
-        self._config_validate(config)
-        self._config = cfgobj.data
+    def __init__(
+        self,
+        config: dict | YAMLConfig | Path | None = None,
+        key_path: list[YAMLKey] | None = None,
+    ) -> None:
+        config = config if isinstance(config, YAMLConfig) else YAMLConfig(config)
+        config.dereference()
+        config_rocoto = reduce(getitem, key_path or [], config)
+        self._config_validate(config_rocoto)
+        self._config = config_rocoto.data
         self._add_workflow(self._config)
 
     def __str__(self) -> str:

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -213,11 +213,11 @@ class _RocotoXML:
         config: dict | YAMLConfig | Path | None = None,
         key_path: list[YAMLKey] | None = None,
     ) -> None:
-        config = config if isinstance(config, YAMLConfig) else YAMLConfig(config)
+        config = YAMLConfig(config)
         config.dereference()
-        config_rocoto = reduce(getitem, key_path or [], config)
-        self._config_validate(config_rocoto)
-        self._config = config_rocoto.data
+        config.data = reduce(getitem, key_path or [], config.data)
+        self._config_validate(config)
+        self._config = config.data
         self._add_workflow(self._config)
 
     def __str__(self) -> str:

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -200,9 +200,9 @@ class _RocotoXML:
     """
 
     def __init__(self, config: dict | YAMLConfig | Path | None = None) -> None:
-        self._config_validate(config)
         cfgobj = config if isinstance(config, YAMLConfig) else YAMLConfig(config)
         cfgobj.dereference()
+        self._config_validate(config)
         self._config = cfgobj.data
         self._add_workflow(self._config)
 

--- a/src/uwtools/tests/api/test_rocoto.py
+++ b/src/uwtools/tests/api/test_rocoto.py
@@ -24,7 +24,7 @@ def test_api_rocoto_realize():
     path1, path2 = Path("foo"), Path("bar")
     with patch.object(rocoto, "_realize") as _realize:
         rocoto.realize(config=path1, output_file=path2)
-    _realize.assert_called_once_with(config=path1, output_file=path2)
+    _realize.assert_called_once_with(config=path1, output_file=path2, key_path=None)
 
 
 def test_api_rocoto_validate_xml():

--- a/src/uwtools/tests/fixtures/hello_workflow.yaml
+++ b/src/uwtools/tests/fixtures/hello_workflow.yaml
@@ -1,7 +1,8 @@
+scheduler: slurm
 workflow:
   attrs:
     realtime: false
-    scheduler: slurm
+    scheduler: '{{ scheduler }}'
   cycledef:
     - attrs:
         activation_offset: -06:00

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -507,17 +507,17 @@ def test_cli_dispatch_rocoto_iterate(utc):
 
 
 def test_cli__dispatch_rocoto_realize():
-    args = {STR.cfgfile: 1, STR.outfile: 2}
+    args = {STR.cfgfile: 1, STR.outfile: 2, STR.keypath: None}
     with patch.object(uwtools.api.rocoto, "_realize") as _realize:
         cli._dispatch_rocoto_realize(args)
-    _realize.assert_called_once_with(config=1, output_file=2)
+    _realize.assert_called_once_with(config=1, output_file=2, key_path=None)
 
 
 def test_cli__dispatch_rocoto_realize_no_optional():
-    args = {STR.cfgfile: None, STR.outfile: None}
+    args: dict = {STR.cfgfile: None, STR.outfile: None, STR.keypath: None}
     with patch.object(uwtools.api.rocoto, "_realize") as func:
         cli._dispatch_rocoto_realize(args)
-    func.assert_called_once_with(config=None, output_file=None)
+    func.assert_called_once_with(config=None, output_file=None, key_path=None)
 
 
 def test_cli__dispatch_rocoto_validate_xml():

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -67,6 +67,16 @@ def test_rocoto_realize__cfg_to_stdout(capsys, assets):
     assert rocoto.validate_xml_file(xml_file=outfile)
 
 
+def test_rocoto_realize__cfg_to_stdout_key_path(capsys, assets):
+    cfgfile, outfile = assets
+    config = YAMLConfig(cfgfile)
+    config["path"] = {"to": {"workflow": config["workflow"]}}
+    del config["workflow"]
+    rocoto.realize(config=config, key_path=["path", "to"])
+    outfile.write_text(capsys.readouterr().out)
+    assert rocoto.validate_xml_file(xml_file=outfile)
+
+
 def test_rocoto_realize__file_to_file(assets):
     cfgfile, outfile = assets
     rocoto.realize(config=cfgfile, output_file=outfile)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -68,6 +68,7 @@ def test_rocoto_realize__cfg_to_stdout(capsys, assets):
 
 
 def test_rocoto_realize__cfg_to_stdout_key_path(capsys, assets):
+    # Test that workflow: block not at the root of the config can be accessed via key_path.
     cfgfile, outfile = assets
     config = YAMLConfig(cfgfile)
     config["path"] = {"to": {"workflow": config["workflow"]}}


### PR DESCRIPTION
**Synopsis**

- Fix the `_RocotoXML` initializer so that dereferencing precedes validation. Previously, unrendered Jinja2 content might still exist in the config, leading to incorrect validation failure.
- Add support for a `key_path` argument to the CLI and API, so that the `workflow:` block can be located at any depth in a Rocoto YAML config.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
