### PR TITLE
Combine string containers

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -30,7 +30,7 @@ from uwtools.config.validator import validate_internal
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.scheduler import JobScheduler
-from uwtools.strings import EC, STR
+from uwtools.strings import STR
 from uwtools.utils.file import writable
 
 if TYPE_CHECKING:
@@ -48,7 +48,7 @@ class _ECFlowDef:
         cfgobj = config if isinstance(config, YAMLConfig) else YAMLConfig(config)
         cfgobj.dereference()
         validate(cfgobj)
-        self._config = cfgobj.data[EC.ecflow][EC.suitedef]
+        self._config = cfgobj.data[STR.ecflow][STR.suitedef]
         self._scheduler = self._config.get(STR.scheduler)
         self._d = Defs()
         log.debug("Adding workflow components to suite definition.")
@@ -117,44 +117,44 @@ class _ECFlowDef:
             match tag:
                 # Tree buiding cases
 
-                case EC.family:
+                case STR.family:
                     self._add_node(subconfig, Family(name), node, refs)
-                case EC.families:
+                case STR.families:
                     self._expand_block(subconfig, name, Family, node, refs)
-                case EC.task:
+                case STR.task:
                     self._add_node(subconfig, Task(name), node, refs)
-                case EC.tasks:
+                case STR.tasks:
                     self._expand_block(subconfig, name, Task, node, refs)
 
                 # Node attribute cases
 
-                case EC.defstatus:
+                case STR.defstatus:
                     node.add_defstatus(getattr(DState, subconfig))
-                case EC.events:
+                case STR.events:
                     for event in subconfig:
                         if isinstance(event, list):
                             node.add_event(*event)
                         else:
                             node.add_event(event)
-                case EC.inlimits:
+                case STR.inlimits:
                     add_items(node.add_inlimit, subconfig)
-                case EC.labels:
+                case STR.labels:
                     add_items(node.add_label, subconfig)
-                case EC.late:
+                case STR.late:
                     node.add_late(Late(**subconfig))
-                case EC.limits:
+                case STR.limits:
                     add_items(node.add_limit, subconfig)
-                case EC.meters:
+                case STR.meters:
                     add_items(node.add_meter, subconfig)
-                case EC.repeat:  # Only one repeat is allowed per node.
+                case STR.repeat:  # Only one repeat is allowed per node.
                     self._add_repeat(subconfig, name, node)
-                case EC.script:
+                case STR.script:
                     self._create_ecf_script(subconfig, node)
-                case EC.trigger:  # Only one trigger is allowed per node.
+                case STR.trigger:  # Only one trigger is allowed per node.
                     node.add_trigger(subconfig)
-                case EC.vars:  # add_variable accepts a dict.
+                case STR.vars:  # add_variable accepts a dict.
                     node.add_variable(subconfig)
-                case EC.expand:  # Already processed by _expand_block.
+                case STR.expand:  # Already processed by _expand_block.
                     pass
                 case _:
                     msg = f"Unrecognized tag: {tag}"
@@ -169,15 +169,15 @@ class _ECFlowDef:
         :param node: The node to add the repeat to.
         """
         match name:
-            case EC.date:
+            case STR.date:
                 repeat = RepeatDate
-            case EC.datelist | EC.enumerated | EC.string:
+            case STR.datelist | STR.enumerated | STR.string:
                 repeat = RepeatEnumerated
-            case EC.datetime:
+            case STR.datetime:
                 repeat = RepeatDateTime
-            case EC.day:
+            case STR.day:
                 repeat = RepeatDay
-            case EC.int:
+            case STR.int:
                 repeat = RepeatInteger
 
         # The schema-checked config blocks for each of these will be the variable and either the
@@ -185,7 +185,7 @@ class _ECFlowDef:
         # ensure their order is either (argument, start, end, [step]) or (argument, list).
         args = [
             config.get(k)
-            for k in (EC.variable, EC.start, EC.end, EC.step, EC.list)
+            for k in (STR.variable, STR.start, STR.end, STR.step, STR.list)
             if config.get(k) is not None
         ]
         node.add_repeat(repeat(*args))
@@ -197,14 +197,14 @@ class _ECFlowDef:
         for key, subconfig in self._config.items():
             tag, name = self._tag_name(key)
             match tag:
-                case EC.extern:
+                case STR.extern:
                     for ext in subconfig:
                         self._d.add_extern(ext)
-                case EC.vars:
+                case STR.vars:
                     self._d.add_variable(subconfig)
-                case EC.suite:
+                case STR.suite:
                     self._add_node(subconfig, Suite(name), self._d)
-                case EC.suites:
+                case STR.suites:
                     self._expand_block(subconfig, name, Suite, self._d)
 
     def _create_ecf_script(self, config: dict, task: Task) -> None:
@@ -216,25 +216,25 @@ class _ECFlowDef:
         """
         scheduler = (
             self._jobscheduler(
-                account=config.get(EC.account, ""),
-                execution=config.get(EC.execution, ""),
-                rundir=config.get(EC.rundir, ""),
+                account=config.get(STR.account, ""),
+                execution=config.get(STR.execution, ""),
+                rundir=config.get(STR.rundir, ""),
             )
             if self._scheduler
             else None
         )
         execution = config[STR.execution]
         try:
