### PR TITLE
ecflow: fix expander schema composition and enforce unevaluatedProperties

### DIFF
--- a/docs/sections/user_guide/cli/tools/ecflow/ecflow-bad.yaml
+++ b/docs/sections/user_guide/cli/tools/ecflow/ecflow-bad.yaml
@@ -1,2 +1,0 @@
-not_ecflow:
-  suite_test: {}

--- a/docs/sections/user_guide/cli/tools/ecflow/ecflow-workflow.yaml
+++ b/docs/sections/user_guide/cli/tools/ecflow/ecflow-workflow.yaml
@@ -8,16 +8,13 @@ ecflow:
         script:
           execution:
             incantation: echo Fetching data...
-            executable: uw fs copy -c files.yaml
       task_process:
         trigger: /workflow/data_prep/fetch == complete
         script:
           execution:
             incantation: echo Processing data...
-            executable: prep.exe
     task_run_model:
       trigger: /workflow/data_prep == complete
       script:
         execution:
           incantation: echo Running model...
-          executable: model.exe

--- a/docs/sections/user_guide/cli/tools/ecflow/ecflow.yaml
+++ b/docs/sections/user_guide/cli/tools/ecflow/ecflow.yaml
@@ -5,13 +5,11 @@ ecflow:
         trigger: "1==1"
         script:
           execution:
-            executable: uw fs copy -c get_obs.yaml
             incantation: /path/to/get_obs.sh
           manual: Retrieve observation data
     task_run_model:
       trigger: /forecast/prep/get_obs == complete
       script:
         execution:
-          executable: model.exe
           incantation: /path/to/run_model.sh
         manual: Run the forecast model

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -342,22 +342,7 @@
       },
       "type": "object"
     },
-    "expander": {
-      "minProperties": 2,
-      "patternProperties": {
-        "^families_.+$": {
-          "$ref": "#/$defs/expander"
-        },
-        "^family_.+$": {
-          "$ref": "#/$defs/familycontainer"
-        },
-        "^task_.+$": {
-          "$ref": "#/$defs/taskcontainer"
-        },
-        "^tasks_.+$": {
-          "$ref": "#/$defs/expander"
-        }
-      },
+    "expand_block": {
       "properties": {
         "expand": {
           "additionalProperties": false,
@@ -372,12 +357,30 @@
       },
       "required": [
         "expand"
-      ],
-      "type": "object"
+      ]
     },
     "family": {
       "$ref": "#/$defs/familycontainer",
       "unevaluatedProperties": false
+    },
+    "family_expander": {
+      "$ref": "#/$defs/family_expander_base",
+      "unevaluatedProperties": false
+    },
+    "family_expander_base": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/addons"
+        },
+        {
+          "$ref": "#/$defs/nodecontainer"
+        },
+        {
+          "$ref": "#/$defs/expand_block"
+        }
+      ],
+      "minProperties": 2,
+      "type": "object"
     },
     "familycontainer": {
       "allOf": [
@@ -393,7 +396,7 @@
     "nodecontainer": {
       "patternProperties": {
         "^families_.+$": {
-          "$ref": "#/$defs/expander"
+          "$ref": "#/$defs/family_expander"
         },
         "^family_.+$": {
           "$ref": "#/$defs/familycontainer"
@@ -402,7 +405,7 @@
           "$ref": "#/$defs/taskcontainer"
         },
         "^tasks_.+$": {
-          "$ref": "#/$defs/expander"
+          "$ref": "#/$defs/task_expander"
         }
       },
       "type": "object"
@@ -410,6 +413,45 @@
     "task": {
       "$ref": "#/$defs/taskcontainer",
       "unevaluatedProperties": false
+    },
+    "task_expand_block": {
+      "properties": {
+        "expand": {
+          "additionalProperties": false,
+          "minProperties": 1,
+          "patternProperties": {
+            "^.+$": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "script": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "expand"
+      ]
+    },
+    "task_expander": {
+      "$ref": "#/$defs/task_expander_base",
+      "unevaluatedProperties": false
+    },
+    "task_expander_base": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/addons"
+        },
+        {
+          "$ref": "#/$defs/nodecontainer"
+        },
+        {
+          "$ref": "#/$defs/task_expand_block"
+        }
+      ],
+      "minProperties": 2,
+      "type": "object"
     },
     "taskcontainer": {
       "allOf": [
@@ -497,7 +539,7 @@
           ]
         },
         "^suites_.+$": {
-          "$ref": "#/$defs/expander"
+          "$ref": "#/$defs/family_expander"
         },
         "unevaluatedProperties": false
       },

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -342,7 +342,7 @@
       },
       "type": "object"
     },
