### PR TITLE
MPAS driver config requires 'length' parameter

### DIFF
--- a/src/uwtools/resources/jsonschema/mpas.jsonschema
+++ b/src/uwtools/resources/jsonschema/mpas.jsonschema
@@ -101,6 +101,7 @@
       "required": [
         "domain",
         "execution",
+        "length",
         "namelist",
         "rundir",
         "streams"

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1450,7 +1450,7 @@ def test_schema_mpas(mpas_streams):
     # Basic correctness:
     assert not errors(config)
     # All top-level keys are required:
-    for key in ("domain", "execution", "namelist", "rundir", "streams"):
+    for key in ("domain", "execution", "length", "namelist", "rundir", "streams"):
         assert f"'{key}' is a required property" in errors(with_del(config, key))
     # Additional top-level keys are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1441,6 +1441,7 @@ def test_schema_mpas(mpas_streams):
         "domain": "regional",
         "execution": {"executable": "atmosphere_model"},
         "lateral_boundary_conditions": {"interval_hours": 3, "offset": 3, "path": "/path/to/lbcs"},
+        "length": 6,
         "namelist": {"base_file": "path/to/simple.nml", "validate": True},
         "rundir": "path/to/rundir",
         "streams": mpas_streams,


### PR DESCRIPTION
**Synopsis**

The `length` parameter was previously optional, but the driver code [requires it](https://github.com/ufs-community/uwtools/blob/main/src/uwtools/drivers/mpas.py#L31).

Require `length` in the schema and update tests.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
