### PR TITLE
ecflow: add test coverage for script/execution validation in task exp…

### DIFF
--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -887,6 +887,16 @@ def test_schema_ecflow_refs_task_expander():
     )
     # addon properties (e.g., trigger) are valid siblings:
     assert not errors({**config, "trigger": "task_setup == complete"})
+    # script is required (taskcontainer is applied within tasks_* expanders):
+    assert "'script' is a required property" in errors(with_del(config, "script"))
+    # script.execution content is validated — incantation is required:
+    assert "'incantation' is a required property" in errors(
+        with_set(config, {}, "script", "execution")
+    )
+    # script.execution rejects unknown keys (e.g., executable has no effect in ecflow):
+    assert "Additional properties are not allowed" in errors(
+        with_set(config, "run.exe", "script", "execution", "executable")
+    )
 
 
 def test_schema_ecflow_refs_nodecontainer_family():


### PR DESCRIPTION

**Synopsis**

Closes #893.

Issue #893 reported that the `expander` schema did not validate `script`/`execution` content for `tasks_*` keys. Invalid or incomplete execution configs could pass `uw ecflow validate` without error.

This was resolved in combination by:

1. PR #901, which rewrote the `tasks_*` pattern in `nodecontainer` to use `allOf: [expander, taskcontainer]`. PR #901 noted that script content within task expanders was not yet validated and tracked that separately as #893.

2. PR #902, which replaced the shared `execution-serial`/`execution-parallel` schema with an ecflow-specific execution schema requiring `incantation` and enforcing `additionalProperties: false`.

Together, these two changes fully close #893. 

This PR adds explicit test assertions to `test_schema_ecflow_refs_task_expander` to verify and document that behavior:
- `script` is required as a sibling of `expand` in `tasks_*` expanders
- `incantation` is required inside `script.execution`
- Unknown keys (e.g., `executable`, which has no effect in ecFlow) are rejected inside `script.execution`

No schema or documentation changes are needed.

**Type**

<!-- Select one or more -->

- [X] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [X] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [X] I have added myself and any co-authors to the PR's _Assignees_ list.
- [X] I have reviewed the documentation and have made any updates necessitated by this change.
- [X] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