-    "expand_block": {
+    "expander": {
       "properties": {
         "expand": {
           "additionalProperties": false,
@@ -364,22 +364,6 @@
       "$ref": "#/$defs/familycontainer",
       "unevaluatedProperties": false
     },
-    "family_expander": {
-      "allOf": [
-        {
-          "$ref": "#/$defs/addons"
-        },
-        {
-          "$ref": "#/$defs/nodecontainer"
-        },
-        {
-          "$ref": "#/$defs/expand_block"
-        }
-      ],
-      "minProperties": 2,
-      "type": "object",
-      "unevaluatedProperties": false
-    },
     "familycontainer": {
       "allOf": [
         {
@@ -394,7 +378,14 @@
     "nodecontainer": {
       "patternProperties": {
         "^families_.+$": {
-          "$ref": "#/$defs/family_expander"
+          "allOf": [
+            {
+              "$ref": "#/$defs/expander"
+            },
+            {
+              "$ref": "#/$defs/familycontainer"
+            }
+          ]
         },
         "^family_.+$": {
           "$ref": "#/$defs/familycontainer"
@@ -405,18 +396,12 @@
         "^tasks_.+$": {
           "allOf": [
             {
-              "$ref": "#/$defs/addons"
+              "$ref": "#/$defs/expander"
             },
             {
-              "$ref": "#/$defs/nodecontainer"
-            },
-            {
-              "$ref": "#/$defs/task_expand_block"
+              "$ref": "#/$defs/taskcontainer"
             }
-          ],
-          "minProperties": 2,
-          "type": "object",
-          "unevaluatedProperties": false
+          ]
         }
       },
       "type": "object"
@@ -424,27 +409,6 @@
     "task": {
       "$ref": "#/$defs/taskcontainer",
       "unevaluatedProperties": false
-    },
-    "task_expand_block": {
-      "properties": {
-        "expand": {
-          "additionalProperties": false,
-          "minProperties": 1,
-          "patternProperties": {
-            "^.+$": {
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "script": {
-          "type": "object"
-        }
-      },
-      "required": [
-        "expand"
-      ],
-      "type": "object"
     },
     "taskcontainer": {
       "allOf": [
@@ -532,7 +496,14 @@
           ]
         },
         "^suites_.+$": {
-          "$ref": "#/$defs/family_expander"
+          "allOf": [
+            {
+              "$ref": "#/$defs/expander"
+            },
+            {
+              "$ref": "#/$defs/familycontainer"
+            }
+          ]
         },
         "unevaluatedProperties": false
       },

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -365,10 +365,6 @@
       "unevaluatedProperties": false
     },
     "family_expander": {
-      "$ref": "#/$defs/family_expander_base",
-      "unevaluatedProperties": false
-    },
-    "family_expander_base": {
       "allOf": [
         {
           "$ref": "#/$defs/addons"
@@ -381,7 +377,8 @@
         }
       ],
       "minProperties": 2,
-      "type": "object"
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "familycontainer": {
       "allOf": [
@@ -437,10 +434,6 @@
       "type": "object"
     },
     "task_expander": {
-      "$ref": "#/$defs/task_expander_base",
-      "unevaluatedProperties": false
-    },
-    "task_expander_base": {
       "allOf": [
         {
           "$ref": "#/$defs/addons"
@@ -453,7 +446,8 @@
         }
       ],
       "minProperties": 2,
-      "type": "object"
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "taskcontainer": {
       "allOf": [

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -359,7 +359,16 @@
     },
     "family": {
       "$ref": "#/$defs/familycontainer",
-      "unevaluatedProperties": false
+      "propertyNames": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/addon_property_names"
+          },
+          {
+            "pattern": "^(families|family|task|tasks)_.+$"
+          }
+        ]
+      }
     },
     "familycontainer": {
       "allOf": [
@@ -383,15 +392,45 @@
               "$ref": "#/$defs/familycontainer"
             }
           ],
-          "unevaluatedProperties": false
+          "propertyNames": {
+            "anyOf": [
+              {
+                "const": "expand"
+              },
+              {
+                "$ref": "#/$defs/addon_property_names"
+              },
+              {
+                "pattern": "^(families|family|task|tasks)_.+$"
+              }
+            ]
+          }
         },
         "^family_.+$": {
           "$ref": "#/$defs/familycontainer",
-          "unevaluatedProperties": false
+          "propertyNames": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/addon_property_names"
+              },
+              {
+                "pattern": "^(families|family|task|tasks)_.+$"
+              }
+            ]
+          }
         },
         "^task_.+$": {
           "$ref": "#/$defs/taskcontainer",
-          "unevaluatedProperties": false
+          "propertyNames": {
+            "anyOf": [
+              {
+                "const": "script"
+              },
+              {
+                "$ref": "#/$defs/addon_property_names"
+              }
+            ]
+          }
         },
         "^tasks_.+$": {
           "allOf": [
@@ -402,14 +441,35 @@
               "$ref": "#/$defs/taskcontainer"
             }
           ],
-          "unevaluatedProperties": false
+          "propertyNames": {
+            "anyOf": [
+              {
+                "const": "expand"
+              },
+              {
+                "const": "script"
+              },
+              {
+                "$ref": "#/$defs/addon_property_names"
+              }
+            ]
+          }
         }
       },
       "type": "object"
     },
     "task": {
       "$ref": "#/$defs/taskcontainer",
-      "unevaluatedProperties": false
+      "propertyNames": {
+        "anyOf": [
+          {
+            "const": "script"
+          },
+          {
+            "$ref": "#/$defs/addon_property_names"
+          }
+        ]
+      }
     },
     "taskcontainer": {
       "allOf": [
@@ -480,6 +540,26 @@
           "type": "object"
         }
       ]
+    },
+    "addon_property_names": {
+      "enum": [
+        "defstatus",
+        "events",
+        "inlimits",
+        "labels",
+        "late",
+        "limits",
+        "meters",
+        "repeat_date",
+        "repeat_datelist",
+        "repeat_datetime",
+        "repeat_day",
+        "repeat_enumerated",
+        "repeat_int",
+        "repeat_string",
+        "trigger",
+        "vars"
+      ]
     }
   },
   "properties": {
@@ -495,7 +575,16 @@
               "$ref": "#/$defs/addons"
             }
           ],
