### PR TITLE
Fix issue with datetime re-parsing during realize

### DIFF
--- a/docs/sections/user_guide/cli/tools/config.rst
+++ b/docs/sections/user_guide/cli/tools/config.rst
@@ -198,7 +198,7 @@ Examples
 ``realize``
 -----------
 
-In ``uw`` terminology, to realize a configuration file is to transform it from its raw form into its final, usable state. The ``realize`` action can build a complete config file from two or more separate files.
+In ``uw`` terminology, to realize a configuration file is to transform it from its raw form into its final, usable state. Specificallly, the ``realize`` action replaces `YAML aliases <https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/>`_ with their anchored content, and renders :jinja2:`Jinja2 expressions<templates>`. It can build a complete config file from two or more separate files.
 
 .. literalinclude:: config/realize-help.cmd
    :language: text
@@ -392,6 +392,8 @@ and YAML file ``update.yaml`` with contents:
      :language: text
 
   Note that ``uw`` logs to ``stderr`` and writes non-log output to ``stdout``, so the streams can be redirected separately via shell redirection.
+
+.. attention:: If ``uwtools`` detects a ``repr()``-style representation of a Python :python:`datetime <datetime.html#datetime.datetime>` object in a Jinja2 expression string, it replaces it with the `ISO8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ representation of that ``datetime``. For example, if ``datetime.datetime(2026, 5, 27, 12)`` appears, it is replaced in the string with ``2026-05-27T12:00:00``. This is done to support cases where ``uwtools`` internally renders expressions and then later re-parses them as YAML.
 
 .. _cli_config_validate_examples:
 

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -69,6 +69,7 @@ ignore = [
   "FLY002",  # static-join-to-f-string
   "N813",    # camelcase-imported-as-lowercase
   "PLR0913", # too-many-arguments
+  "PLR2004", # magic-value-comparison
   "PT019",   # pytest-fixture-param-without-value
   "PTH207",  # glob
   "RUF015",  # unnecessary-iterable-allocation-for-first-element
@@ -86,7 +87,6 @@ ignore = [
 "uwtools/tests/*" = [
   "ANN001",  # missing-type-function-argument
   "N802",    # invalid-function-name
-  "PLR2004", # magic-value-comparison
   "PT013",   # pytest-incorrect-pytest-import
   "SLF001",  # private-member-access
 ]

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -36,7 +36,7 @@ class INIConfig(Config):
         # INI configs have one level for the [section], and one level for each key, so are exactly
         # depth 2.
 
-        return depth == 2  # noqa: PLR2004
+        return depth == 2
 
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -54,7 +54,7 @@ class NMLConfig(Config):
         # per f90nml. uwtools can map back and forth between these formats, but it should be clear
         # that a ceiling cannot be defined for the YAML depth.
 
-        return depth >= 2  # noqa: PLR2004
+        return depth >= 2
 
     @classmethod
     def _dict_to_str(cls, cfg: dict) -> str:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -138,6 +138,7 @@ def dereference(
     :param keys: The dict keys leading to this value.
     :return: The input value, with Jinja2 syntax rendered.
     """
+    report = lambda x: deref_debug("Rendering", x)
     rendered: _ConfigVal
     if isinstance(val, dict):
         keys = keys or []
@@ -151,14 +152,14 @@ def dereference(
     elif isinstance(val, list):
         rendered = [dereference(v, context) for v in val]
     elif isinstance(val, str):
-        deref_debug("Rendering", val)
+        report(val)
         rendered = _deref_render(val, context, local)
     elif isinstance(val, UWYAMLConvert):
-        deref_debug("Rendering", val.value)
+        report(val.value)
         val.value = _deref_render(val.value, context, local)
         rendered = _deref_convert(val)
     elif isinstance(val, UWYAMLGlob):
-        deref_debug("Rendering", val.value)
+        report(val.value)
         val.value = _deref_render(val.value, context, local)
         rendered = val
     else:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -322,13 +322,14 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
 
 
 def _deref_render_datetime(s: str) -> str:
+    orig = s
     pattern = re.compile(r"(datetime\.datetime\(([^)]+)\))")
     for old, argstr in re.findall(pattern, s):
         dtargs: Any = map(int, argstr.split(","))
         dt = datetime(*dtargs, tzinfo=timezone.utc)  # type: ignore[misc]
         new = to_iso8601(dt)
         s = s.replace(old, new)
-        log.debug("Replaced '%s' with '%s' in '%s'", old, new, s)
+        log.debug("Replaced '%s' with '%s' in '%s'", old, new, orig)
     return s
 
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -301,7 +301,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
         rendered = val
         deref_debug("Rendering failed", val)
         for line in str(e).split("\n"):
-            deref_debug(line)
+            deref_debug(f"  Exception text: {line}")
     else:
         deref_debug("Rendered", rendered)
     try:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -321,13 +321,15 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     return rendered
 
 
-def _deref_render_datetime(rendered: str) -> str:
+def _deref_render_datetime(s: str) -> str:
     pattern = re.compile(r"(datetime\.datetime\(([^)]+)\))")
-    for dtstr, argstr in re.findall(pattern, rendered):
+    for old, argstr in re.findall(pattern, s):
         dtargs: Any = map(int, argstr.split(","))
         dt = datetime(*dtargs, tzinfo=timezone.utc)  # type: ignore[misc]
-        rendered = rendered.replace(dtstr, to_iso8601(dt))
-    return rendered
+        new = to_iso8601(dt)
+        s = s.replace(old, new)
+        log.debug("Replaced '%s' with '%s' in '%s'", old, new, s)
+    return s
 
 
 def _dry_run_template(rendered_template: str) -> str:

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -307,10 +307,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
             deref_debug(f"  Exception text: {line}")
     else:
         deref_debug("Rendered", rendered)
-    for dtstr, argstr in re.findall(re.compile(r"(datetime\.datetime\(([^)]+)\))"), rendered):
-        dtargs: Any = map(int, argstr.split(","))
-        dt = datetime(*dtargs, tzinfo=timezone.utc)  # type: ignore[misc]
-        rendered = rendered.replace(dtstr, to_iso8601(dt))
+    rendered = _deref_render_datetime(rendered)
     try:
         loaded = yaml.load(rendered, Loader=uw_yaml_loader())
     except Exception as e:  # noqa: BLE001
@@ -321,6 +318,15 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     if isinstance(loaded, UWYAMLConvert):
         rendered = val
         deref_debug("Held", rendered)
+    return rendered
+
+
+def _deref_render_datetime(rendered: str) -> str:
+    pattern = re.compile(r"(datetime\.datetime\(([^)]+)\))")
+    for dtstr, argstr in re.findall(pattern, rendered):
+        dtargs: Any = map(int, argstr.split(","))
+        dt = datetime(*dtargs, tzinfo=timezone.utc)  # type: ignore[misc]
+        rendered = rendered.replace(dtstr, to_iso8601(dt))
     return rendered
 
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -322,6 +322,12 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
 
 
 def _deref_render_datetime(s: str) -> str:
+    """
+    Returns the given string with datetime repr strings, e.g. datetime.datetime(2026, 5, 27, 12),
+    converted to ISO8601 timestamps so that they can be YAML-loaded again without error.
+
+    :param s: A string potentially containing a datetime repr string.
+    """
     orig = s
     pattern = re.compile(r"(datetime\.datetime\(([^)]+)\))")
     for old, argstr in re.findall(pattern, s):

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -5,7 +5,8 @@ Support for rendering Jinja2 templates.
 from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta
+import re
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from pathlib import Path
 from typing import Any, NoReturn
@@ -24,6 +25,7 @@ from uwtools.config.support import (
 )
 from uwtools.logging import INDENT, MSGWIDTH, log
 from uwtools.utils.file import get_config_format, readable, writable
+from uwtools.utils.time import to_iso8601
 
 _ConfigVal = (
     bool
@@ -305,6 +307,10 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
             deref_debug(f"  Exception text: {line}")
     else:
         deref_debug("Rendered", rendered)
+    for dtstr, argstr in re.findall(re.compile(r"(datetime\.datetime\(([^)]+)\))"), rendered):
+        dtargs: Any = map(int, argstr.split(","))
+        dt = datetime(*dtargs, tzinfo=timezone.utc)  # type: ignore[misc]
+        rendered = rendered.replace(dtstr, to_iso8601(dt))
     try:
         loaded = yaml.load(rendered, Loader=uw_yaml_loader())
     except Exception as e:  # noqa: BLE001

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -151,7 +151,7 @@ def dict_to_yaml_str(d: dict, sort: bool = False) -> str:
     """
 
     class UWYAMLDumper(yaml.Dumper):
-        def ignore_aliases(self, data: object) -> bool:  # noqa: ARG002
+        def ignore_aliases(self, _data: object) -> bool:
             return True
 
     add_yaml_representers()

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -151,7 +151,7 @@ def dict_to_yaml_str(d: dict, sort: bool = False) -> str:
     """
 
     class UWYAMLDumper(yaml.Dumper):
-        def ignore_aliases(self, *_args):
+        def ignore_aliases(self, data: object) -> bool:  # noqa: ARG002
             return True
 
     add_yaml_representers()

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -431,6 +431,18 @@ def test_config_jinja2__deref_render__unloadable_val(logged):
     assert not logged("Rendering failed")
 
 
+def test_config_jinja2__deref_render_datetime(uwcaplog):
+    s = "foo datetime.datetime(2026, 5, 27) bar datetime.datetime(2026, 5, 27, 1, 2, 3, 4) baz"
+    actual = jinja2._deref_render_datetime(s)
+    expected = "foo 2026-05-27T00:00:00 bar 2026-05-27T01:02:03 baz"
+    assert actual == expected
+    for old, new in [
+        ("datetime.datetime(2026, 5, 27)", "2026-05-27T00:00:00"),
+        ("datetime.datetime(2026, 5, 27, 1, 2, 3, 4)", "2026-05-27T01:02:03"),
+    ]:
+        assert f"Replaced '{old}' with '{new}' in '{s}'" in uwcaplog.text
+
+
 def test_config_jinja2__dry_run_template(logged):
     jinja2._dry_run_template("roses are red\nviolets are blue")
     assert logged("roses are red")

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -227,6 +227,32 @@ def test_config_tools_compose__bad_duplicate_anchor(tmp_path):
     assert "found duplicate anchor 'A'" in str(e.value)
 
 
+def test_config_tools_compose__datetime(capsys, tmp_path):
+    yaml1 = """
+    a:
+      t: !datetime 2022-02-01T00
+    c: !dict '{{ b }}'
+    """
+    config1 = tmp_path / "config1.yaml"
+    config1.write_text(dedent(yaml1))
+    yaml2 = """
+    b:
+      t: !datetime '{{ a.t }}'
+    """
+    config2 = tmp_path / "config2.yaml"
+    config2.write_text(dedent(yaml2))
+    expected = """
+    a:
+      t: 2022-02-01T00:00:00
+    c:
+      t: 2022-02-01T00:00:00
+    b:
+      t: 2022-02-01T00:00:00
+    """
+    tools.compose(configs=[config1, config2], realize=True)
+    assert capsys.readouterr().out.strip() == dedent(expected).strip()
+
+
 @mark.parametrize(("configclass", "fmt"), [(INIConfig, FORMAT.ini), (NMLConfig, FORMAT.nml)])
 def test_config_tools_compose__fmt_ini_nml_2x(configclass, fmt, logged, tmp_path):
     d = {"constants": {"pi": 3.142, "e": 2.718}, "trees": {"leaf": "elm", "needle": "spruce"}}


### PR DESCRIPTION
**Synopsis**

Given `a.yaml`
```
a:
  t: !datetime 2022-02-01T00
c: !dict '{{ b }}'
```
and `b.yaml`
```
b:
  x: !datetime '{{ a.t }}'
```
Old behavior:
```
$ uw config compose --realize a.yaml b.yaml
a:
  t: 2022-02-01T00:00:00
c:
  x: datetime.datetime(2022
  2: null
  1: null
  0: null
  0): null
b:
  x: 2022-02-01T00:00:00
```
New behavior:
```
$ uw config compose --realize a.yaml b.yaml
a:
  t: 2022-02-01T00:00:00
c:
  x: 2022-02-01T00:00:00
b:
  x: 2022-02-01T00:00:00
```
I spent a lot of time looking for a better solution, but couldn't find one. This solution requires a caveat, which I've added to the docs. I think the potential for a problem with the documented behavior is low.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Documentation

**Impact**

- [x] This is a breaking change (changes existing functionality)

Technically a breaking change, though I highly doubt any users have `datetime` `repr` strings in their configs.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
