### PR TITLE
Log even errors at debug level when quiet=True

### DIFF
--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -10,16 +10,19 @@ from uwtools.logging import log
 from uwtools.utils import processing
 
 
-def test_utils_processing_run_shell_cmd__failure(logged):
+@mark.parametrize("quiet", [True, False])
+def test_utils_processing_run_shell_cmd__failure(caplog, logged, quiet):
+    caplog.set_level(logging.INFO if quiet else logging.DEBUG)
     cmd = "expr 1 / 0"
-    success, output = processing.run_shell_cmd(cmd=cmd)
+    success, output = processing.run_shell_cmd(cmd=cmd, quiet=quiet)
     assert "division by zero" in output
     assert success is False
-    assert logged("Running:")
-    assert logged("  %s" % cmd)
-    assert logged("Failed with status: 2")
-    assert logged("Output:")
-    assert logged("  expr: division by zero")
+    check = lambda msg: not logged(msg) if quiet else logged
+    assert check("Running:")
+    assert check("  %s" % cmd)
+    assert check("Failed with status: 2")
+    assert check("Output:")
+    assert check("  expr: division by zero")
 
 
 @mark.parametrize("log_output", [True, False])

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -50,8 +50,9 @@ def run_shell_cmd(
         success = True
     except CalledProcessError as e:
         output = e.output
-        log.error("%sFailed with status: %s", pre, e.returncode)
-        logfunc = log.error
+        if not quiet:
+            log.error("%sFailed with status: %s", pre, e.returncode)
+            logfunc = log.error
         success = False
     if output and (log_output or not success):
         logfunc("%sOutput:", pre)


### PR DESCRIPTION
**Synopsis**

I'm working on a POC for `ecflow_server` startup and found that that executable is quite noisy when it fails, which we expect it to do when it tries to use an already-in-use TCP port. In that case, we will not want to flood the users with error messages about a benign failure we expect to happen sometimes and have a mechanism to address (pick another random TCP port and try again). This PR updates `run_shell_cmd()` so that even errors are logged at debug level when the `quiet=True` flag is set.

This will be useful on `main`, but this PR targets `ecflow_tool` so we can use it there first.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