-          "unevaluatedProperties": false
+          "propertyNames": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/addon_property_names"
+              },
+              {
+                "pattern": "^(families|family|task|tasks)_.+$"
+              }
+            ]
+          }
         },
         "^suites_.+$": {
           "allOf": [
@@ -506,7 +595,19 @@
               "$ref": "#/$defs/familycontainer"
             }
           ],
-          "unevaluatedProperties": false
+          "propertyNames": {
+            "anyOf": [
+              {
+                "const": "expand"
+              },
+              {
+                "$ref": "#/$defs/addon_property_names"
+              },
+              {
+                "pattern": "^(families|family|task|tasks)_.+$"
+              }
+            ]
+          }
         }
       },
       "properties": {

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -1,5 +1,25 @@
 {
   "$defs": {
+    "addon_property_names": {
+      "enum": [
+        "defstatus",
+        "events",
+        "inlimits",
+        "labels",
+        "late",
+        "limits",
+        "meters",
+        "repeat_date",
+        "repeat_datelist",
+        "repeat_datetime",
+        "repeat_day",
+        "repeat_enumerated",
+        "repeat_int",
+        "repeat_string",
+        "trigger",
+        "vars"
+      ]
+    },
     "addons": {
       "properties": {
         "defstatus": {
@@ -539,26 +559,6 @@
           ],
           "type": "object"
         }
-      ]
-    },
-    "addon_property_names": {
-      "enum": [
-        "defstatus",
-        "events",
-        "inlimits",
-        "labels",
-        "late",
-        "limits",
-        "meters",
-        "repeat_date",
-        "repeat_datelist",
-        "repeat_datetime",
-        "repeat_day",
-        "repeat_enumerated",
-        "repeat_int",
-        "repeat_string",
-        "trigger",
-        "vars"
       ]
     }
   },

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -403,7 +403,20 @@
           "$ref": "#/$defs/taskcontainer"
         },
         "^tasks_.+$": {
-          "$ref": "#/$defs/task_expander"
+          "allOf": [
+            {
+              "$ref": "#/$defs/addons"
+            },
+            {
+              "$ref": "#/$defs/nodecontainer"
+            },
+            {
+              "$ref": "#/$defs/task_expand_block"
+            }
+          ],
+          "minProperties": 2,
+          "type": "object",
+          "unevaluatedProperties": false
         }
       },
       "type": "object"
@@ -432,22 +445,6 @@
         "expand"
       ],
       "type": "object"
-    },
-    "task_expander": {
-      "allOf": [
-        {
-          "$ref": "#/$defs/addons"
-        },
-        {
-          "$ref": "#/$defs/nodecontainer"
-        },
-        {
-          "$ref": "#/$defs/task_expand_block"
-        }
-      ],
-      "minProperties": 2,
-      "type": "object",
-      "unevaluatedProperties": false
     },
     "taskcontainer": {
       "allOf": [

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -345,13 +345,10 @@
     "expander": {
       "properties": {
         "expand": {
-          "additionalProperties": false,
-          "minProperties": 1,
-          "patternProperties": {
-            "^.+$": {
-              "type": "array"
-            }
+          "additionalProperties": {
+            "type": "array"
           },
+          "minProperties": 1,
           "type": "object"
         }
       },
@@ -385,13 +382,16 @@
             {
               "$ref": "#/$defs/familycontainer"
             }
-          ]
+          ],
+          "unevaluatedProperties": false
         },
         "^family_.+$": {
-          "$ref": "#/$defs/familycontainer"
+          "$ref": "#/$defs/familycontainer",
+          "unevaluatedProperties": false
         },
         "^task_.+$": {
-          "$ref": "#/$defs/taskcontainer"
+          "$ref": "#/$defs/taskcontainer",
+          "unevaluatedProperties": false
         },
         "^tasks_.+$": {
           "allOf": [
@@ -401,7 +401,8 @@
             {
               "$ref": "#/$defs/taskcontainer"
             }
-          ]
+          ],
+          "unevaluatedProperties": false
         }
       },
       "type": "object"
@@ -493,7 +494,8 @@
             {
               "$ref": "#/$defs/addons"
             }