-            cmd = execution[EC.incantation]
+            cmd = execution[STR.incantation]
         except KeyError as e:
             msg = "The execution block for %s must include 'incantation'" % task.name()
             raise UWConfigError(msg) from e
         script_contents = self._ecflowscript(
             execution=[cmd],
-            manual=config.get(EC.manual, f"Script to run {task.name()}"),
-            envcmds=execution.get(EC.envcmds, []),
-            pre_includes=config.get(EC.pre_includes, []),
-            post_includes=config.get(EC.post_includes, []),
+            manual=config.get(STR.manual, f"Script to run {task.name()}"),
+            envcmds=execution.get(STR.envcmds, []),
+            pre_includes=config.get(STR.pre_includes, []),
+            post_includes=config.get(STR.post_includes, []),
             scheduler=scheduler,
         )
 
@@ -323,7 +323,7 @@ class _ECFlowDef:
         :param refs: Variable/value pairs used in higher-level expand blocks.
         """
         refs = refs if refs is not None else {}
-        expand = config[EC.expand]
+        expand = config[STR.expand]
 
         # Check to make sure all lists are the same length.
         try:
@@ -340,10 +340,10 @@ class _ECFlowDef:
             new_block = YAMLConfig({name: config}).dereference(context={"ec": new_refs})
             new_name = list(new_block.keys())[0]
             args = {
-                EC.config: new_block[new_name],
-                EC.node: nodetype(new_name),
-                EC.parent: parent,
-                EC.refs: new_refs,
+                STR.config: new_block[new_name],
+                STR.node: nodetype(new_name),
+                STR.parent: parent,
+                STR.refs: new_refs,
             }
             self._add_node(**args)
 
@@ -411,7 +411,7 @@ def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
     :return: ``True`` if the config conforms to the schema.
     :raises: ``UWConfigError`` if validation fails.
     """
