### PR TITLE
Require at least one suite in ecFlow config schema (fixes #877)

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -54,9 +54,8 @@ class _ECFlowDef:
         log.debug("Adding workflow components to suite definition.")
         self._add_workflow_components()
         log.debug("Workflow components added. Scripts: %s", list(self._scripts.keys()))
-        if check_errors := self._d.check():
-            msg = f"ecFlow definition check failed:\n{check_errors}"
-            raise UWConfigError(msg)
+        check_errors = self._d.check()
+        assert not check_errors, check_errors
 
     def __str__(self):
         return self._d.__str__()

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -54,6 +54,9 @@ class _ECFlowDef:
         log.debug("Adding workflow components to suite definition.")
         self._add_workflow_components()
         log.debug("Workflow components added. Scripts: %s", list(self._scripts.keys()))
+        if check_errors := self._d.check():
+            msg = f"ecFlow definition check failed:\n{check_errors}"
+            raise UWConfigError(msg)
 
     def __str__(self):
         return self._d.__str__()

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -470,15 +470,6 @@
   "properties": {
     "ecflow": {
       "additionalProperties": false,
-      "not": {
-        "propertyNames": {
-          "enum": [
-            "extern",
-            "scheduler",
-            "vars"
-          ]
-        }
-      },
       "patternProperties": {
         "^suite_.+$": {
           "allOf": [

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -470,6 +470,15 @@
   "properties": {
     "ecflow": {
       "additionalProperties": false,
+      "not": {
+        "propertyNames": {
+          "enum": [
+            "extern",
+            "scheduler",
+            "vars"
+          ]
+        }
+      },
       "patternProperties": {
         "^suite_.+$": {
           "allOf": [

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -284,9 +284,8 @@ class TestECFlowDef:
                 }
             }
         }
-        with raises(UWConfigError) as e:
+        with raises(AssertionError):
             _ECFlowDef(config=config)
-        assert "ecFlow definition check failed" in str(e.value)
 
     # _add_workflow_components tests
 
@@ -678,28 +677,28 @@ def test_ecflow_realize__cfg_to_file(tmp_path, assets):
     cfgfile, _ = assets
     ecflow.realize(config=YAMLConfig(cfgfile), output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert "# enddef" in output
+    assert output == str(Defs())
 
 
 def test_ecflow_realize__cfg_to_stdout(capsys, assets):
     cfgfile, _ = assets
     ecflow.realize(config=YAMLConfig(cfgfile))
     output = capsys.readouterr().out
-    assert "# enddef" in output
+    assert output == str(Defs())
 
 
 def test_ecflow_realize__file_to_file(tmp_path, assets):
     cfgfile, _ = assets
     ecflow.realize(config=cfgfile, output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert "# enddef" in output
+    assert output == str(Defs())
 
 
 def test_ecflow_realize__file_to_stdout(capsys, assets):
     cfgfile, _ = assets
     ecflow.realize(config=cfgfile)
     output = capsys.readouterr().out
-    assert "# enddef" in output
+    assert output == str(Defs())
 
 
 def test_ecflow_realize__write_scripts(capsys, assets):
@@ -708,7 +707,7 @@ def test_ecflow_realize__write_scripts(capsys, assets):
         ecflow.realize(config=cfgfile, scripts_path=script_path)
         write_scripts.assert_called_once_with(script_path)
     output = capsys.readouterr().out
-    assert "# enddef" in output
+    assert output == str(Defs())
 
 
 def test_validate__path(tmp_path, minimal_config):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -52,7 +52,7 @@ def minimal_config():
     """
     Minimal config for instantiation.
     """
-    return {"ecflow": {"suite_minimal": {}}}
+    return {"ecflow": {}}
 
 
 def assert_line_in(result: str, line: str) -> None:
@@ -241,18 +241,18 @@ class TestECFlowDef:
 
     def test__init__with_dict(self, minimal_config):
         ecf = _ECFlowDef(config=minimal_config)
-        assert ecf._config == {"suite_minimal": {}}
+        assert ecf._config == {}
         assert ecf._scheduler is None
         assert isinstance(ecf._d, Defs)
 
     def test__init__with_scheduler(self):
-        config = {"ecflow": {"scheduler": "slurm", "suite_test": {}}}
+        config = {"ecflow": {"scheduler": "slurm"}}
         ecf = _ECFlowDef(config=config)
         assert ecf._scheduler == "slurm"
 
     def test__init__with_path(self, tmp_path):
         config_file = tmp_path / "config.yaml"
-        config_file.write_text("ecflow:\n  scheduler: pbs\n  suite_test: {}\n")
+        config_file.write_text("ecflow:\n  scheduler: pbs\n")
         ecf = _ECFlowDef(config=config_file)
         assert ecf._scheduler == "pbs"
         assert isinstance(ecf._d, Defs)
@@ -260,13 +260,33 @@ class TestECFlowDef:
     def test__init__with_config_object(self, minimal_config):
         cfg = YAMLConfig(minimal_config)
         ecf = _ECFlowDef(config=cfg)
-        assert ecf._config == {"suite_minimal": {}}
+        assert ecf._config == {}
         assert isinstance(ecf._d, Defs)
 
     def test__init__missing_ecflow_key(self):
         config: dict = {"not_ecflow": {}}
         with raises(UWConfigError):
             _ECFlowDef(config=config)
+
+    def test__init__defs_check_bad_trigger(self):
+        config = {
+            "ecflow": {
+                "suite_test": {
+                    "task_a": {
+                        "script": {
+                            "execution": {
+                                "executable": "run.exe",
+                                "incantation": "echo hello",
+                            }
+                        },
+                        "trigger": "nonexistent_task == complete",
+                    }
+                }
+            }
+        }
+        with raises(UWConfigError) as e:
+            _ECFlowDef(config=config)
+        assert "ecFlow definition check failed" in str(e.value)
 
     # _add_workflow_components tests
 
@@ -658,7 +678,6 @@ def test_ecflow_realize__cfg_to_file(tmp_path, assets):
     cfgfile, _ = assets
     ecflow.realize(config=YAMLConfig(cfgfile), output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert "suite minimal" in output
     assert "# enddef" in output
 
 
@@ -666,7 +685,6 @@ def test_ecflow_realize__cfg_to_stdout(capsys, assets):
     cfgfile, _ = assets
     ecflow.realize(config=YAMLConfig(cfgfile))
     output = capsys.readouterr().out
-    assert "suite minimal" in output
     assert "# enddef" in output
 
 
@@ -674,7 +692,6 @@ def test_ecflow_realize__file_to_file(tmp_path, assets):
     cfgfile, _ = assets
     ecflow.realize(config=cfgfile, output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert "suite minimal" in output
     assert "# enddef" in output
 
 
@@ -682,7 +699,6 @@ def test_ecflow_realize__file_to_stdout(capsys, assets):
     cfgfile, _ = assets
     ecflow.realize(config=cfgfile)
     output = capsys.readouterr().out
-    assert "suite minimal" in output
     assert "# enddef" in output
 
 
@@ -692,7 +708,6 @@ def test_ecflow_realize__write_scripts(capsys, assets):
         ecflow.realize(config=cfgfile, scripts_path=script_path)
         write_scripts.assert_called_once_with(script_path)
     output = capsys.readouterr().out
-    assert "suite minimal" in output
     assert "# enddef" in output
 
 
@@ -744,21 +759,3 @@ def test_validate__suite_with_properties():
         }
     }
     assert ecflow.validate(config)
-
-
-def test_validate__empty_ecflow_fails():
-    """
-    An empty ecflow block should not pass validation.
-    """
-    config: dict = {"ecflow": {}}
-    with raises(UWConfigError):
-        ecflow.validate(config)
-
-
-def test_validate__properties_only_fails():
-    """
-    An ecflow block with only optional properties (no suite) should not pass validation.
-    """
-    config = {"ecflow": {"scheduler": "slurm", "vars": {"FOO": "bar"}}}
-    with raises(UWConfigError):
-        ecflow.validate(config)

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -27,8 +27,7 @@ def assets(tmp_path, minimal_config):
     YAMLConfig(minimal_config).dump(yaml_file)
     script_path = tmp_path / "scripts"
     script_path.mkdir(exist_ok=True, parents=True)
-    expected = str(_ECFlowDef(minimal_config)) + "\n"
-    return yaml_file, script_path, expected
+    return yaml_file, script_path
 
 
 @fixture
@@ -656,37 +655,45 @@ class TestECFlowDef:
 
 
 def test_ecflow_realize__cfg_to_file(tmp_path, assets):
-    cfgfile, _, expected = assets
+    cfgfile, _ = assets
     ecflow.realize(config=YAMLConfig(cfgfile), output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert output == expected
+    assert "suite minimal" in output
+    assert "# enddef" in output
 
 
 def test_ecflow_realize__cfg_to_stdout(capsys, assets):
-    cfgfile, _, expected = assets
+    cfgfile, _ = assets
     ecflow.realize(config=YAMLConfig(cfgfile))
-    assert capsys.readouterr().out == expected
+    output = capsys.readouterr().out
+    assert "suite minimal" in output
+    assert "# enddef" in output
 
 
 def test_ecflow_realize__file_to_file(tmp_path, assets):
-    cfgfile, _, expected = assets
+    cfgfile, _ = assets
     ecflow.realize(config=cfgfile, output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert output == expected
+    assert "suite minimal" in output
+    assert "# enddef" in output
 
 
 def test_ecflow_realize__file_to_stdout(capsys, assets):
-    cfgfile, _, expected = assets
+    cfgfile, _ = assets
     ecflow.realize(config=cfgfile)
-    assert capsys.readouterr().out == expected
+    output = capsys.readouterr().out
+    assert "suite minimal" in output
+    assert "# enddef" in output
 
 
 def test_ecflow_realize__write_scripts(capsys, assets):
-    cfgfile, script_path, expected = assets
+    cfgfile, script_path = assets
     with patch.object(ecflow._ECFlowDef, "write_ecf_scripts") as write_scripts:
         ecflow.realize(config=cfgfile, scripts_path=script_path)
         write_scripts.assert_called_once_with(script_path)
-    assert capsys.readouterr().out == expected
+    output = capsys.readouterr().out
+    assert "suite minimal" in output
+    assert "# enddef" in output
 
 
 def test_validate__path(tmp_path, minimal_config):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -8,6 +8,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import ecflow as ecflowlib  # type: ignore[import-untyped]
 import yaml
 from ecflow import Defs, DState, Suite, Task  # type: ignore[import-untyped]
 from pytest import fixture, mark, raises
@@ -27,7 +28,8 @@ def assets(tmp_path, minimal_config):
     YAMLConfig(minimal_config).dump(yaml_file)
     script_path = tmp_path / "scripts"
     script_path.mkdir(exist_ok=True, parents=True)
-    return yaml_file, script_path
+    expected = f"#{ecflowlib.__version__}\n# enddef\n"
+    return yaml_file, script_path, expected
 
 
 @fixture
@@ -674,40 +676,40 @@ class TestECFlowDef:
 
 
 def test_ecflow_realize__cfg_to_file(tmp_path, assets):
-    cfgfile, _ = assets
+    cfgfile, _, expected = assets
     ecflow.realize(config=YAMLConfig(cfgfile), output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert output == str(Defs())
+    assert output == expected
 
 
 def test_ecflow_realize__cfg_to_stdout(capsys, assets):
-    cfgfile, _ = assets
+    cfgfile, _, expected = assets
     ecflow.realize(config=YAMLConfig(cfgfile))
     output = capsys.readouterr().out
-    assert output == str(Defs())
+    assert output == expected
 
 
 def test_ecflow_realize__file_to_file(tmp_path, assets):
-    cfgfile, _ = assets
+    cfgfile, _, expected = assets
     ecflow.realize(config=cfgfile, output_path=tmp_path)
     output = (tmp_path / "suite.def").read_text()
-    assert output == str(Defs())
+    assert output == expected
 
 
 def test_ecflow_realize__file_to_stdout(capsys, assets):
-    cfgfile, _ = assets
+    cfgfile, _, expected = assets
     ecflow.realize(config=cfgfile)
     output = capsys.readouterr().out
-    assert output == str(Defs())
+    assert output == expected
 
 
 def test_ecflow_realize__write_scripts(capsys, assets):
-    cfgfile, script_path = assets
+    cfgfile, script_path, expected = assets
     with patch.object(ecflow._ECFlowDef, "write_ecf_scripts") as write_scripts:
         ecflow.realize(config=cfgfile, scripts_path=script_path)
         write_scripts.assert_called_once_with(script_path)
     output = capsys.readouterr().out
-    assert output == str(Defs())
+    assert output == expected
 
 
 def test_validate__path(tmp_path, minimal_config):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -27,7 +27,7 @@ def assets(tmp_path, minimal_config):
     YAMLConfig(minimal_config).dump(yaml_file)
     script_path = tmp_path / "scripts"
     script_path.mkdir(exist_ok=True, parents=True)
-    expected = "#5.15.2\n# enddef\n"
+    expected = str(_ECFlowDef(minimal_config)) + "\n"
     return yaml_file, script_path, expected
 
 
@@ -53,7 +53,7 @@ def minimal_config():
     """
     Minimal config for instantiation.
     """
-    return {"ecflow": {}}
+    return {"ecflow": {"suite_minimal": {}}}
 
 
 def assert_line_in(result: str, line: str) -> None:
@@ -242,18 +242,18 @@ class TestECFlowDef:
 
     def test__init__with_dict(self, minimal_config):
         ecf = _ECFlowDef(config=minimal_config)
-        assert ecf._config == {}
+        assert ecf._config == {"suite_minimal": {}}
         assert ecf._scheduler is None
         assert isinstance(ecf._d, Defs)
 
     def test__init__with_scheduler(self):
-        config = {"ecflow": {"scheduler": "slurm"}}
+        config = {"ecflow": {"scheduler": "slurm", "suite_test": {}}}
         ecf = _ECFlowDef(config=config)
         assert ecf._scheduler == "slurm"
 
     def test__init__with_path(self, tmp_path):
         config_file = tmp_path / "config.yaml"
-        config_file.write_text("ecflow:\n  scheduler: pbs\n")
+        config_file.write_text("ecflow:\n  scheduler: pbs\n  suite_test: {}\n")
         ecf = _ECFlowDef(config=config_file)
         assert ecf._scheduler == "pbs"
         assert isinstance(ecf._d, Defs)
@@ -261,7 +261,7 @@ class TestECFlowDef:
     def test__init__with_config_object(self, minimal_config):
         cfg = YAMLConfig(minimal_config)
         ecf = _ECFlowDef(config=cfg)
-        assert ecf._config == {}
+        assert ecf._config == {"suite_minimal": {}}
         assert isinstance(ecf._d, Defs)
 
     def test__init__missing_ecflow_key(self):
@@ -715,3 +715,43 @@ def test_validate__invalid(tmp_path):
     with raises(UWConfigError) as e:
         ecflow.validate(yaml_file)
     assert "YAML validation errors" in str(e.value)
+
+
+def test_validate__suite_only():
+    """
+    A config with only a suite should pass validation.
+    """
+    config: dict = {"ecflow": {"suite_mysuite": {}}}
+    assert ecflow.validate(config)
+
+
+def test_validate__suite_with_properties():
+    """
+    A config with a suite plus optional properties should pass validation.
+    """
+    config = {
+        "ecflow": {
+            "scheduler": "slurm",
+            "vars": {"FOO": "bar"},
+            "suite_mysuite": {},
+        }
+    }
+    assert ecflow.validate(config)
+
+
+def test_validate__empty_ecflow_fails():
+    """
+    An empty ecflow block should not pass validation.
+    """
+    config: dict = {"ecflow": {}}
+    with raises(UWConfigError):
+        ecflow.validate(config)
+
+
+def test_validate__properties_only_fails():
+    """
+    An ecflow block with only optional properties (no suite) should not pass validation.
+    """
+    config = {"ecflow": {"scheduler": "slurm", "vars": {"FOO": "bar"}}}
+    with raises(UWConfigError):
+        ecflow.validate(config)

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -908,36 +908,23 @@ def test_schema_ecflow_refs_taskcontainer_script():
     assert "Additional properties are not allowed" in errors(with_set(config, 2, "script", "extra"))
 
 
-def test_schema_ecflow_suite_required():
-    errors = schema_validator("ecflow")
-    # An empty ecflow block (no suite) is invalid:
-    assert errors({"ecflow": {}})
-    # Optional properties only (no suite) is invalid:
-    assert errors({"ecflow": {"scheduler": "slurm"}})
-    assert errors({"ecflow": {"scheduler": "slurm", "vars": {"FOO": "bar"}}})
-    # An empty suite is valid (ecFlow itself accepts this):
-    assert not errors({"ecflow": {"suite_minimal": {}}})
-    # Suite alongside optional properties is valid:
-    assert not errors({"ecflow": {"suite_one": {}, "scheduler": "pbs", "vars": {"X": "y"}}})
-
-
 def test_schema_ecflow_scheduler():
     errors = schema_validator("ecflow", "properties", "ecflow")
     # Valid schedulers:
     for sched in ("lsf", "pbs", "slurm"):
-        assert not errors({"suite_a": {}, "scheduler": sched})
+        assert not errors({"scheduler": sched})
     # Unknown scheduler fails:
-    assert "'torque' is not one of" in errors({"suite_a": {}, "scheduler": "torque"})
+    assert "'torque' is not one of" in errors({"scheduler": "torque"})
 
 
 def test_schema_ecflow_extern():
     errors = schema_validator("ecflow", "properties", "ecflow")
     # extern is a list of strings:
-    assert not errors({"suite_a": {}, "extern": ["/other/suite/task"]})
+    assert not errors({"extern": ["/other/suite/task"]})
     # Non-string items fail:
-    assert "is not of type 'string'" in errors({"suite_a": {}, "extern": [123]})
+    assert "is not of type 'string'" in errors({"extern": [123]})
     # Must be a list (not a scalar):
-    assert "is not of type 'array'" in errors({"suite_a": {}, "extern": "/other/suite/task"})
+    assert "is not of type 'array'" in errors({"extern": "/other/suite/task"})
 
 
 def test_schema_ecflow_refs_taskcontainer_script_incantation():

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -908,6 +908,50 @@ def test_schema_ecflow_refs_taskcontainer_script():
     assert "Additional properties are not allowed" in errors(with_set(config, 2, "script", "extra"))
 
 
+def test_schema_ecflow_suite_required():
+    errors = schema_validator("ecflow")
+    # An empty ecflow block (no suite) is invalid:
+    assert errors({"ecflow": {}})
+    # Optional properties only (no suite) is invalid:
+    assert errors({"ecflow": {"scheduler": "slurm"}})
+    assert errors({"ecflow": {"scheduler": "slurm", "vars": {"FOO": "bar"}}})
+    # An empty suite is valid (ecFlow itself accepts this):
+    assert not errors({"ecflow": {"suite_minimal": {}}})
+    # Suite alongside optional properties is valid:
+    assert not errors({"ecflow": {"suite_one": {}, "scheduler": "pbs", "vars": {"X": "y"}}})
+
+
+def test_schema_ecflow_scheduler():
+    errors = schema_validator("ecflow", "properties", "ecflow")
+    # Valid schedulers:
+    for sched in ("lsf", "pbs", "slurm"):
+        assert not errors({"suite_a": {}, "scheduler": sched})
+    # Unknown scheduler fails:
+    assert "'torque' is not one of" in errors({"suite_a": {}, "scheduler": "torque"})
+
+
+def test_schema_ecflow_extern():
+    errors = schema_validator("ecflow", "properties", "ecflow")
+    # extern is a list of strings:
+    assert not errors({"suite_a": {}, "extern": ["/other/suite/task"]})
+    # Non-string items fail:
+    assert "is not of type 'string'" in errors({"suite_a": {}, "extern": [123]})
+    # Must be a list (not a scalar):
+    assert "is not of type 'array'" in errors({"suite_a": {}, "extern": "/other/suite/task"})
+
+
+def test_schema_ecflow_refs_taskcontainer_script_incantation():
+    errors = schema_validator("ecflow", "$defs", "taskcontainer")
+    # incantation alongside executable is valid per schema:
+    assert not errors(
+        {"script": {"execution": {"executable": "run.exe", "incantation": "/path/to/run.sh"}}}
+    )
+    # incantation alone is invalid per schema (executable is required by execution-serial/parallel):
+    assert "is not valid under any of the given schemas" in errors(
+        {"script": {"execution": {"incantation": "/path/to/run.sh"}}}
+    )
+
+
 # enkf
 
 


### PR DESCRIPTION

**Synopsis**

Closes #877

## Problem ##

During review of issue #877, the team discussed whether `uw ecflow` validate should reject configs with no suites. After testing, the team agreed on a convention: accept what ecFlow accepts. Since `Defs.check()` accepts empty and suite-free definitions without complaint, the schema should not be stricter than ecFlow itself.

The gap identified in #877 is better addressed by running ecFlow's own correctness checker — analogous to how `uwtools` validates Rocoto XML against Rocoto's official schema — rather than adding JSON Schema constraints that may reject valid configs.

## Fix ##

Added a call to `self._d.check()` in `_ECFlowDef.__init__` after building the suite definition. If ecFlow reports any errors (e.g. unresolvable trigger expressions, limit violations), a `UWConfigError` is raised. This gives ecFlow's own client-side validation layer on top of the JSON Schema check.

No schema constraint was added — the `ecflow` block permits empty and suite-free configs consistent with what ecFlow itself accepts.

## Changes ##

- `ecflow.py`: Call `self._d.check()` after `_add_workflow_components()`; raise `UWConfigError` on non-empty output

- `test_ecflow.py`:
    - Reverted `minimal_config` to `{"ecflow": {}}`
    - Reverted `assets` fixture and `realize()` tests to use `{"ecflow": {}}` minimal config; `realize()` tests assert only `"# enddef" in output`
    - Removed `test_validate__empty_ecflow_fails` and `test_validate__properties_only_fails` - these behaviors are now permitted
    - Added `test__init__defs_check_bad_trigger`: verifies that a trigger referencing a nonexistent task raises `UWConfigError` via `Defs.check()`
- `test_schemas.py`:
    - Added `test_schema_ecflow_scheduler`: valid scheduler values pass; unknown values fail
    - Added `test_schema_ecflow_extern`: string list passes; non-string items and scalar values fail
    - Added `test_schema_ecflow_refs_taskcontainer_script_incantation`: `incantation` + `executable` valid; `incantation` alone fails, schema requires `executable`

**Type**

<!-- Select one or more -->

- [X] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [X] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [X] I have added myself and any co-authors to the PR's _Assignees_ list.
- [X] I have reviewed the documentation and have made any updates necessitated by this change.