-          ]
+          ],
+          "unevaluatedProperties": false
         },
         "^suites_.+$": {
           "allOf": [
@@ -503,9 +505,9 @@
             {
               "$ref": "#/$defs/familycontainer"
             }
-          ]
-        },
-        "unevaluatedProperties": false
+          ],
+          "unevaluatedProperties": false
+        }
       },
       "properties": {
         "extern": {

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -357,7 +357,8 @@
       },
       "required": [
         "expand"
-      ]
+      ],
+      "type": "object"
     },
     "family": {
       "$ref": "#/$defs/familycontainer",
@@ -432,7 +433,8 @@
       },
       "required": [
         "expand"
-      ]
+      ],
+      "type": "object"
     },
     "task_expander": {
       "$ref": "#/$defs/task_expander_base",

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -661,7 +661,7 @@ class TestECFlowDef:
                     "tasks_member_{{ ec.MEM }}": {
                         "expand": {"MEM": ["01", "02", "03"]},
                         "script": {
-                            "execution": {"executable": "hello.exe", "incantation": "hello"}
+                            "execution": {"incantation": "hello.exe"}
                         },
                     }
                 }

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -660,7 +660,9 @@ class TestECFlowDef:
                 "suite_ensemble": {
                     "tasks_member_{{ ec.MEM }}": {
                         "expand": {"MEM": ["01", "02", "03"]},
-                        "script": {"execution": {"incantation": "hello"}},
+                        "script": {
+                            "execution": {"executable": "hello.exe", "incantation": "hello"}
+                        },
                     }
                 }
             }

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -660,9 +660,7 @@ class TestECFlowDef:
                 "suite_ensemble": {
                     "tasks_member_{{ ec.MEM }}": {
                         "expand": {"MEM": ["01", "02", "03"]},
-                        "script": {
-                            "execution": {"incantation": "hello.exe"}
-                        },
+                        "script": {"execution": {"incantation": "hello.exe"}},
                     }
                 }
             }

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -682,7 +682,7 @@ def test_schema_ecflow():
                 "task_two": {"script": {"execution": {"incantation": "/path/to/run.sh"}}},
                 "families_two": {
                     "expand": {
-                        "myvar": ["foo", "bar"],
+                        "MEM": ["00", "06"],
                     },
                     "family_three": {},
                 },