-    kwargs: dict = {"schema_name": EC.ecflow, "desc": "ecFlow config"}
+    kwargs: dict = {"schema_name": STR.ecflow, "desc": "ecFlow config"}
     if isinstance(config, (dict, YAMLConfig)):
         kwargs["config_data"] = config
     else:

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -540,7 +540,7 @@ def server(
     cfg = YAMLConfig(config)
     cfg.dereference()
     validate(cfg)
-    server_cfg = cfg.data[EC.ecflow][EC.server]
+    server_cfg = cfg.data[STR.ecflow][STR.server]
     if not insecure:
         _provision_ssl()
     rundir = Path(server_cfg["ECF_HOME"])

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -180,7 +180,6 @@ class _STR(_ValsMatchKeys):
     scripts_dir: str = _
     search_path: str = _
     server: str = _
-    server: str = _
     sfc_climo_gen: str = _
     shave: str = _
     show_schema: str = _

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -24,60 +24,6 @@ class _ValsMatchKeys:
 
 
 @dataclass(frozen=True)
-class _EC(_ValsMatchKeys):
-    """
-    EcFlow-specific strings.
-    """
-
-    account: str = _
-    config: str = _
-    date: str = _
-    datelist: str = _
-    datetime: str = _
-    day: str = _
-    defstatus: str = _
-    ecflow: str = _
-    end: str = _
-    enumerated: str = _
-    envcmds: str = _
-    events: str = _
-    execution: str = _
-    expand: str = _
-    extern: str = _
-    families: str = _
-    family: str = _
-    inlimits: str = _
-    int: str = _
-    incantation: str = _
-    labels: str = _
-    late: str = _
-    limits: str = _
-    list: str = _
-    manual: str = _
-    meters: str = _
-    node: str = _
-    parent: str = _
-    post_includes: str = _
-    pre_includes: str = _
-    refs: str = _
-    repeat: str = _
-    rundir: str = _
-    script: str = _
-    server: str = _
-    start: str = _
-    step: str = _
-    string: str = _
-    suite: str = _
-    suitedef: str = _
-    suites: str = _
-    task: str = _
-    tasks: str = _
-    trigger: str = _
-    variable: str = _
-    vars: str = _
-
-
-@dataclass(frozen=True)
 class _FORMAT(_ValsMatchKeys):
     """
     Format names.
@@ -135,16 +81,28 @@ class _STR(_ValsMatchKeys):
     copy: str = _
     cycle: str = _
     database: str = _
+    date: str = _
+    datelist: str = _
+    datetime: str = _
+    day: str = _
+    defstatus: str = _
     dry_run: str = _
     ecflow: str = _
+    end: str = _
     enkf: str = _
+    enumerated: str = _
     env: str = _
     envcmds: str = _
     esg_grid: str = _
+    events: str = _
     executable: str = _
     execute: str = _
     execution: str = _
+    expand: str = _
+    extern: str = _
     fallback: str = _
+    families: str = _
+    family: str = _
     file: str = _
     filter_topo: str = _
     format1: str = _
@@ -158,18 +116,27 @@ class _STR(_ValsMatchKeys):
     help: str = _
     hsi: str = _
     htar: str = _
+    incantation: str = _
+    inlimits: str = _
     input_file: str = _
     input_format: str = _
+    int: str = _
     ioda: str = _
     iterate: str = _
     jedi: str = _
     key_eq_val_pairs: str = _
     key_path: str = _
+    labels: str = _
+    late: str = _
     leadtime: str = _
+    limits: str = _
     link: str = _
+    list: str = _
     make_hgrid: str = _
     make_solo_mosaic: str = _
     makedirs: str = _
+    manual: str = _
+    meters: str = _
     mode: str = _
     module: str = _
     mpas: str = _
@@ -178,21 +145,27 @@ class _STR(_ValsMatchKeys):
     mpiargs: str = _
     mpicmd: str = _
     namelist: str = _
+    node: str = _
     notready: str = _
     orog: str = _
     orog_gsl: str = _
     output_dir: str = _
     output_file: str = _
     output_format: str = _
+    parent: str = _
     path1: str = _
     path2: str = _
     platform: str = _
+    post_includes: str = _
+    pre_includes: str = _
     properties: str = _
     quiet: str = _
     rate: str = _
     ready: str = _
     realize: str = _
+    refs: str = _
     render: str = _
+    repeat: str = _
     report: str = _
     rocoto: str = _
     run: str = _
@@ -200,13 +173,21 @@ class _STR(_ValsMatchKeys):
     scheduler: str = _
     schema_file: str = _
     schism: str = _
+    script: str = _
     scripts_dir: str = _
     search_path: str = _
+    server: str = _
     sfc_climo_gen: str = _
     shave: str = _
     show_schema: str = _
     stacksize: str = _
+    start: str = _
     stdout: str = _
+    step: str = _
+    string: str = _
+    suite: str = _
+    suitedef: str = _
+    suites: str = _
     symlink: str = _
     target_dir: str = _
     task: str = _
@@ -215,6 +196,7 @@ class _STR(_ValsMatchKeys):
     threads: str = _
     total: str = _
     translate: str = _
+    trigger: str = _
     ungrib: str = _
     update_file: str = _
     update_format: str = _
@@ -231,6 +213,8 @@ class _STR(_ValsMatchKeys):
     values_file: str = _
     values_format: str = _
     values_needed: str = _
+    variable: str = _
+    vars: str = _
     verbose: str = _
     version: str = _
     workflow: str = _
@@ -239,6 +223,5 @@ class _STR(_ValsMatchKeys):
 
 # Public
 
-EC = _EC()
 FORMAT = _FORMAT()
 STR = _STR()


### PR DESCRIPTION
**Synopsis**

To avoid confusion about where to define string constants, combine the `EC` and `STR` string containers. For now, the `FORMAT` container remains, since its class offers some helper methods specific to data formats.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
