### PR TITLE
Emit YAML without synthetic anchors/aliases

### DIFF
--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -9,7 +9,6 @@ from yaml.constructor import ConstructorError
 from uwtools.config.formats.base import Config
 from uwtools.config.support import (
     INCLUDE_TAG,
-    add_yaml_representers,
     dict_to_yaml_str,
     log_and_error,
     uw_yaml_loader,
@@ -73,7 +72,6 @@ class YAMLConfig(Config):
 
         :param cfg: The in-memory config object.
         """
-        add_yaml_representers()
         return dict_to_yaml_str(cfg)
 
     @staticmethod

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -8,7 +8,7 @@ import os
 from datetime import datetime, timedelta
 from functools import cached_property
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, Undefined, meta
@@ -293,18 +293,14 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :return: The rendered value (potentially unchanged).
     """
 
-    # Update context, converting tagged values to their final representations when possible.
-    # UWYAMLConvert values that cannot yet be converted (because their inner template hasn't been
-    # rendered yet) are replaced with Pending sentinels. When Jinja2 serializes a template
-    # result containing such a sentinel (e.g. via __repr__), UndefinedError is raised, causing the
-    # template render to fail gracefully and the original value to be returned unchanged (held for a
-    # later iteration with a better context). This ensures that:
-    #   - Sibling keys in the same dict remain accessible to other templates.
-    #   - Templates that depend on not-yet-available values are held rather than converting with
-    #     partial/incorrect data.
+    # Update context, converting tagged values to their final representations when possible. Values
+    # that cannot yet be converted because they contain unrendered content are replaced with Pending
+    # sentinels. When Jinja2 serializes a template containing such a sentinel, an UndefinedError is
+    # raised, causing the template render to fail gracefully and the original value to be returned
+    # unchanged (held for a later iteration with a better context).
 
     class Pending:
-        def __repr__(self) -> str:
+        def __repr__(self) -> NoReturn:
             msg = "Value is not yet resolvable"
             raise UndefinedError(msg)
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -301,8 +301,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
 
     class Pending:
         def __repr__(self) -> NoReturn:
-            msg = "Value is not yet resolvable"
-            raise UndefinedError(msg)
+            raise UndefinedError
 
     nil = object()
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -317,7 +317,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     def resolve(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
             try:
-                return v.converted  # raises if not yet convertible
+                return v.converted
             except Exception:  # noqa: BLE001
                 return nil
         if isinstance(v, dict):

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -280,42 +280,6 @@ def _deref_convert(val: UWYAMLConvert) -> _ConfigVal:
     return converted
 
 
-def _update_context(context: dict, local: dict | None = None) -> dict:
-    """
-    Update context, converting tagged values to their final representations when possible.
-
-    Values that cannot yet be converted because they contain unrendered content are replaced with
-    Pending sentinels. When Jinja2 serializes a template containing such a sentinel, UndefinedError
-    # is raised; then the template render fails gracefully and the original value is returned #
-    unchanged (held for a later iteration with a better context).
-
-    :param context: Values to use when rendering Jinja2 syntax.
-    :param local: Local sibling values to use if a match is not found in context.
-    :return: The updated context.
-    """
-
-    class Pending:
-        def __repr__(self) -> NoReturn:
-            raise UndefinedError
-
-    nil = object()
-
-    def resolve(v: Any) -> Any:
-        if isinstance(v, UWYAMLConvert):
-            try:
-                return v.converted
-            except Exception:  # noqa: BLE001
-                return nil
-        if isinstance(v, dict):
-            return {k: Pending() if (r := resolve(x)) is nil else r for k, x in v.items()}
-        if isinstance(v, list):
-            return [resolve(x) for x in v]
-        return v
-
-    kvpairs = {**(local or {}), **context}.items()
-    return {k: r for k, v in kvpairs if (r := resolve(v)) is not nil}
-
-
 def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     """
     Render a Jinja2 variable/expression as part of dereferencing.
@@ -438,6 +402,42 @@ def _supplement_values(
         values.update(os.environ)
         log.debug("Supplemented template values with environment variables")
     return values
+
+
+def _update_context(context: dict, local: dict | None = None) -> dict:
+    """
+    Update context, converting tagged values to their final representations when possible.
+
+    Values that cannot yet be converted because they contain unrendered content are replaced with
+    Pending sentinels. When Jinja2 serializes a template containing such a sentinel, UndefinedError
+    # is raised; then the template render fails gracefully and the original value is returned #
+    unchanged (held for a later iteration with a better context).
+
+    :param context: Values to use when rendering Jinja2 syntax.
+    :param local: Local sibling values to use if a match is not found in context.
+    :return: The updated context.
+    """
+
+    class Pending:
+        def __repr__(self) -> NoReturn:
+            raise UndefinedError
+
+    nil = object()
+
+    def resolve(v: Any) -> Any:
+        if isinstance(v, UWYAMLConvert):
+            try:
+                return v.converted
+            except Exception:  # noqa: BLE001
+                return nil
+        if isinstance(v, dict):
+            return {k: Pending() if (r := resolve(x)) is nil else r for k, x in v.items()}
+        if isinstance(v, list):
+            return [resolve(x) for x in v]
+        return v
+
+    kvpairs = {**(local or {}), **context}.items()
+    return {k: r for k, v in kvpairs if (r := resolve(v)) is not nil}
 
 
 def _values_needed(undeclared_variables: set[str]) -> None:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -295,8 +295,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
 
     # Update context, converting tagged values to their final representations when possible, but
     # otherwise replacing them with a Jinja2 Undefined so that any template expression referencing
-    # them (directly or via a nested dict/list) raises UndefinedError and causes _deref_render to
-    # return the original value unchanged.
+    # them raises UndefinedError and leads to the original value being returned unchanged.
 
     def resolve(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
@@ -305,9 +304,9 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
             except Exception:  # noqa: BLE001
                 return StrictUndefined(name=v.tagged_string)
         if isinstance(v, dict):
-            return {k: resolve(vv) for k, vv in v.items()}
+            return {k: resolve(x) for k, x in v.items()}
         if isinstance(v, list):
-            return [resolve(vv) for vv in v]
+            return [resolve(x) for x in v]
         return v
 
     context = {k: resolve(v) for k, v in {**(local or {}), **context}.items()}

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -292,9 +292,9 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :param local: Local sibling values to use if a match is not found in context.
     :return: The rendered value (potentially unchanged).
     """
-    context = _update_context(context, local)
     env = _register_filters(Environment(undefined=StrictUndefined))
     template = env.from_string(val)
+    context = _update_context(context, local)
     try:
         rendered = template.render(context)
     except Exception as e:  # noqa: BLE001

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -294,22 +294,30 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     """
 
     # Update context, converting tagged values to their final representations when possible, but
-    # otherwise replacing them with a Jinja2 Undefined so that any template expression referencing
-    # them raises UndefinedError and leads to the original value being returned unchanged.
+    # otherwise omitting top-level keys whose value trees contain any not-yet-convertible tagged
+    # values. This prevents string representations of unconverted tags from leaking into rendered
+    # expressions, whether at the top level or nested inside dicts/lists.
 
     def resolve(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
-            try:
-                return v.converted
-            except Exception:  # noqa: BLE001
-                return StrictUndefined(name=v.tagged_string)
+            return v.converted  # raises if not yet convertible
         if isinstance(v, dict):
             return {k: resolve(x) for k, x in v.items()}
         if isinstance(v, list):
             return [resolve(x) for x in v]
         return v
 
-    context = {k: resolve(v) for k, v in {**(local or {}), **context}.items()}
+    nil = object()
+
+    def safe_resolve(v: Any) -> Any:
+        try:
+            return resolve(v)
+        except Exception:  # noqa: BLE001
+            return nil
+
+    context = {
+        k: r for k, v in {**(local or {}), **context}.items() if (r := safe_resolve(v)) is not nil
+    }
 
     # Render.
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -293,21 +293,24 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :return: The rendered value (potentially unchanged).
     """
 
-    # Update context, convering tagged values to their final representations when possible, but
-    # otherwise omitting them to prevent their string representations from appearing in rendered
-    # expressions.
+    # Update context, converting tagged values to their final representations when possible, but
+    # otherwise replacing them with a Jinja2 Undefined so that any template expression referencing
+    # them (directly or via a nested dict/list) raises UndefinedError and causes _deref_render to
+    # return the original value unchanged.
 
-    def convert(v: Any) -> Any:
+    def resolve(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
             try:
                 return v.converted
             except Exception:  # noqa: BLE001
-                return nil
+                return StrictUndefined(name=v.tagged_string)
+        if isinstance(v, dict):
+            return {k: resolve(vv) for k, vv in v.items()}
+        if isinstance(v, list):
+            return [resolve(vv) for vv in v]
         return v
 
-    nil = object()
-    kvpairs = {**(local or {}), **context}.items()
-    context = {k: r for k, v in kvpairs if (r := convert(v)) is not nil}
+    context = {k: resolve(v) for k, v in {**(local or {}), **context}.items()}
 
     # Render.
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -304,37 +304,30 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     #     partial/incorrect data.
 
     class Pending:
-        """
-        Sentinel for a value that cannot yet be converted.
-        """
+        msg = "Value is not yet resolvable"
 
         def __repr__(self) -> str:
-            msg = "value is not yet resolvable"
-            raise UndefinedError(msg)
+            raise UndefinedError(self.msg)
 
         def __str__(self) -> str:
-            msg = "value is not yet resolvable"
-            raise UndefinedError(msg)
+            raise UndefinedError(self.msg)
 
     nil = object()
 
     def resolve(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
-            return v.converted  # raises if not yet convertible
+            try:
+                return v.converted  # raises if not yet convertible
+            except Exception:  # noqa: BLE001
+                return nil
         if isinstance(v, dict):
-            return {k: Pending() if (r := safe_resolve(x)) is nil else r for k, x in v.items()}
+            return {k: Pending() if (r := resolve(x)) is nil else r for k, x in v.items()}
         if isinstance(v, list):
             return [resolve(x) for x in v]
         return v
 
-    def safe_resolve(v: Any) -> Any:
-        try:
-            return resolve(v)
-        except Exception:  # noqa: BLE001
-            return nil
-
     context = {
-        k: r for k, v in {**(local or {}), **context}.items() if (r := safe_resolve(v)) is not nil
+        k: r for k, v in {**(local or {}), **context}.items() if (r := resolve(v)) is not nil
     }
 
     # Render.

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -410,8 +410,8 @@ def _update_context(context: dict, local: dict | None = None) -> dict:
 
     Values that cannot yet be converted because they contain unrendered content are replaced with
     Pending sentinels. When Jinja2 serializes a template containing such a sentinel, UndefinedError
-    # is raised; then the template render fails gracefully and the original value is returned #
-    unchanged (held for a later iteration with a better context).
+    is raised, the render fails gracefully, and the original value is returned unchanged, held for a
+    later iteration with better context.
 
     :param context: Values to use when rendering Jinja2 syntax.
     :param local: Local sibling values to use if a match is not found in context.

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -291,9 +291,20 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :param local: Local sibling values to use if a match is not found in context.
     :return: The rendered value (potentially unchanged).
     """
+
+    def resolve(v: object) -> object:
+        if isinstance(v, UWYAMLConvert):
+            try:
+                return v.converted
+            except Exception:  # noqa: BLE001
+                return nil
+        return v
+
+    nil = object()
     env = _register_filters(Environment(undefined=StrictUndefined))
     template = env.from_string(val)
-    context = {**(local or {}), **context}
+    kvpairs = {**(local or {}), **context}.items()
+    context = {k: r for k, v in kvpairs if (r := resolve(v)) is not nil}
     try:
         rendered = template.render(context)
     except Exception as e:  # noqa: BLE001

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -304,13 +304,9 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     #     partial/incorrect data.
 
     class Pending:
-        msg = "Value is not yet resolvable"
-
         def __repr__(self) -> str:
-            raise UndefinedError(self.msg)
-
-        def __str__(self) -> str:
-            raise UndefinedError(self.msg)
+            msg = "Value is not yet resolvable"
+            raise UndefinedError(msg)
 
     nil = object()
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -293,7 +293,11 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :return: The rendered value (potentially unchanged).
     """
 
-    def resolve(v: Any) -> Any:
+    # Update context, convering tagged values to their final representations when possible, but
+    # otherwise omitting them to prevent their string representations from appearing in rendered
+    # expressions.
+
+    def convert(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
             try:
                 return v.converted
@@ -302,10 +306,13 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
         return v
 
     nil = object()
+    kvpairs = {**(local or {}), **context}.items()
+    context = {k: r for k, v in kvpairs if (r := convert(v)) is not nil}
+
+    # Render.
+
     env = _register_filters(Environment(undefined=StrictUndefined))
     template = env.from_string(val)
-    kvpairs = {**(local or {}), **context}.items()
-    context = {k: r for k, v in kvpairs if (r := resolve(v)) is not nil}
     try:
         rendered = template.render(context)
     except Exception as e:  # noqa: BLE001

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -326,9 +326,8 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
             return [resolve(x) for x in v]
         return v
 
-    context = {
-        k: r for k, v in {**(local or {}), **context}.items() if (r := resolve(v)) is not nil
-    }
+    kvpairs = {**(local or {}), **context}.items()
+    context = {k: r for k, v in kvpairs if (r := resolve(v)) is not nil}
 
     # Render.
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -295,7 +295,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
 
     # Update context, converting tagged values to their final representations when possible.
     # UWYAMLConvert values that cannot yet be converted (because their inner template hasn't been
-    # rendered yet) are replaced with _Unresolvable sentinels. When Jinja2 serializes a template
+    # rendered yet) are replaced with Pending sentinels. When Jinja2 serializes a template
     # result containing such a sentinel (e.g. via __repr__), UndefinedError is raised, causing the
     # template render to fail gracefully and the original value to be returned unchanged (held for a
     # later iteration with a better context). This ensures that:
@@ -303,7 +303,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     #   - Templates that depend on not-yet-available values are held rather than converting with
     #     partial/incorrect data.
 
-    class _Unresolvable:
+    class Pending:
         """
         Sentinel for a value that cannot yet be converted.
         """
@@ -322,9 +322,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
         if isinstance(v, UWYAMLConvert):
             return v.converted  # raises if not yet convertible
         if isinstance(v, dict):
-            return {
-                k: _Unresolvable() if (r := safe_resolve(x)) is nil else r for k, x in v.items()
-            }
+            return {k: Pending() if (r := safe_resolve(x)) is nil else r for k, x in v.items()}
         if isinstance(v, list):
             return [resolve(x) for x in v]
         return v

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -293,21 +293,41 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :return: The rendered value (potentially unchanged).
     """
 
-    # Update context, converting tagged values to their final representations when possible, but
-    # otherwise omitting top-level keys whose value trees contain any not-yet-convertible tagged
-    # values. This prevents string representations of unconverted tags from leaking into rendered
-    # expressions, whether at the top level or nested inside dicts/lists.
+    # Update context, converting tagged values to their final representations when possible.
+    # UWYAMLConvert values that cannot yet be converted (because their inner template hasn't been
+    # rendered yet) are replaced with _Unresolvable sentinels. When Jinja2 serializes a template
+    # result containing such a sentinel (e.g. via __repr__), UndefinedError is raised, causing the
+    # template render to fail gracefully and the original value to be returned unchanged (held for a
+    # later iteration with a better context). This ensures that:
+    #   - Sibling keys in the same dict remain accessible to other templates.
+    #   - Templates that depend on not-yet-available values are held rather than converting with
+    #     partial/incorrect data.
+
+    class _Unresolvable:
+        """
+        Sentinel for a value that cannot yet be converted.
+        """
+
+        def __repr__(self) -> str:
+            msg = "value is not yet resolvable"
+            raise UndefinedError(msg)
+
+        def __str__(self) -> str:
+            msg = "value is not yet resolvable"
+            raise UndefinedError(msg)
+
+    nil = object()
 
     def resolve(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
             return v.converted  # raises if not yet convertible
         if isinstance(v, dict):
-            return {k: resolve(x) for k, x in v.items()}
+            return {
+                k: _Unresolvable() if (r := safe_resolve(x)) is nil else r for k, x in v.items()
+            }
         if isinstance(v, list):
             return [resolve(x) for x in v]
         return v
-
-    nil = object()
 
     def safe_resolve(v: Any) -> Any:
         try:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -8,6 +8,7 @@ import os
 from datetime import datetime, timedelta
 from functools import cached_property
 from pathlib import Path
+from typing import Any
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, Undefined, meta
@@ -292,7 +293,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :return: The rendered value (potentially unchanged).
     """
 
-    def resolve(v: object) -> object:
+    def resolve(v: Any) -> Any:
         if isinstance(v, UWYAMLConvert):
             try:
                 return v.converted

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -280,24 +280,19 @@ def _deref_convert(val: UWYAMLConvert) -> _ConfigVal:
     return converted
 
 
-def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
+def _update_context(context: dict, local: dict | None = None) -> dict:
     """
-    Render a Jinja2 variable/expression as part of dereferencing.
+    Update context, converting tagged values to their final representations when possible.
 
-    If the value cannot be rendered, perhaps due to missing values or syntax errors, a debug message
-    will be logged and the original value will be returned unchanged.
+    Values that cannot yet be converted because they contain unrendered content are replaced with
+    Pending sentinels. When Jinja2 serializes a template containing such a sentinel, UndefinedError
+    # is raised; then the template render fails gracefully and the original value is returned #
+    unchanged (held for a later iteration with a better context).
 
-    :param val: The value potentially containing Jinja2 syntax to render.
     :param context: Values to use when rendering Jinja2 syntax.
     :param local: Local sibling values to use if a match is not found in context.
-    :return: The rendered value (potentially unchanged).
+    :return: The updated context.
     """
-
-    # Update context, converting tagged values to their final representations when possible. Values
-    # that cannot yet be converted because they contain unrendered content are replaced with Pending
-    # sentinels. When Jinja2 serializes a template containing such a sentinel, an UndefinedError is
-    # raised, causing the template render to fail gracefully and the original value to be returned
-    # unchanged (held for a later iteration with a better context).
 
     class Pending:
         def __repr__(self) -> NoReturn:
@@ -318,10 +313,22 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
         return v
 
     kvpairs = {**(local or {}), **context}.items()
-    context = {k: r for k, v in kvpairs if (r := resolve(v)) is not nil}
+    return {k: r for k, v in kvpairs if (r := resolve(v)) is not nil}
 
-    # Render.
 
+def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
+    """
+    Render a Jinja2 variable/expression as part of dereferencing.
+
+    If the value cannot be rendered, perhaps due to missing values or syntax errors, a debug message
+    will be logged and the original value will be returned unchanged.
+
+    :param val: The value potentially containing Jinja2 syntax to render.
+    :param context: Values to use when rendering Jinja2 syntax.
+    :param local: Local sibling values to use if a match is not found in context.
+    :return: The rendered value (potentially unchanged).
+    """
+    context = _update_context(context, local)
     env = _register_filters(Environment(undefined=StrictUndefined))
     template = env.from_string(val)
     try:

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -248,7 +248,7 @@ class UWYAMLConvert(UWYAMLTaggedStr):
 
         :raises: Appropriate exception if the value cannot be represented as the required type.
         """
-        load_as = lambda t, v: t(yaml.safe_load(v))
+        load_as = lambda t, v: t(yaml.load(v, Loader=uw_yaml_loader()))
         converters: list[Callable[..., UWYAMLConvert.TaggedValT]] = [
             partial(load_as, bool),  # !bool
             to_datetime,  # !datetime

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -148,8 +148,20 @@ def dict_to_yaml_str(d: dict, sort: bool = False) -> str:
     :param d: A dict object.
     :param sort: Sort dict/mapping keys?
     """
+
+    class UWYAMLDumper(yaml.Dumper):
+        def ignore_aliases(self, *_args):
+            return True
+
     add_yaml_representers()
-    return yaml.dump(d, default_flow_style=False, indent=2, sort_keys=sort, width=math.inf).strip()
+    return yaml.dump(
+        d,
+        Dumper=UWYAMLDumper,
+        default_flow_style=False,
+        indent=2,
+        sort_keys=sort,
+        width=math.inf,
+    ).strip()
 
 
 class UWYAMLTag:

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from collections import OrderedDict
+from copy import deepcopy
 from datetime import datetime, timedelta
 from functools import cache, partial
 from importlib import import_module
@@ -192,8 +193,11 @@ class UWYAMLTag:
 
         Implements the interface required by pyyaml's add_representer() function. See the pyyaml
         documentation for details.
+
+        Returns a copy of the node to prevent pyyaml from seeing the same node object at multiple
+        positions in the tree and emitting anchors and aliases to eliminate repetition.
         """
-        return data.node
+        return deepcopy(data.node)
 
 
 class UWYAMLTaggedStr(UWYAMLTag):

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -88,16 +88,14 @@ def test_config_support_dict_to_yaml_str(capsys):
     assert capsys.readouterr().out.strip() == expected
 
 
-def test_config_support_dict_to_yaml_str__no_aliases(capsys, tmp_path):
-    path = tmp_path / "a.yaml"
-    s1 = """
+def test_config_support_dict_to_yaml_str__no_anchors_or_aliases(capsys, tmp_path):
+    yaml1 = """
     a: &a
       foo: bar
     b: *a
     c: *a
     """
-    path.write_text(dedent(s1))
-    s2 = """
+    yaml2 = """
     a:
       foo: bar
     b:
@@ -105,7 +103,9 @@ def test_config_support_dict_to_yaml_str__no_aliases(capsys, tmp_path):
     c:
       foo: bar
     """
-    expected = dedent(s2).strip()
+    path = tmp_path / "a.yaml"
+    path.write_text(dedent(yaml1))
+    expected = dedent(yaml2).strip()
     cfgobj = YAMLConfig(path)
     assert repr(cfgobj) == expected
     assert str(cfgobj) == expected

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -88,6 +88,31 @@ def test_config_support_dict_to_yaml_str(capsys):
     assert capsys.readouterr().out.strip() == expected
 
 
+def test_config_support_dict_to_yaml_str__no_aliases(capsys, tmp_path):
+    path = tmp_path / "a.yaml"
+    s1 = """
+    a: &a
+      foo: bar
+    b: *a
+    c: *a
+    """
+    path.write_text(dedent(s1))
+    s2 = """
+    a:
+      foo: bar
+    b:
+      foo: bar
+    c:
+      foo: bar
+    """
+    expected = dedent(s2).strip()
+    cfgobj = YAMLConfig(path)
+    assert repr(cfgobj) == expected
+    assert str(cfgobj) == expected
+    cfgobj.dump()
+    assert capsys.readouterr().out.strip() == expected
+
+
 def test_config_support_from_od():
     assert support.from_od(d=OrderedDict([("example", OrderedDict([("key", "value")]))])) == {
         "example": {"key": "value"}

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -320,37 +320,49 @@ def test_config_tools_compose__fmt_yaml_2x(compose_assets_yaml, logged, suffix, 
             outpath.unlink()
 
 
-def test_config_tools_compose__no_anchors_or_aliases(capsys, tmp_path):
+@mark.parametrize(
+    ("initial", "final"),
+    [
+        (" !bool 'yes'", " true"),
+        (" !datetime '2026-05-26T12'", " 2026-05-26T12:00:00"),
+        (" !dict '{a: 1}'", "\n        a: 1"),
+        (" !float '3.14'", " 3.14"),
+        (" !int '1'", " 1"),
+        (" !list '[1, 2]'", "\n      - 1\n      - 2"),
+        (" !timedelta '6'", " !timedelta '6:00:00'"),
+    ],
+)
+def test_config_tools_compose__no_anchors_or_aliases(capsys, initial, final, tmp_path):
     yaml1 = """
     b: *a
     c: *a
     """
     config1 = tmp_path / "config1.yaml"
     config1.write_text(dedent(yaml1))
-    yaml2 = """
+    yaml2 = f"""
     a: &a
-      foo: !int '1'
+      foo:{initial}
     """
     config2 = tmp_path / "config2.yaml"
     config2.write_text(dedent(yaml2))
     tools.compose(configs=[config1, config2], realize=False)
-    expected_unrealized = """
+    expected_unrealized = f"""
     b:
-      foo: !int '1'
+      foo:{initial}
     c:
-      foo: !int '1'
+      foo:{initial}
     a:
-      foo: !int '1'
+      foo:{initial}
     """
     assert capsys.readouterr().out.strip() == dedent(expected_unrealized).strip()
     tools.compose(configs=[config1, config2], realize=True)
-    expected_realized = """
+    expected_realized = f"""
     b:
-      foo: 1
+      foo:{final}
     c:
-      foo: 1
+      foo:{final}
     a:
-      foo: 1
+      foo:{final}
     """
     assert capsys.readouterr().out.strip() == dedent(expected_realized).strip()
 

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -744,57 +744,60 @@ def test_config_tools_realize__output_file_format(tmp_path):
 
 
 def test_config_tools_realize__reference_tagged_val_1(capsys, tmp_path):
-    path = tmp_path / "config,yaml"
-    s = """
+    yaml1 = """
     a: !int '{{ 1 + 1 }}'
     b: '{{ a }} is 2'
     """
-    path.write_text(dedent(s))
-    tools.realize(input_config=path)
-    expected = """
+    yaml2 = """
     a: 2
     b: 2 is 2
     """
-    assert capsys.readouterr().out.strip() == dedent(expected).strip()
+    path = tmp_path / "config,yaml"
+    path.write_text(dedent(yaml1))
+    tools.realize(input_config=path)
+    expected = dedent(yaml2).strip()
+    assert capsys.readouterr().out.strip() == expected
 
 
 def test_config_tools_realize__reference_tagged_val_2(capsys, tmp_path):
-    path = tmp_path / "config,yaml"
-    s = """
+    yaml1 = """
     freq: '{{ val.step }}h'
     td: !timedelta '6'
     val:
       step: !int '{{ (td.total_seconds() / 3600) | int }}'
     """
-    path.write_text(dedent(s))
-    tools.realize(input_config=path)
-    expected = """
+    yaml2 = """
     freq: 6h
     td: !timedelta '6:00:00'
     val:
       step: 6
     """
-    assert capsys.readouterr().out.strip() == dedent(expected).strip()
+    path = tmp_path / "config,yaml"
+    path.write_text(dedent(yaml1))
+    tools.realize(input_config=path)
+    expected = dedent(yaml2).strip()
+    assert capsys.readouterr().out.strip() == expected
 
 
 def test_config_tools_realize__reference_tagged_val_3(capsys, tmp_path):
-    path = tmp_path / "config,yaml"
-    s = """
+    yaml1 = """
     d:
       i: !int '{{ s }}'
     s: '1'
     x: !dict '{{ dict(d) }}'
     """
-    path.write_text(dedent(s))
-    tools.realize(input_config=path)
-    expected = """
+    yaml2 = """
     d:
       i: 1
     s: '1'
     x:
       i: 1
     """
-    assert capsys.readouterr().out.strip() == dedent(expected).strip()
+    path = tmp_path / "config,yaml"
+    path.write_text(dedent(yaml1))
+    tools.realize(input_config=path)
+    expected = dedent(yaml2).strip()
+    assert capsys.readouterr().out.strip() == expected
 
 
 def test_config_tools_realize__remove_nml_to_nml(tmp_path):

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -743,7 +743,7 @@ def test_config_tools_realize__output_file_format(tmp_path):
     assert compare_files(outfile, infile)
 
 
-def test_config_tools_realize__reference_tagged_val(capsys, tmp_path):
+def test_config_tools_realize__reference_tagged_val_1(capsys, tmp_path):
     path = tmp_path / "config,yaml"
     s = """
     a: !int '{{ 1 + 1 }}'
@@ -754,6 +754,25 @@ def test_config_tools_realize__reference_tagged_val(capsys, tmp_path):
     expected = """
     a: 2
     b: 2 is 2
+    """
+    assert capsys.readouterr().out.strip() == dedent(expected).strip()
+
+
+def test_config_tools_realize__reference_tagged_val_2(capsys, tmp_path):
+    path = tmp_path / "config,yaml"
+    s = """
+    freq: '{{ val.step }}h'
+    td: !timedelta '6'
+    val:
+      step: !int '{{ (td.total_seconds() / 3600) | int }}'
+    """
+    path.write_text(dedent(s))
+    tools.realize(input_config=path)
+    expected = """
+    freq: 6h
+    td: !timedelta '6:00:00'
+    val:
+      step: 6
     """
     assert capsys.readouterr().out.strip() == dedent(expected).strip()
 

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -753,7 +753,7 @@ def test_config_tools_realize__reference_tagged_val(capsys, tmp_path):
     tools.realize(input_config=path)
     expected = """
     a: 2
-    b: '2 is 2'
+    b: 2 is 2
     """
     assert capsys.readouterr().out.strip() == dedent(expected).strip()
 

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -777,6 +777,26 @@ def test_config_tools_realize__reference_tagged_val_2(capsys, tmp_path):
     assert capsys.readouterr().out.strip() == dedent(expected).strip()
 
 
+def test_config_tools_realize__reference_tagged_val_3(capsys, tmp_path):
+    path = tmp_path / "config,yaml"
+    s = """
+    d:
+      i: !int '{{ s }}'
+    s: '1'
+    x: !dict '{{ dict(d) }}'
+    """
+    path.write_text(dedent(s))
+    tools.realize(input_config=path)
+    expected = """
+    d:
+      i: 1
+    s: '1'
+    x:
+      i: 1
+    """
+    assert capsys.readouterr().out.strip() == dedent(expected).strip()
+
+
 def test_config_tools_realize__remove_nml_to_nml(tmp_path):
     input_config = NMLConfig({"constants": {"pi": 3.141, "e": 2.718}})
     s = """

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -743,6 +743,21 @@ def test_config_tools_realize__output_file_format(tmp_path):
     assert compare_files(outfile, infile)
 
 
+def test_config_tools_realize__reference_tagged_val(capsys, tmp_path):
+    path = tmp_path / "config,yaml"
+    s = """
+    a: !int '{{ 1 + 1 }}'
+    b: '{{ a }} is 2'
+    """
+    path.write_text(dedent(s))
+    tools.realize(input_config=path)
+    expected = """
+    a: 2
+    b: '2 is 2'
+    """
+    assert capsys.readouterr().out.strip() == dedent(expected).strip()
+
+
 def test_config_tools_realize__remove_nml_to_nml(tmp_path):
     input_config = NMLConfig({"constants": {"pi": 3.141, "e": 2.718}})
     s = """

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -320,6 +320,41 @@ def test_config_tools_compose__fmt_yaml_2x(compose_assets_yaml, logged, suffix, 
             outpath.unlink()
 
 
+def test_config_tools_compose__no_anchors_or_aliases(capsys, tmp_path):
+    yaml1 = """
+    b: *a
+    c: *a
+    """
+    config1 = tmp_path / "config1.yaml"
+    config1.write_text(dedent(yaml1))
+    yaml2 = """
+    a: &a
+      foo: !int '1'
+    """
+    config2 = tmp_path / "config2.yaml"
+    config2.write_text(dedent(yaml2))
+    tools.compose(configs=[config1, config2], realize=False)
+    expected_unrealized = """
+    b:
+      foo: !int '1'
+    c:
+      foo: !int '1'
+    a:
+      foo: !int '1'
+    """
+    assert capsys.readouterr().out.strip() == dedent(expected_unrealized).strip()
+    tools.compose(configs=[config1, config2], realize=True)
+    expected_realized = """
+    b:
+      foo: 1
+    c:
+      foo: 1
+    a:
+      foo: 1
+    """
+    assert capsys.readouterr().out.strip() == dedent(expected_realized).strip()
+
+
 @mark.parametrize("realize", [False, True])
 def test_config_tools_compose__realize(realize, tmp_path, utc):
     dyaml = """


### PR DESCRIPTION
**Synopsis**

This has been a bother in some contexts for a long time, but has become a real liability with large, complex configs like we are now seeing in project EAGLE. Essentially, `pyyaml` by default optimizes for space by creating new aliases and anchors to reduce repetition, but these are (a) surprising to users who didn't write and don't recognize them, and (b) can make it difficult to reason about how a perhaps-composed but not-yet-realized config will ultimately look given the interplay of the new anchors/aliases and unrendered Jinja2 expressions.

Given `a.yaml`
```
a: &a
  foo: bar
b: *a
c: *a
```
Old behavior:
```
$ uw config realize -i a.yaml 
a: &id001
  foo: bar
b: *id001
c: *id001
```
New behavior:
```
$ uw config realize -i a.yaml 
a:
  foo: bar
b:
  foo: bar
c:
  foo: bar
```
I'm opening the PR now for your consideration, but I'm also going to test a `uwtools` built against this PR with EAGLE to see if it might surface any unwanted side effects.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