@@ -698,11 +698,9 @@ def test_schema_ecflow_nested_family():
     config = {
         "ecflow": {
             "suites_a": {
-                "family_a": {
-                    "families_a{{ ec.var }}": {"family_b": {}, "expand": {"myvar": [1, 2]}}
-                },
+                "family_a": {"families_a{{ ec.var }}": {"family_b": {}, "expand": {"MEM": [1, 2]}}},
                 "expand": {
-                    "avar": ["foo", "bar"],
+                    "MEMBER": ["00", "06"],
                 },
             }
         }
@@ -718,30 +716,34 @@ def test_schema_ecflow_refs_addons_defstatus():
     errors = schema_validator("ecflow", "$defs", "addons")
     # Basic spec:
     assert not errors({"defstatus": "suspended"})
-    assert "'foo' is not one of" in errors({"defstatus": "foo"})
+    assert "'halted' is not one of" in errors({"defstatus": "halted"})
 
 
 def test_schema_ecflow_refs_addons_events():
     errors = schema_validator("ecflow", "$defs", "addons")
     # Basic spec:
-    assert not errors({"events": [[1, "foo"]]})
-    assert not errors({"events": [1, "foo"]})
+    assert not errors({"events": [[1, "sim_complete"]]})
+    assert not errors({"events": [1, "sim_complete"]})
     assert not errors({"events": [1, 2, 3]})
-    assert not errors({"events": ["foo", "bar", "baz"]})
+    assert not errors({"events": ["sim_complete", "post_done", "arch_done"]})
     # Must be one of the specified patterns:
-    assert "is not valid under any of the given schemas" in errors({"events": [["foo", 2]]})
+    assert "is not valid under any of the given schemas" in errors(
+        {"events": [["sim_complete", 2]]}
+    )
 
 
 def test_schema_ecflow_refs_addons_inlimits():
     errors = schema_validator("ecflow", "$defs", "addons")
     # Supports one of four categories:
-    assert not errors({"inlimits": [["foo"]]})
-    assert not errors({"inlimits": [["foo", "bar"]]})
-    assert not errors({"inlimits": [["foo", "bar", 2], ["baz", "qux"]]})
-    assert not errors({"inlimits": [["foo", "bar", 2, True]]})
+    assert not errors({"inlimits": [["max_members"]]})
+    assert not errors({"inlimits": [["max_members", "/suite/limit"]]})
+    assert not errors(
+        {"inlimits": [["max_members", "/suite/limit", 10], ["max_procs", "/other/limit"]]}
+    )
+    assert not errors({"inlimits": [["max_members", "/suite/limit", 10, True]]})
     # Exactly one is required:
-    assert "['foo', 2] is not valid under any of the given schemas" in errors(
-        {"inlimits": [["foo", 2]]}
+    assert "['max_members', 2] is not valid under any of the given schemas" in errors(
+        {"inlimits": [["max_members", 2]]}
     )
     assert "{} is not of type 'array'" in errors({"inlimits": {}})
     assert "[] should be non-empty" in errors({"inlimits": []})
@@ -750,10 +752,10 @@ def test_schema_ecflow_refs_addons_inlimits():
 def test_schema_ecflow_refs_addons_labels():
     errors = schema_validator("ecflow", "$defs", "addons")
     # Allows for a list of 2-lists:
-    assert not errors({"labels": [["foo", "bar"], ["baz", "qux"]]})
+    assert not errors({"labels": [["info", "running"], ["progress", "75%"]]})
     # List must contain 2-item lists:
-    assert "'foo' is not of type 'array'" in errors({"labels": ["foo", "bar"]})
-    assert "['foo'] is too short" in errors({"labels": [["foo"]]})
+    assert "'info' is not of type 'array'" in errors({"labels": ["info", "running"]})
+    assert "['info'] is too short" in errors({"labels": [["info"]]})
     assert "[] should be non-empty" in errors({"labels": []})
 
 
@@ -766,18 +768,20 @@ def test_schema_ecflow_refs_addons_late():
 def test_schema_ecflow_refs_addons_limits():
     errors = schema_validator("ecflow", "$defs", "addons")
     # Basic spec:
-    assert not errors({"limits": [["foo", 1], ["bar", 2]]})
+    assert not errors({"limits": [["max_tasks", 10], ["max_procs", 8]]})
     # It's a list of lists:
-    assert "'foo' is not of type 'array'" in errors({"limits": ["foo"]})
+    assert "'max_tasks' is not of type 'array'" in errors({"limits": ["max_tasks"]})
     assert "[] should be non-empty" in errors({"limits": []})
 
 
 def test_schema_ecflow_refs_addons_meters():
     errors = schema_validator("ecflow", "$defs", "addons")
     # Basic spec:
-    assert not errors({"meters": [["foo", 1, 2], ["bar", 2, 8]]})
+    assert not errors({"meters": [["progress", 0, 100], ["step", 0, 10]]})
     # It's a list of lists:
-    assert "'foo' is not valid under any of the given schemas" in errors({"meters": ["foo"]})
+    assert "'progress' is not valid under any of the given schemas" in errors(
+        {"meters": ["progress"]}
+    )
     assert "[] should be non-empty" in errors({"meters": []})
 
 
@@ -785,7 +789,7 @@ def test_schema_ecflow_refs_addons_meters():
 def test_schema_ecflow_refs_addons_repeat_ints(top_level):
     errors = schema_validator("ecflow", "$defs", "addons")
     # Basic spec:
-    config = {"variable": "foo", "start": 20260101, "end": 20260102}
+    config = {"variable": "MEMBER", "start": 20260101, "end": 20260102}
     assert not errors({top_level: config})
     with_step = {**config, "step": 2}
     assert not errors({top_level: with_step})
@@ -793,7 +797,9 @@ def test_schema_ecflow_refs_addons_repeat_ints(top_level):
     for key in ("end", "start", "variable"):
         assert f"'{key}' is a required property" in errors({top_level: with_del(config, key)})
     # Additional top-level keys are not allowed:
-    assert "Additional properties are not allowed" in errors({top_level: {**config, "foo": "bar"}})
+    assert "Additional properties are not allowed" in errors(
+        {top_level: {**config, "bad_key": "bad_value"}}
+    )
 
 
 @mark.parametrize("top_level", ["repeat_datelist", "repeat_enumerated", "repeat_string"])
@@ -801,19 +807,21 @@ def test_schema_ecflow_refs_addons_repeat_lists(top_level):
     errors = schema_validator("ecflow", "$defs", "addons")
     type_ = int if top_level == "repeat_datelist" else str
     # Basic spec:
-    config = {"variable": "foo", "list": [type_(i) for i in (20270104, 20270204)]}
+    config = {"variable": "CYCLE", "list": [type_(i) for i in (20270104, 20270204)]}
     assert not errors({top_level: config})
     # All top-level keys are required:
     for key in ("variable", "list"):
         assert f"'{key}' is a required property" in errors({top_level: with_del(config, key)})
     # Additional top-level keys are not allowed:
-    assert "Additional properties are not allowed" in errors({top_level: {**config, "foo": "bar"}})
+    assert "Additional properties are not allowed" in errors(
+        {top_level: {**config, "bad_key": "bad_value"}}
+    )
 
 
 def test_schema_ecflow_refs_addons_repeat_datetime():
     errors = schema_validator("ecflow", "$defs", "addons")
     # Basic spec:
-    config = {"variable": "foo", "start": "20260101T120000", "end": "20260102T123000"}
+    config = {"variable": "CYCLE", "start": "20260101T120000", "end": "20260102T123000"}
     assert not errors({"repeat_datetime": config})
     with_step = {**config, "step": "02:00:00"}
     assert not errors({"repeat_datetime": with_step})
@@ -824,7 +832,7 @@ def test_schema_ecflow_refs_addons_repeat_datetime():
         )
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors(
-        {"repeat_datetime": {**config, "foo": "bar"}}
+        {"repeat_datetime": {**config, "bad_key": "bad_value"}}
     )
 
 
@@ -836,7 +844,7 @@ def test_schema_ecflow_refs_addons_repeat_day():
     # step is a required top-level key:
     assert "'step' is a required property" in errors({"repeat_day": with_del(config, "step")})
     assert "Additional properties are not allowed" in errors(
-        {"repeat_day": {**config, "foo": "bar"}}
+        {"repeat_day": {**config, "bad_key": "bad_value"}}
     )
 
 
@@ -852,6 +860,8 @@ def test_schema_ecflow_refs_families_expander():
     # expand requires at least one variable/list pair:
     assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
     assert "{} should be non-empty" in errors({**config, "expand": {}})
+    # Extra properties are not allowed:
+    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
 
@@ -869,14 +879,40 @@ def test_schema_ecflow_refs_task_expander():
     # expand requires at least one variable/list pair:
     assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
     assert "{} should be non-empty" in errors({**config, "expand": {}})
+    # Extra properties are not allowed:
+    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
+
+
+def test_schema_ecflow_refs_nodecontainer_family():
+    errors = schema_validator(
+        "ecflow", "$defs", "nodecontainer", "patternProperties", "^family_.+$"
+    )
+    # Basic spec:
+    config = {"task_one": {"script": {"execution": {"executable": "run.exe"}}}}
+    assert not errors(config)
+    # Extra properties are not allowed:
+    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
+    # addon properties are valid siblings:
+    assert not errors({**config, "defstatus": "suspended"})
+
+
+def test_schema_ecflow_refs_nodecontainer_task():
+    errors = schema_validator("ecflow", "$defs", "nodecontainer", "patternProperties", "^task_.+$")
+    # Basic spec:
+    config = {"script": {"execution": {"executable": "run.exe"}}}
+    assert not errors(config)
+    # Extra properties are not allowed:
+    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
+    # addon properties are valid siblings:
+    assert not errors({**config, "defstatus": "suspended"})
 
 
 def test_schema_ecflow_refs_family():
     errors = schema_validator("ecflow", "$defs", "family")
     # Basic spec:
-    config = {"family_one": {}, "vars": {"foo": 1, "bar": 2}}
+    config = {"family_one": {}, "vars": {"MEMBER": "00", "LEAD": "006"}}
     assert not errors(config)
     assert "Unevaluated properties are not allowed" in errors({**config, "extra": 2})
 
@@ -884,7 +920,7 @@ def test_schema_ecflow_refs_family():
 def test_schema_ecflow_refs_familycontainer():
     errors = schema_validator("ecflow", "$defs", "familycontainer")
     # Basic spec:
-    config = {"family_one": {}, "vars": {"foo": 1, "bar": 2}}
+    config = {"family_one": {}, "vars": {"MEMBER": "00", "LEAD": "006"}}
     assert not errors(config)
     # Note: expected to allow additional properties since it's used to compose higher-level refs.
 
@@ -892,7 +928,7 @@ def test_schema_ecflow_refs_familycontainer():
 def test_schema_ecflow_refs_nodecontainer():
     errors = schema_validator("ecflow", "$defs", "nodecontainer")
     # Basic spec:
-    config = {"family_one": {}, "vars": {"foo": 1, "bar": 2}}
+    config = {"family_one": {}, "vars": {"MEMBER": "00", "LEAD": "006"}}
     assert not errors(config)
     # Note: expected to allow additional properties since it's used to compose higher-level refs.
 
@@ -900,7 +936,10 @@ def test_schema_ecflow_refs_nodecontainer():
 def test_schema_ecflow_refs_task():
     errors = schema_validator("ecflow", "$defs", "task")
     # Basic spec:
-    config = {"script": {"execution": {"incantation": "/path/to/run.sh"}}, "vars": {"key": 1}}
+    config = {
+        "script": {"execution": {"executable": "echo hi"}},
+        "vars": {"MEMBER": "00", "LEAD": "006"},
+    }
     assert not errors(config)
     assert "'script' is a required property" in errors({"defstatus": "complete"})
     assert "Unevaluated properties are not allowed" in errors({**config, "extra": 2})
@@ -909,7 +948,10 @@ def test_schema_ecflow_refs_task():
 def test_schema_ecflow_refs_taskcontainer():
     errors = schema_validator("ecflow", "$defs", "taskcontainer")
     # Basic spec:
-    config = {"script": {"execution": {"incantation": "/path/to/run.sh"}}, "vars": {"key": 1}}
+    config = {
+        "script": {"execution": {"executable": "echo hi"}},
+        "vars": {"MEMBER": "00", "LEAD": "006"},
+    }
     assert not errors(config)
     # Note: expected to allow additional properties since it's used to compose higher-level refs.
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -861,7 +861,9 @@ def test_schema_ecflow_refs_families_expander():
     assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
     assert "{} should be non-empty" in errors({**config, "expand": {}})
     # Extra properties are not allowed:
-    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
+    assert "is not valid under any of the given schemas" in errors(
+        {**config, "bad_key": "bad_value"}
+    )
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
 
@@ -880,7 +882,7 @@ def test_schema_ecflow_refs_task_expander():
     assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
     assert "{} should be non-empty" in errors({**config, "expand": {}})
     # Extra properties are not allowed:
-    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
+    assert "is not valid under any of the given schemas" in errors({**config, "bad_key": "bad_value"})
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
 
@@ -893,7 +895,9 @@ def test_schema_ecflow_refs_nodecontainer_family():
     config = {"task_one": {"script": {"execution": {"incantation": "/path/to/run.sh"}}}}
     assert not errors(config)
     # Extra properties are not allowed:
-    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
+    assert "is not valid under any of the given schemas" in errors(
+        {**config, "bad_key": "bad_value"}
+    )
     # addon properties are valid siblings:
     assert not errors({**config, "defstatus": "suspended"})
 
@@ -904,7 +908,7 @@ def test_schema_ecflow_refs_nodecontainer_task():
     config = {"script": {"execution": {"incantation": "/path/to/run.sh"}}}
     assert not errors(config)
     # Extra properties are not allowed:
-    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
+    assert "is not valid under any of the given schemas" in errors({**config, "bad_key": "bad_value"})
     # addon properties are valid siblings:
     assert not errors({**config, "defstatus": "suspended"})
 
@@ -914,7 +918,7 @@ def test_schema_ecflow_refs_family():
     # Basic spec:
     config = {"family_one": {}, "vars": {"MEMBER": "00", "LEAD": "006"}}
     assert not errors(config)
-    assert "Unevaluated properties are not allowed" in errors({**config, "extra": 2})
+    assert "is not valid under any of the given schemas" in errors({**config, "extra": 2})
 
 
 def test_schema_ecflow_refs_familycontainer():
@@ -942,7 +946,7 @@ def test_schema_ecflow_refs_task():
     }
     assert not errors(config)
     assert "'script' is a required property" in errors({"defstatus": "complete"})
