### PR TITLE
Fix timezone reparse issue

### DIFF
--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -227,14 +227,15 @@ def test_config_tools_compose__bad_duplicate_anchor(tmp_path):
     assert "found duplicate anchor 'A'" in str(e.value)
 
 
-def test_config_tools_compose__datetime(capsys, tmp_path):
+@mark.parametrize("dtval", ["2022-02-01T00", "2022-02-01T00:00:00+00:00"])
+def test_config_tools_compose__datetime(capsys, dtval, tmp_path):
     yaml1 = """
     a:
-      t: !datetime 2022-02-01T00
+      t: !datetime %s
     c: !dict '{{ b }}'
     """
     config1 = tmp_path / "config1.yaml"
-    config1.write_text(dedent(yaml1))
+    config1.write_text(dedent(yaml1 % dtval))
     yaml2 = """
     b:
       t: !datetime '{{ a.t }}'

--- a/src/uwtools/utils/time.py
+++ b/src/uwtools/utils/time.py
@@ -12,7 +12,7 @@ ISO8601FMT = "%Y-%m-%dT%H:%M:%S"
 def to_datetime(value: str | datetime) -> datetime:
     if isinstance(value, datetime):
         return value
-    return datetime.fromisoformat(value)
+    return datetime.fromisoformat(value).replace(tzinfo=None)
 
 
 def to_iso8601(value: str | datetime) -> str:


### PR DESCRIPTION
**Synopsis**

Given `a.yaml`
```
cycles:
  start: !datetime '{{ start }}'
latency: !timedelta '6'
now: !datetime '{{ "NOW" | env }}'
start: !datetime '{{ now - latency }}'
```
and `b.yaml`
```
cycles:
  start: !datetime '{{ start }}'
lam:
  cycles: !dict '{{ cycles }}'
```
Old behavior:
```
$ NOW=2026-06-01T18:00:00+00:00 uw config compose --realize a.yaml b.yaml 
Traceback (most recent call last):
...
ValueError: invalid literal for int() with base 10: ' tzinfo=datetime.timezone.utc'
```
New behavior:
```
$ NOW=2026-06-01T18:00:00+00:00 uw config compose --realize a.yaml b.yaml 
cycles:
  start: 2026-06-01T12:00:00
latency: !timedelta '6:00:00'
now: 2026-06-01T18:00:00
start: 2026-06-01T12:00:00
lam:
  cycles:
    start: 2026-06-01T12:00:00
```

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
