### PR TITLE
Submit job via bash

### DIFF
--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, fields
+from shutil import which
 from typing import TYPE_CHECKING, Any
 
 from uwtools.exceptions import UWConfigError
@@ -90,7 +91,7 @@ class JobScheduler(ABC):
         cmd = f"{self._submit_cmd} {runscript.name}"
         if submit_file:
             cmd = "set -o pipefail && %s 2>&1 | tee %s" % (cmd, submit_file.name)
-        success, _ = run_shell_cmd(cmd=cmd, cwd=f"{runscript.parent}", executable="/bin/bash")
+        success, _ = run_shell_cmd(cmd=cmd, cwd=f"{runscript.parent}", executable=which("bash"))
         return success
 
     # Private methods

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -90,7 +90,7 @@ class JobScheduler(ABC):
         cmd = f"{self._submit_cmd} {runscript.name}"
         if submit_file:
             cmd = "set -o pipefail && %s 2>&1 | tee %s" % (cmd, submit_file.name)
-        success, _ = run_shell_cmd(cmd=cmd, cwd=f"{runscript.parent}")
+        success, _ = run_shell_cmd(cmd=cmd, cwd=f"{runscript.parent}", executable="/bin/bash")
         return success
 
     # Private methods

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -2,6 +2,7 @@
 Tests for uwtools.scheduler module.
 """
 
+from shutil import which
 from typing import Any
 from unittest.mock import patch
 
@@ -124,7 +125,7 @@ def test_JobScheduler_submit_job(schedulerobj, supply_submit_file, tmp_path):
             cmd = f"set -o pipefail && sub {runscript.name} 2>&1 | tee {submit_file.name}"
         else:
             cmd = f"sub {runscript.name}"
-        run_shell_cmd.assert_called_once_with(cmd=cmd, cwd=str(tmp_path), executable="/bin/bash")
+        run_shell_cmd.assert_called_once_with(cmd=cmd, cwd=str(tmp_path), executable=which("bash"))
 
 
 def test_JobScheduler__directive_separator(schedulerobj):

--- a/src/uwtools/tests/test_scheduler.py
+++ b/src/uwtools/tests/test_scheduler.py
@@ -124,7 +124,7 @@ def test_JobScheduler_submit_job(schedulerobj, supply_submit_file, tmp_path):
             cmd = f"set -o pipefail && sub {runscript.name} 2>&1 | tee {submit_file.name}"
         else:
             cmd = f"sub {runscript.name}"
-        run_shell_cmd.assert_called_once_with(cmd=cmd, cwd=str(tmp_path))
+        run_shell_cmd.assert_called_once_with(cmd=cmd, cwd=str(tmp_path), executable="/bin/bash")
 
 
 def test_JobScheduler__directive_separator(schedulerobj):

--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -25,14 +25,22 @@ def test_utils_processing_run_shell_cmd__failure(caplog, logged, quiet):
     assert check("  expr: division by zero")
 
 
+@mark.parametrize("executable", ["/bin/bash", None])
 @mark.parametrize("log_output", [True, False])
 @mark.parametrize("quiet", [True, False])
-def test_utils_processing_run_shell_cmd__success(caplog, logged, log_output, quiet, tmp_path):
+def test_utils_processing_run_shell_cmd__success(
+    caplog, executable, logged, log_output, quiet, tmp_path
+):
     cmd = "echo hello $FOO"
     if quiet:
         log.setLevel(logging.INFO)
     success, _ = processing.run_shell_cmd(
-        cmd=cmd, cwd=tmp_path, env={"FOO": "bar"}, log_output=log_output, quiet=quiet
+        cmd=cmd,
+        cwd=tmp_path,
+        env={"FOO": "bar"},
+        log_output=log_output,
+        quiet=quiet,
+        executable=executable,
     )
     assert success
     if quiet:

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -20,6 +20,7 @@ def run_shell_cmd(
     log_output: bool | None = False,
     taskname: str | None = None,
     quiet: bool | None = None,
+    executable: str | None = None,
 ) -> tuple[bool, str]:
     """
     Run a command in a shell.
@@ -30,6 +31,7 @@ def run_shell_cmd(
     :param log_output: Log output from successful cmd? (Error output is always logged.)
     :param taskname: Name of task executing this command, for logging.
     :param quiet: Log INFO messages as DEBUG.
+    :param executable: Interpreter to use (e.g. "/bin/bash")
     :return: A result object providing combined stder/stdout output and success values.
     """
     pre = f"{taskname}: " if taskname else ""
@@ -43,10 +45,11 @@ def run_shell_cmd(
     logfunc = log.debug if quiet else log.info
     logfunc(msg, pre)
     logfunc("%s  %s", pre, cmd)
+    kwargs: dict = dict(cwd=cwd, encoding="utf=8", env=env, shell=True, stderr=STDOUT, text=True)  # noqa: S604
+    if executable:
+        kwargs["executable"] = executable
     try:
-        output = check_output(
-            cmd, cwd=cwd, encoding="utf=8", env=env, shell=True, stderr=STDOUT, text=True
-        )
+        output = check_output(cmd, **kwargs)  # noqa: S603
         success = True
     except CalledProcessError as e:
         output = e.output


### PR DESCRIPTION
**Synopsis**

`JobScheduler.submit_job` runs `set -o pipefail` in its subprocess command to ensure that failure of the primary command (and not `tee`, which the primary command's output is piped to) causes the subprocess to fail. This command is supported by `bash`, but not by other shells, and Python defaults to using `/bin/sh`, which may or may not be `bash`.

Add support to `run_shell_cmd` for specifying the interpreter, and have `submit_job` specify `bash`, via a `which` call to find it on `PATH`.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