-    assert "Unevaluated properties are not allowed" in errors({**config, "extra": 2})
+    assert "is not valid under any of the given schemas" in errors({**config, "extra": 2})
 
 
 def test_schema_ecflow_refs_taskcontainer():

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -864,7 +864,7 @@ def test_schema_ecflow_refs_family_expander():
 
 
 def test_schema_ecflow_refs_task_expander():
-    errors = schema_validator("ecflow", "$defs", "task_expander")
+    errors = schema_validator("ecflow", "$defs", "nodecontainer", "patternProperties", "^tasks_.+$")
     # Basic spec (script content is not validated here; that is issue #893):
     config = {
         "expand": {"MEM": ["01", "02"]},

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -843,19 +843,43 @@ def test_schema_ecflow_refs_addons_repeat_day():
     )
 
 
-def test_schema_ecflow_refs_expander():
-    errors = schema_validator("ecflow", "$defs", "expander")
+def test_schema_ecflow_refs_family_expander():
+    errors = schema_validator("ecflow", "$defs", "family_expander")
     # Basic spec:
-    config = {"expand": {"foo": [1, 2]}, "family_one": {}}
+    config = {"expand": {"MEM": ["01", "02"]}, "family_member": {}}
     assert not errors(config)
-    # Note: expected to allow additional properties since it's used to compose higher-level refs.
     # expand is a required top-level key:
     assert "'expand' is a required property" in errors(with_del(config, "expand"))
