### PR TITLE
Remove RST formatting in docstrings outside of API code

### DIFF
--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -78,7 +78,7 @@ class FieldTableConfig(YAMLConfig):
         """
         Dump a provided config dictionary in Field Table format.
 
-        FMS field and tracer managers must be registered in an ASCII table called ``field_table``.
+        FMS field and tracer managers must be registered in an ASCII table called 'field_table'.
         This table lists field type, target model and methods the querying model will ask for. See
         UFS documentation for more information:
 

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -250,7 +250,7 @@ def unrendered(s: str) -> bool:
     Does the supplied string contain unrendered Jinja2 variables/expressions?
 
     :param s: The string to check for unrendered content.
-    :return: ``True`` if unrendered content was found, ``False`` otherwise.
+    :return: True if unrendered content was found, False otherwise.
     """
     try:
         Environment(undefined=StrictUndefined).from_string(s).render({})

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -130,7 +130,7 @@ def validate_internal(
     """
     Validate a config against a uwtools-internal schema.
 
-    Specify at most one of config_data or config_path. If no config is specified, ``stdin`` is read
+    Specify at most one of config_data or config_path. If no config is specified, stdin is read
     and will be parsed as YAML and then validated.
 
     :param schema_name: Name of uwtools schema to validate the config against.
@@ -158,7 +158,7 @@ def validate_external(
     """
     Validate a YAML config against the JSON Schema in the given schema file.
 
-    Specify at most one of config_data or config_path. If no config is specified, ``stdin`` is read
+    Specify at most one of config_data or config_path. If no config is specified, stdin is read
     and will be parsed as YAML and then validated.
 
     :param schema_file: The JSON Schema file to use for validation.

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -130,8 +130,8 @@ def validate_internal(
     """
     Validate a config against a uwtools-internal schema.
 
-    Specify at most one of config_data or config_path. If no config is specified, stdin is read
-    and will be parsed as YAML and then validated.
+    Specify at most one of config_data or config_path. If no config is specified, stdin is read and
+    will be parsed as YAML and then validated.
 
     :param schema_name: Name of uwtools schema to validate the config against.
     :param desc: A description of the config being validated, for logging.
@@ -158,8 +158,8 @@ def validate_external(
     """
     Validate a YAML config against the JSON Schema in the given schema file.
 
-    Specify at most one of config_data or config_path. If no config is specified, stdin is read
-    and will be parsed as YAML and then validated.
+    Specify at most one of config_data or config_path. If no config is specified, stdin is read and
+    will be parsed as YAML and then validated.
 
     :param schema_file: The JSON Schema file to use for validation.
     :param desc: A description of the config being validated, for logging.

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -387,11 +387,10 @@ def realize(
 ) -> str:
     """
     Realize the ecFlow suite defined in a given YAML as a Suite Definition and corresponding ecf
-    scripts (if ``scripts_path`` is provided).
+    scripts (if 'scripts_path' is provided).
 
-    :param config: Path to YAML input file (None => read ``stdin``), or YAMLConfig object.
-    :param output_path: Path to write the rendered Suite Definition file (None => write to
-        ``stdout``).
+    :param config: Path to YAML input file (None => read stdin), or YAMLConfig object.
+    :param output_path: Path to write the rendered Suite Definition file (None => write to stdout).
     :param scripts_path: Path to write the rendered ecf scripts (None => do not write scripts).
     :return: Suite Definition as a string.
     """
@@ -406,10 +405,10 @@ def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
     """
     Validate an ecFlow config against the internal ecFlow schema.
 
-    :param config: A ``dict``, a ``YAMLConfig``, a path to a YAML file, or ``None``
-        (``None`` => read ``stdin``).
-    :return: ``True`` if the config conforms to the schema.
-    :raises: ``UWConfigError`` if validation fails.
+    :param config: A dict, a YAMLConfig, a path to a YAML file, or None
+        (None => read stdin).
+    :return: True if the config conforms to the schema.
+    :raises: UWConfigError if validation fails.
     """
     kwargs: dict = {"schema_name": EC.ecflow, "desc": "ecFlow config"}
     if isinstance(config, (dict, YAMLConfig)):

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -428,11 +428,11 @@ _SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
 
 def _provision_ssl() -> None:
     """
-    Ensure SSL certificates exist in ``$HOME/.ecflowrc/ssl``.
+    Ensure SSL certificates exist in $HOME/.ecflowrc/ssl.
 
     If all required files exist, logs that they will be reused. If the directory exists but is
-    missing one or more required files, logs an error and raises ``UWError``. If the directory does
-    not exist, creates it and generates the required SSL files using ``openssl``.
+    missing one or more required files, logs an error and raises UWError. If the directory does
+    not exist, creates it and generates the required SSL files using openssl.
 
     :raises UWError: If the SSL directory exists but is incomplete, or if certificate generation
         fails.
@@ -458,10 +458,10 @@ def _provision_ssl() -> None:
 
 def _ssl_generate_key(path: Path) -> None:
     """
-    Generate a 2048-bit RSA private key (no password) at ``path``.
+    Generate a 2048-bit RSA private key (no password) at 'path'.
 
     :param path: Destination for the private key file.
-    :raises UWError: If ``openssl`` reports failure.
+    :raises UWError: If openssl reports failure.
     """
     log.info("Generating SSL private key: %s", path)
     success, _ = run_shell_cmd(f"umask 0077 && openssl genrsa -out {path} 2048")
@@ -472,11 +472,11 @@ def _ssl_generate_key(path: Path) -> None:
 
 def _ssl_generate_cert(path: Path, key_path: Path) -> None:
     """
-    Generate a self-signed X.509 certificate at ``path`` using the key at ``key_path``.
+    Generate a self-signed X.509 certificate at 'path' using the key at 'key_path'.
 
     :param path: Destination for the certificate file.
     :param key_path: Path to the existing RSA private key.
-    :raises UWError: If ``openssl`` reports failure.
+    :raises UWError: If openssl reports failure.
     """
     hostname = socket.gethostname()
     log.info("Generating SSL certificate: %s", path)
@@ -492,10 +492,10 @@ def _ssl_generate_cert(path: Path, key_path: Path) -> None:
 
 def _ssl_generate_dhparam(path: Path) -> None:
     """
-    Generate 2048-bit Diffie-Hellman parameters at ``path``.
+    Generate 2048-bit Diffie-Hellman parameters at 'path'.
 
     :param path: Destination for the DH parameters file.
-    :raises UWError: If ``openssl`` reports failure.
+    :raises UWError: If openssl reports failure.
     """
     log.info("Generating DH parameters: %s", path)
     success, _ = run_shell_cmd(f"umask 0077 && openssl dhparam -out {path} 2048")
@@ -526,14 +526,14 @@ def server(
     Start an ecFlow server on an available TCP port, optionally with SSL security enabled.
 
     The server runs in the foreground until interrupted (e.g. via CTRL-C), at which point it is
-    shut down gracefully via ``ecflow_client --terminate``.
+    shut down gracefully via 'ecflow_client --terminate'.
 
-    :param config: A ``dict``, a ``YAMLConfig``, or a path to a YAML file providing server settings
-        (``None`` => read ``stdin``).
-    :param port: TCP port to use (``None`` => pick a random available port from
-        ``ECFLOW_PORT_MIN``-``ECFLOW_PORT_MAX``).
+    :param config: A dict, a YAMLConfig, or a path to a YAML file providing server settings
+        (None => read stdin).
+    :param port: TCP port to use (None => pick a random available port from the range
+        ECFLOW_PORT_MIN through ECFLOW_PORT_MAX).
     :param insecure: Start the server without SSL security.
-    :param report: Output server details (e.g. hostname, port) as JSON to ``stdout``.
+    :param report: Output server details (e.g. hostname, port) as JSON to stdout.
     :raises UWError: If the server fails to start.
     """
     cfg = YAMLConfig(config)
@@ -577,19 +577,19 @@ def server(
 
 def _server_start(rundir: Path, env: dict[str, str], port: int | None, insecure: bool) -> None:
     """
-    Thread target: launch ``ecflow_server``, hunting for a free port if none was specified.
+    Thread target: launch ecflow_server, hunting for a free port if none was specified.
 
-    The subprocess is placed in its own session (``start_new_session=True``) so that it does not
+    The subprocess is placed in its own session (start_new_session=True) so that it does not
     receive the terminal's SIGINT; the main thread alone handles keyboard interrupts and shuts the
-    server down gracefully. (``start_new_session`` is preferred over ``preexec_fn``, which the
+    server down gracefully. ('start_new_session' is preferred over 'preexec_fn', which the
     Python docs warn is unsafe in a multi-threaded process.)
 
-    The run directory (``ECF_HOME``) is created if it does not already exist.
+    The run directory (ECF_HOME) is created if it does not already exist.
 
-    :param rundir: Directory to run the server in (``ECF_HOME``).
+    :param rundir: Directory to run the server in (ECF_HOME).
     :param env: Base environment variables for the server.
-    :param port: A specific port to use, or ``None`` to pick a random port
-        (``ECFLOW_PORT_MIN``-``ECFLOW_PORT_MAX``).
+    :param port: A specific port to use, or None to pick a random port from the range
+        ECFLOW_PORT_MIN through ECFLOW_PORT_MAX.
     :param insecure: Start the server without SSL security.
     """
     thread = cast(_ServerThread, current_thread())
@@ -642,8 +642,8 @@ def _server_wait(thread: _ServerThread, ssl_opt: str, report_vars: dict[str, str
     Wait for the server to respond to a ping, then optionally report its details.
 
     :param thread: The running server thread.
-    :param ssl_opt: ``ecflow_client`` SSL option (``"--ssl "`` for secure servers, else ``""``).
-    :param report_vars: Server variables to report as JSON once the server is up (``None`` => do
+    :param ssl_opt: ecflow_client SSL option ('--ssl' for secure servers, else the empty string).
+    :param report_vars: Server variables to report as JSON once the server is up (None => do
         not report).
     """
     while not thread.terminal.is_set():
@@ -662,10 +662,10 @@ def _server_wait(thread: _ServerThread, ssl_opt: str, report_vars: dict[str, str
 
 def _server_report(port: int, report_vars: dict[str, str]) -> None:
     """
-    Print ecFlow server details as JSON to ``stdout``.
+    Print ecFlow server details as JSON to stdout.
 
     :param port: The TCP port the server is using.
-    :param report_vars: Server variables to report, exclusive of ``ECF_PORT``.
+    :param report_vars: Server variables to report, exclusive of ECF_PORT.
     """
     vars_ = {**report_vars, "ECF_PORT": str(port)}
     # Flush so downstream consumers (e.g. a piped jq) see the report while the server runs, rather

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -431,8 +431,8 @@ def _provision_ssl() -> None:
     Ensure SSL certificates exist in $HOME/.ecflowrc/ssl.
 
     If all required files exist, logs that they will be reused. If the directory exists but is
-    missing one or more required files, logs an error and raises UWError. If the directory does
-    not exist, creates it and generates the required SSL files using openssl.
+    missing one or more required files, logs an error and raises UWError. If the directory does not
+    exist, creates it and generates the required SSL files using openssl.
 
     :raises UWError: If the SSL directory exists but is incomplete, or if certificate generation
         fails.
@@ -525,11 +525,11 @@ def server(
     """
     Start an ecFlow server on an available TCP port, optionally with SSL security enabled.
 
-    The server runs in the foreground until interrupted (e.g. via CTRL-C), at which point it is
-    shut down gracefully via 'ecflow_client --terminate'.
+    The server runs in the foreground until interrupted (e.g. via CTRL-C), at which point it is shut
+    down gracefully via 'ecflow_client --terminate'.
 
-    :param config: A dict, a YAMLConfig, or a path to a YAML file providing server settings
-        (None => read stdin).
+    :param config: A dict, a YAMLConfig, or a path to a YAML file providing server settings (None =>
+        read stdin).
     :param port: TCP port to use (None => pick a random available port from the range
         ECFLOW_PORT_MIN through ECFLOW_PORT_MAX).
     :param insecure: Start the server without SSL security.
@@ -643,8 +643,8 @@ def _server_wait(thread: _ServerThread, ssl_opt: str, report_vars: dict[str, str
 
     :param thread: The running server thread.
     :param ssl_opt: ecflow_client SSL option ('--ssl' for secure servers, else the empty string).
-    :param report_vars: Server variables to report as JSON once the server is up (None => do
-        not report).
+    :param report_vars: Server variables to report as JSON once the server is up (None => do not
+        report).
     """
     while not thread.terminal.is_set():
         if thread.port:
@@ -677,8 +677,7 @@ def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
     """
     Validate an ecFlow config against the internal ecFlow schema.
 
-    :param config: A dict, a YAMLConfig, a path to a YAML file, or None
-        (None => read stdin).
+    :param config: A dict, a YAMLConfig, a path to a YAML file, or None (None => read stdin).
     :return: True if the config conforms to the schema.
     :raises: UWConfigError if validation fails.
     """

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -292,10 +292,10 @@ class Linker(FileStager):
         """
         Create links to filesystem items.
 
-        When 'hardlink' is False (the default), links may target files, hardlinks, symlinks,
-        and directories; when True, links may not be made across filesystems, or to directories.
-        When 'fallback' is set, a copy or symlink will be created, if possible, if a
-        hardlink cannot be created.
+        When 'hardlink' is False (the default), links may target files, hardlinks, symlinks, and
+        directories; when True, links may not be made across filesystems, or to directories. When
+        'fallback' is set, a copy or symlink will be created, if possible, if a hardlink cannot be
+        created.
 
         :param name: A string identifier to disambiguate the task from others like it.
         """

--- a/src/uwtools/fs.py
+++ b/src/uwtools/fs.py
@@ -45,12 +45,12 @@ class Stager(ABC):
         key_path: list[YAMLKey] | None = None,
     ) -> None:
         """
-        :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).
+        :param config: YAML-file path, or dict (read stdin if missing or None).
         :param target_dir: Path to target directory.
-        :param cycle: A ``datetime`` object to make available for use in the config.
-        :param leadtime: A ``timedelta`` object to make available for use in the config.
+        :param cycle: A datetime object to make available for use in the config.
+        :param leadtime: A timedelta object to make available for use in the config.
         :param key_path: Path of keys to config block to use.
-        :raises: ``UWConfigError`` if config fails validation.
+        :raises: UWConfigError if config fails validation.
         """
         self._target_dir = str2path(target_dir)
         yaml_config = YAMLConfig(config=str2path(config))
@@ -274,14 +274,14 @@ class Linker(FileStager):
         fallback: str | None = None,
     ) -> None:
         """
-        :param config: YAML-file path, or ``dict`` (read ``stdin`` if missing or ``None``).
+        :param config: YAML-file path, or dict (read stdin if missing or None).
         :param target_dir: Path to target directory.
-        :param cycle: A ``datetime`` object to make available for use in the config.
+        :param cycle: A datetime object to make available for use in the config.
         :param hardlink: Create hardlinks instead of symlinks?
-        :param leadtime: A ``timedelta`` object to make available for use in the config.
+        :param leadtime: A timedelta object to make available for use in the config.
         :param key_path: Path of keys to config block to use.
         :param fallback: Choice of copy or symlink if hardlink fails when hardlink=True?
-        :raises: ``UWConfigError`` if config fails validation.
+        :raises: UWConfigError if config fails validation.
         """
         super().__init__(config, target_dir, cycle, leadtime, key_path)
         self.hardlink = hardlink
@@ -292,9 +292,9 @@ class Linker(FileStager):
         """
         Create links to filesystem items.
 
-        When ``hardlink`` is ``False`` (the default), links may target files, hardlinks, symlinks,
-        and directories; when ``True``, links may not be made across filesystems, or to directories.
-        When ``fallback`` is set, a ``copy`` or ``symlink`` will be created, if possible, if a
+        When 'hardlink' is False (the default), links may target files, hardlinks, symlinks,
+        and directories; when True, links may not be made across filesystems, or to directories.
+        When 'fallback' is set, a copy or symlink will be created, if possible, if a
         hardlink cannot be created.
 
         :param name: A string identifier to disambiguate the task from others like it.

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -166,7 +166,7 @@ def _execute(
     """
     Execute a task.
 
-    If ``batch`` is specified, a runscript will be written and submitted to the batch system.
+    If 'batch' is specified, a runscript will be written and submitted to the batch system.
     Otherwise, the executable will be run directly on the current system.
 
     :param driver_class: Class of driver object to instantiate.
@@ -180,7 +180,7 @@ def _execute(
     :param key_path: Path of keys to config block to use.
     :param schema_file: The JSON Schema file to use for validation.
     :param stdin_ok: OK to read from stdin?
-    :return: ``True`` if task completes without raising an exception.
+    :return: True if task completes without raising an exception.
     """
     kwargs = dict(
         config=ensure_data_source(str2path(config), stdin_ok),


### PR DESCRIPTION
**Synopsis**

Since only docstrings in API code will be rendered to HTML, RST formatting elsewhere is unnecessary, inconsistent, and requires maintenance.

**Type**

- [x] Documentation

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