-    # expand requires at least one variable/list pair
-    config.update({"expand": {"foo": 2}})  # type: ignore [dict-item]
-    assert "2 is not of type 'array'" in errors(config)
-    config.update({"expand": {}})
-    assert "{} should be non-empty" in errors(config)
+    # expand requires at least one variable/list pair:
+    assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
+    assert "{} should be non-empty" in errors({**config, "expand": {}})
+    # Arbitrary sibling properties are not allowed:
+    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_val"})
+    # script is not valid for a family expander:
+    assert "Unevaluated properties are not allowed" in errors(
+        {**config, "script": {"execution": {"incantation": "echo hi"}}}
+    )
+    # addon properties (e.g., trigger) are valid siblings:
+    assert not errors({**config, "trigger": "task_setup == complete"})
+
+
+def test_schema_ecflow_refs_task_expander():
+    errors = schema_validator("ecflow", "$defs", "task_expander")
+    # Basic spec (script content is not validated here; that is issue #893):
+    config = {
+        "expand": {"MEM": ["01", "02"]},
+        "script": {"execution": {"incantation": "echo hi"}},
+    }
+    assert not errors(config)
+    # expand is a required top-level key:
+    assert "'expand' is a required property" in errors(with_del(config, "expand"))
+    # expand requires at least one variable/list pair:
+    assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
+    assert "{} should be non-empty" in errors({**config, "expand": {}})
+    # Arbitrary sibling properties are not allowed:
+    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_val"})
+    # addon properties (e.g., trigger) are valid siblings:
+    assert not errors({**config, "trigger": "task_setup == complete"})
 
 
 def test_schema_ecflow_refs_family():

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -708,12 +708,9 @@ def test_schema_ecflow_nested_family():
         }
     }
     assert not errors(config)
-    # Ensure that the required "expand" and node entries are present:
-    assert "does not have enough properties" in errors(
+    # Ensure that the required "expand" key is present:
+    assert "'expand' is a required property" in errors(
         with_del(config, "ecflow", "suites_a", "expand")
-    )
-    assert "does not have enough properties" in errors(
-        with_del(config, "ecflow", "suites_a", "family_a")
     )
 
 
@@ -843,8 +840,10 @@ def test_schema_ecflow_refs_addons_repeat_day():
     )
 
 
-def test_schema_ecflow_refs_family_expander():
-    errors = schema_validator("ecflow", "$defs", "family_expander")
+def test_schema_ecflow_refs_families_expander():
+    errors = schema_validator(
+        "ecflow", "$defs", "nodecontainer", "patternProperties", "^families_.+$"
+    )
     # Basic spec:
     config = {"expand": {"MEM": ["01", "02"]}, "family_member": {}}
     assert not errors(config)
@@ -853,22 +852,16 @@ def test_schema_ecflow_refs_family_expander():
     # expand requires at least one variable/list pair:
     assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
     assert "{} should be non-empty" in errors({**config, "expand": {}})
-    # Arbitrary sibling properties are not allowed:
-    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_val"})
-    # script is not valid for a family expander:
-    assert "Unevaluated properties are not allowed" in errors(
-        {**config, "script": {"execution": {"incantation": "echo hi"}}}
-    )
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
 
 
 def test_schema_ecflow_refs_task_expander():
     errors = schema_validator("ecflow", "$defs", "nodecontainer", "patternProperties", "^tasks_.+$")
-    # Basic spec (script content is not validated here; that is issue #893):
+    # Basic spec:
     config = {
         "expand": {"MEM": ["01", "02"]},
-        "script": {"execution": {"incantation": "echo hi"}},
+        "script": {"execution": {"executable": "forecast.exe"}},
     }
     assert not errors(config)
     # expand is a required top-level key:
@@ -876,8 +869,6 @@ def test_schema_ecflow_refs_task_expander():
     # expand requires at least one variable/list pair:
     assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
     assert "{} should be non-empty" in errors({**config, "expand": {}})
-    # Arbitrary sibling properties are not allowed:
-    assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_val"})
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -882,7 +882,9 @@ def test_schema_ecflow_refs_task_expander():
     assert "'01' is not of type 'array'" in errors({**config, "expand": {"MEM": "01"}})
     assert "{} should be non-empty" in errors({**config, "expand": {}})
     # Extra properties are not allowed:
-    assert "is not valid under any of the given schemas" in errors({**config, "bad_key": "bad_value"})
+    assert "is not valid under any of the given schemas" in errors(
+        {**config, "bad_key": "bad_value"}
+    )
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
 
@@ -908,7 +910,9 @@ def test_schema_ecflow_refs_nodecontainer_task():
     config = {"script": {"execution": {"incantation": "/path/to/run.sh"}}}
     assert not errors(config)
     # Extra properties are not allowed:
-    assert "is not valid under any of the given schemas" in errors({**config, "bad_key": "bad_value"})
+    assert "is not valid under any of the given schemas" in errors(
+        {**config, "bad_key": "bad_value"}
+    )
     # addon properties are valid siblings:
     assert not errors({**config, "defstatus": "suspended"})
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -871,7 +871,7 @@ def test_schema_ecflow_refs_task_expander():
     # Basic spec:
     config = {
         "expand": {"MEM": ["01", "02"]},
-        "script": {"execution": {"executable": "forecast.exe"}},
+        "script": {"execution": {"incantation": "/path/to/run.sh"}},
     }
     assert not errors(config)
     # expand is a required top-level key:
@@ -890,7 +890,7 @@ def test_schema_ecflow_refs_nodecontainer_family():
         "ecflow", "$defs", "nodecontainer", "patternProperties", "^family_.+$"
     )
     # Basic spec:
-    config = {"task_one": {"script": {"execution": {"executable": "run.exe"}}}}
+    config = {"task_one": {"script": {"execution": {"incantation": "/path/to/run.sh"}}}}
     assert not errors(config)
     # Extra properties are not allowed:
     assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
@@ -901,7 +901,7 @@ def test_schema_ecflow_refs_nodecontainer_family():
 def test_schema_ecflow_refs_nodecontainer_task():
     errors = schema_validator("ecflow", "$defs", "nodecontainer", "patternProperties", "^task_.+$")
     # Basic spec:
-    config = {"script": {"execution": {"executable": "run.exe"}}}
+    config = {"script": {"execution": {"incantation": "/path/to/run.sh"}}}
     assert not errors(config)
     # Extra properties are not allowed:
     assert "Unevaluated properties are not allowed" in errors({**config, "bad_key": "bad_value"})
@@ -937,7 +937,7 @@ def test_schema_ecflow_refs_task():
     errors = schema_validator("ecflow", "$defs", "task")
     # Basic spec:
     config = {
-        "script": {"execution": {"executable": "echo hi"}},
+        "script": {"execution": {"incantation": "/path/to/run.sh"}},
         "vars": {"MEMBER": "00", "LEAD": "006"},
     }
     assert not errors(config)
@@ -949,7 +949,7 @@ def test_schema_ecflow_refs_taskcontainer():
     errors = schema_validator("ecflow", "$defs", "taskcontainer")
     # Basic spec:
     config = {
-        "script": {"execution": {"executable": "echo hi"}},
+        "script": {"execution": {"incantation": "/path/to/run.sh"}},
         "vars": {"MEMBER": "00", "LEAD": "006"},
     }
     assert not errors(config)


### PR DESCRIPTION

**Synopsis**

Fixes #897. The single `expander` `$def` in `ecflow.jsonschema` did not restrict which properties could appear as siblings of the `expand` key, allowing arbitrary keys to pass `uw ecflow validate` without error. It also could not distinguish between family expanders (where `script` is invalid) and task expanders (where script is a required sibling).

This PR addresses both issues by:

-Keeping a single `expander` def (which validates only the expand key and its value)
-Using `allOf` composition at each `patternProperties` usage site to pair `expander` with the appropriate container type, `familycontainer` for `families_*` keys, `taskcontainer` for `tasks_*` keys, so that `script` is required for task expanders and rejected for family expanders
-Adding `unevaluatedProperties: false` at each usage site (all four patterns in `nodecontainer` and the two top-level suite patterns) so that unknown properties are rejected across all node levels
-Simplifying the `expand` inner schema to use `additionalProperties: {"type": "array"}` instead of `patternProperties`
-Removing a pre-existing bug where `"unevaluatedProperties": false` appeared as a literal key inside `patternProperties` at the ecflow level, where it was treated as a regex pattern rather than a schema keyword

Tests are updated to cover valid and invalid sibling properties at each node level.

Note: `script` content within task expanders is not validated by this change, which is tracked separately in #893.

**Type**

<!-- Select one or more -->

- [X] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [X] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [X] I have added myself and any co-authors to the PR's _Assignees_ list.
- [X] I have reviewed the documentation and have made any updates necessitated by this change.
- [X] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
