### PR TITLE
Stricter control of ECF_ variables in suite-definition files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extlinks = {
     "condev": ("https://github.com/maddenp/condev/%s", "%s"),
     "coverage": ("https://coverage.readthedocs.io/en/7.3.4/%s", "%s"),
     "docformatter": ("https://docformatter.readthedocs.io/en/stable/%s", "%s"),
-    "ecflow": ("https://ecflow.readthedocs.io/en/latest/%s", "%s"),
+    "ecflow": ("https://ecflow.readthedocs.io/en/5.16.0/%s", "%s"),
     "fre-nctools": ("https://github.com/NOAA-GFDL/FRE-NCtools/blob/main/src/make-hgrid/%s", "%s"),
     "github-docs": ("https://docs.github.com/en/%s", "%s"),
     "iotaa-readme": ("https://github.com/maddenp/iotaa/blob/main/README.md#%s", "%s"),

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -24,6 +24,8 @@ UW YAML Keys
 
 ``scheduler:`` -- Optional. The batch scheduler to use when generating ``.ecf`` scripts. Supported values are ``lsf``, ``pbs``, and ``slurm``. When set, the scheduler's directives are automatically added to generated ``.ecf`` scripts. Omit this key if scripts are not needed or if no batch directives are required.
 
+.. _ecflow_suite_level_vars:
+
 ``vars:`` -- Optional. A mapping of variable name/value pairs set as ecFlow edit variables at the workflow (``Defs``) level. These become globally accessible within the suite. For example:
 
 .. code-block:: yaml
@@ -32,6 +34,10 @@ UW YAML Keys
      vars:
        ECF_HOME: /path/to/ecf
        ACCOUNT: myproject
+
+Variables beginning with ``ECF_`` are reserved by ecFlow and a defined set are supported: :ecflow:`suite definition variables<ug/user_manual/ecflow_variables/ecflow_suite_definition_variables.html>`, and :ecflow:`generated variables<ug/user_manual/ecflow_variables/generated_variables.html>`. Values for the latter are automatically supplied by the ecFlow server for use in ``.ecf`` scripts, but can be overriden by users in a suite-definition file.
+
+See the :ecflow:`ecFlow documentation<ug/user_manual/ecflow_variables/index.html>` for more information on available variables and their meanings.
 
 ``extern:`` -- Optional. A list of external node paths to declare in the suite definition. Useful for triggering tasks across suites. For example:
 
@@ -95,6 +101,8 @@ The following attributes may appear under any suite, family, or task node:
        MEMBER: "001"
      script:
        ...
+
+See :ref:`this section <ecflow_suite_level_vars>` for more information on ``ECF_`` and other variables that can be set on nodes as well as at the suite level.
 
 ``trigger:`` -- A string expression defining the conditions under which a node may run (see :ecflow:`ecflow.Trigger <python_api/Trigger.html>`). Only one ``trigger:`` is allowed per node. For example:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - python {{ pymin }}
     - setuptools
   run:
-    - ecflow 5.16.*
+    - ecflow 5.16.* # keep docs/conf.py in-sync
     - f90nml >=1.4,<1.6
     - iotaa 1.6.*
     - jinja2 >=3.1,<3.2

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -744,16 +744,16 @@
           "additionalProperties": false,
           "properties": {
             "ECF_CHECK": {
-              "description": "Name of the checkpoint file. Prepended with <host>.<port> at runtime.",
+              "description": "Name of the checkpoint file, pepended with <host>.<port> at runtime",
               "type": "string"
             },
             "ECF_CHECKINTERVAL": {
-              "description": "Interval in seconds between automatic checkpoint saves.",
+              "description": "Interval in seconds between automatic checkpoint saves",
               "minimum": 1,
               "type": "integer"
             },
             "ECF_CHECKMODE": {
-              "description": "Checkpoint mode: when to auto-save the checkpoint file.",
+              "description": "Checkpoint mode: when to auto-save the checkpoint file",
               "enum": [
                 "CHECK_ALWAYS",
                 "CHECK_NEVER",
@@ -762,72 +762,72 @@
               "type": "string"
             },
             "ECF_CHECKOLD": {
-              "description": "Name of the backup checkpoint file. Prepended with <host>.<port> at runtime.",
+              "description": "Name of the backup checkpoint file, prepended with <host>.<port> at runtime",
               "type": "string"
             },
             "ECF_CUSTOM_PASSWD": {
-              "description": "Password file for users whose UID on the remote client does not match that on the server.",
+              "description": "Password file for users whose UID on the remote client does not match that on the server",
               "type": "string"
             },
             "ECF_HOME": {
-              "description": "Root directory for all .ecf script files.",
+              "description": "Root directory for all .ecf script files",
               "type": "string"
             },
             "ECF_INTERVAL": {
-              "description": "Period in seconds for traversing dependencies and submitting jobs.",
+              "description": "Period in seconds for traversing dependencies and submitting jobs",
               "minimum": 1,
               "type": "integer"
             },
             "ECF_JOB_CMD": {
-              "description": "Shell command used for job submission.",
+              "description": "Shell command used for job submission",
               "type": "string"
             },
             "ECF_KILL_CMD": {
-              "description": "Shell command used to kill a running job.",
+              "description": "Shell command used to kill a running job",
               "type": "string"
             },
             "ECF_LISTS": {
-              "description": "File listing users permitted to access the server via client commands.",
+              "description": "File listing users permitted to access the server via client commands",
               "type": "string"
             },
             "ECF_LOG": {
-              "description": "Name of the log file. Prepended with <host>.<port> at runtime.",
+              "description": "Name of the log file, prepended with <host>.<port> at runtime",
               "type": "string"
             },
             "ECF_MICRODEF": {
-              "description": "Character used for ECF pre-processing and variable substitution in .ecf scripts.",
+              "description": "Character used for ECF pre-processing and variable substitution in .ecf scripts",
               "maxLength": 1,
               "minLength": 1,
               "type": "string"
             },
             "ECF_PASSWD": {
-              "description": "Password file for full user password authentication.",
+              "description": "Password file for full user password authentication",
               "type": "string"
             },
             "ECF_PRUNE_NODE_LOG": {
-              "description": "Prune node log/edit history older than this number of days when checkpoint is loaded.",
+              "description": "Prune node log/edit history older than this number of days when checkpoint is loaded",
               "minimum": 0,
               "type": "integer"
             },
             "ECF_STATUS_CMD": {
-              "description": "Command executed by the server to obtain the current status of a job.",
+              "description": "Command executed by the server to obtain the current status of a job",
               "type": "string"
             },
             "ECF_TASK_THRESHOLD": {
-              "description": "Report tasks taking longer than this threshold (in milliseconds).",
+              "description": "Report tasks taking longer than this threshold (in milliseconds)",
               "minimum": 0,
               "type": "integer"
             },
             "ECF_URL": {
-              "description": "URL path appended to ECF_URL_BASE for browser-based job status links.",
+              "description": "URL path appended to ECF_URL_BASE for browser-based job status links",
               "type": "string"
             },
             "ECF_URL_BASE": {
-              "description": "Base URL used with ECF_URL for browser-based job status links.",
+              "description": "Base URL used with ECF_URL for browser-based job status links",
               "type": "string"
             },
             "ECF_URL_CMD": {
-              "description": "Command executed by the client to open a browser with the job status URL.",
+              "description": "Command executed by the client to open a browser with the job status URL",
               "type": "string"
             }
           },

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -744,7 +744,7 @@
           "additionalProperties": false,
           "properties": {
             "ECF_CHECK": {
-              "description": "Name of the checkpoint file, pepended with <host>.<port> at runtime",
+              "description": "Name of the checkpoint file, prepended with <host>.<port> at runtime",
               "type": "string"
             },
             "ECF_CHECKINTERVAL": {

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -357,7 +357,7 @@
           "type": "string"
         },
         "vars": {
-          "type": "object"
+          "$ref": "#/$defs/vars"
         }
       },
       "type": "object"
@@ -560,6 +560,24 @@
           "type": "object"
         }
       ]
+    },
+    "vars": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!ECF_)": {}
+      },
+      "properties": {
+        "ECF_MICRO": {
+          "maxLength": 1,
+          "minLength": 1,
+          "type": "string"
+        },
+        "ECF_TRIES": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": "object"
     }
   },
   "properties": {
@@ -737,7 +755,7 @@
               "type": "string"
             },
             "vars": {
-              "type": "object"
+              "$ref": "#/$defs/vars"
             }
           },
           "type": "object"

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -582,7 +582,7 @@
           "additionalProperties": false,
           "properties": {
             "ECF_CHECK": {
-              "description": "Name of the checkpoint file. Prepended with <host>.<port> at runtime. Default: ecf.check",
+              "description": "Name of the checkpoint file. Prepended with <host>.<port> at runtime.",
               "type": "string"
             },
             "ECF_CHECKINTERVAL": {
@@ -600,11 +600,11 @@
               "type": "string"
             },
             "ECF_CHECKOLD": {
-              "description": "Name of the backup checkpoint file. Prepended with <host>.<port> at runtime. Default: ecf.check.b",
+              "description": "Name of the backup checkpoint file. Prepended with <host>.<port> at runtime.",
               "type": "string"
             },
             "ECF_CUSTOM_PASSWD": {
-              "description": "Password file for users whose UID on the remote client does not match that on the server. Default: <host>.<port>.ecf.custom_passwd",
+              "description": "Password file for users whose UID on the remote client does not match that on the server.",
               "type": "string"
             },
             "ECF_HOME": {
@@ -625,11 +625,11 @@
               "type": "string"
             },
             "ECF_LISTS": {
-              "description": "File listing users permitted to access the server via client commands. Default: <host>.<port>.ecf.lists",
+              "description": "File listing users permitted to access the server via client commands.",
               "type": "string"
             },
             "ECF_LOG": {
-              "description": "Name of the log file. Prepended with <host>.<port> at runtime. Default: ecf.log",
+              "description": "Name of the log file. Prepended with <host>.<port> at runtime.",
               "type": "string"
             },
             "ECF_MICRODEF": {
@@ -639,8 +639,12 @@
               "type": "string"
             },
             "ECF_PASSWD": {
-              "description": "Password file for full user password authentication. Default: <host>.<port>.ecf.passwd",
+              "description": "Password file for full user password authentication.",
               "type": "string"
+            },
+            "ECF_PRUNE_NODE_LOG": {
+              "description": "Prune node log/edit history older than this number of days when checkpoint is loaded.",
+              "type": "integer"
             },
             "ECF_STATUS_CMD": {
               "description": "Command executed by the server to obtain the current status of a job.",

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -644,6 +644,7 @@
             },
             "ECF_PRUNE_NODE_LOG": {
               "description": "Prune node log/edit history older than this number of days when checkpoint is loaded.",
+              "minimum": 0,
               "type": "integer"
             },
             "ECF_STATUS_CMD": {

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -567,14 +567,158 @@
         "^(?!ECF_)": {}
       },
       "properties": {
+        "ECF_CHECK": {
+          "description": "Name of the checkpoint file",
+          "type": "string"
+        },
+        "ECF_CHECKINTERVAL": {
+          "description": "The interval, in seconds, between saving current state into the checkpoint file",
+          "type": "string"
+        },
+        "ECF_CHECKMODE": {
+          "description": "The mode to perform checkpoint file saving",
+          "type": "string"
+        },
+        "ECF_CHECKOLD": {
+          "description": "Name of the backup of the checkpoint file",
+          "type": "string"
+        },
+        "ECF_CLOCK": {
+          "description": "Composite weekday, month, Day Of the Week, Day Of Year",
+          "type": "string"
+        },
+        "ECF_CUSTOM_PASSWD": {
+          "description": "Default custom password string to replace the real password, when communicating with the server",
+          "type": "string"
+        },
+        "ECF_DATE": {
+          "description": "Single date in format YYYYMMDD",
+          "pattern": "^[0-9]{8}$",
+          "type": "string"
+        },
+        "ECF_DUMMY_TASK": {
+          "description": "Stops job generation checking from raising errors",
+          "type": "string"
+        },
+        "ECF_EXTN": {
+          "description": "Overrides the default script extension",
+          "type": "string"
+        },
+        "ECF_FILES": {
+          "description": "Alternate location for ecFlow files",
+          "type": "string"
+        },
+        "ECF_HOME": {
+          "description": "Home for all the ecFlow files",
+          "type": "string"
+        },
+        "ECF_INCLUDE": {
+          "description": "Path for the include files",
+          "type": "string"
+        },
+        "ECF_INTERVAL": {
+          "description": "The interval between check of time dependencies and job submission",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ECF_JOB": {
+          "description": "Name of the job file created by ECF",
+          "type": "string"
+        },
+        "ECF_JOBOUT": {
+          "description": "The filename of the job output",
+          "type": "string"
+        },
+        "ECF_JOB_CMD": {
+          "description": "Command to be executed to send a job",
+          "type": "string"
+        },
+        "ECF_JULIAN": {
+          "description": "Julian day",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ECF_KILL_CMD": {
+          "description": "Command to be executed to kill a job",
+          "type": "string"
+        },
+        "ECF_LISTS": {
+          "description": "Name of the ecFlow white-list file",
+          "type": "string"
+        },
+        "ECF_LOG": {
+          "description": "Name of the ecFlow history, or log file",
+          "type": "string"
+        },
         "ECF_MICRO": {
+          "description": "The default preprocessor character used during variable substitution",
           "maxLength": 1,
           "minLength": 1,
           "type": "string"
         },
-        "ECF_TRIES": {
+        "ECF_NAME": {
+          "description": "Full name of the task",
+          "type": "string"
+        },
+        "ECF_NODE": {
+          "description": "The hostname of the machine running ECF",
+          "type": "string"
+        },
+        "ECF_OUT": {
+          "description": "Alternate location for job and cmd output files",
+          "type": "string"
+        },
+        "ECF_PASS": {
+          "description": "Password for the task to enable login to ECF",
+          "type": "string"
+        },
+        "ECF_PASSWD": {
+          "description": "Default password string to replace the real password, when communicating with the server",
+          "type": "string"
+        },
+        "ECF_PORT": {
+          "description": "The ecFlow server TCP port number",
           "minimum": 1,
           "type": "integer"
+        },
+        "ECF_RID": {
+          "description": "The Request ID of the job (only for running jobs)",
+          "type": "string"
+        },
+        "ECF_SCRIPT": {
+          "description": "The full pathname for the script",
+          "type": "string"
+        },
+        "ECF_STATUS_CMD": {
+          "description": "Command to be executed to retrieve the job status",
+          "type": "string"
+        },
+        "ECF_TIME": {
+          "description": "Time of the suites clock, HH:MM",
+          "pattern": "^[0-9]{2}:[0-9]{2}$",
+          "type": "string"
+        },
+        "ECF_TRIES": {
+          "description": "The default number of tries for each task",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ECF_TRYNO": {
+          "description": "The current try number for the task ",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ECF_URL": {
+          "description": "The stem suffix for the job URL",
+          "type": "string"
+        },
+        "ECF_URL_BASE": {
+          "description": "The base prefix for the job URL",
+          "type": "string"
+        },
+        "ECF_URL_CMD": {
+          "description": "Command to be executed to open job files in a browser",
+          "type": "string"
         }
       },
       "type": "object"

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -747,10 +747,11 @@ def test_schema_ecflow_server():
         assert "is not of type 'integer'\n" in err(k, "x")
         assert "is less than the minimum of 1" in err(k, 0)
         assert not err(k, 1)
-    # ECF_TASK_THRESHOLD must be an integer >= 0:
-    assert "is not of type 'integer'\n" in err("ECF_TASK_THRESHOLD", "x")
-    assert "is less than the minimum of 0" in err("ECF_TASK_THRESHOLD", -1)
-    assert not err("ECF_TASK_THRESHOLD", 0)
+    # These values must be integers >= 0:
+    for k in ["ECF_PRUNE_NODE_LOG", "ECF_TASK_THRESHOLD"]:
+        assert "is not of type 'integer'\n" in err(k, "x")
+        assert "is less than the minimum of 0" in err(k, -1)
+        assert not err(k, 0)
     # ECF_CHECKMODE is constrained to an enum:
     assert "is not one of" in err("ECF_CHECKMODE", "bad")
     assert not err("ECF_CHECKMODE", "CHECK_ON_TIME")

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1106,6 +1106,70 @@ def test_schema_ecflow_suitedef_execution():
     assert "is less than the minimum" in errors({"incantation": "/path/to/run.sh", "threads": 0})
 
 
+def test_schema_ecflow_suitedef_refs_vars():
+    errors = schema_validator("ecflow", "$defs", "vars")
+    err = lambda k, v: errors({k: v})
+    # Non-ECF_ keys are accepted with any value type:
+    assert not errors({"MY_VAR": "hello", "count": 42, "flag": True})
+    # Unknown ECF_ keys are rejected:
+    assert "does not match any of the regexes" in err("ECF_BOGUS", "x")
+    # These values must be strings:
+    ks_string = [
+        "ECF_CHECK",
+        "ECF_CHECKINTERVAL",
+        "ECF_CHECKMODE",
+        "ECF_CHECKOLD",
+        "ECF_CLOCK",
+        "ECF_CUSTOM_PASSWD",
+        "ECF_DUMMY_TASK",
+        "ECF_EXTN",
+        "ECF_FILES",
+        "ECF_HOME",
+        "ECF_INCLUDE",
+        "ECF_JOB",
+        "ECF_JOBOUT",
+        "ECF_JOB_CMD",
+        "ECF_KILL_CMD",
+        "ECF_LISTS",
+        "ECF_LOG",
+        "ECF_NAME",
+        "ECF_NODE",
+        "ECF_OUT",
+        "ECF_PASS",
+        "ECF_PASSWD",
+        "ECF_RID",
+        "ECF_SCRIPT",
+        "ECF_STATUS_CMD",
+        "ECF_URL",
+        "ECF_URL_BASE",
+        "ECF_URL_CMD",
+    ]
+    for k in ks_string:
+        assert "is not of type 'string'\n" in err(k, 42)
+        assert not err(k, "value")
+    # These values must be integers >= 1:
+    for k in ["ECF_INTERVAL", "ECF_JULIAN", "ECF_PORT", "ECF_TRIES", "ECF_TRYNO"]:
+        assert "is not of type 'integer'\n" in err(k, "x")
+        assert "is less than the minimum of 1" in err(k, 0)
+        assert not err(k, 1)
+    # ECF_MICRO must be a single character:
+    assert "is not of type 'string'\n" in err("ECF_MICRO", 1)
+    assert "should be non-empty" in err("ECF_MICRO", "")
+    assert "is too long" in err("ECF_MICRO", "ab")
+    assert not err("ECF_MICRO", "%")
+    # ECF_DATE must be an 8-digit string:
+    assert "is not of type 'string'\n" in err("ECF_DATE", 20260101)
+    assert "does not match" in err("ECF_DATE", "2026abc1")
+    assert "does not match" in err("ECF_DATE", "2026010")
+    assert "does not match" in err("ECF_DATE", "202601011")
+    assert not err("ECF_DATE", "20260101")
+    # ECF_TIME must match HH:MM pattern:
+    assert "is not of type 'string'\n" in err("ECF_TIME", 1200)
+    assert "does not match" in err("ECF_TIME", "1200")
+    assert "does not match" in err("ECF_TIME", "12:00:00")
+    assert not err("ECF_TIME", "12:00")
+
+
 # enkf
 
 


### PR DESCRIPTION
**Synopsis**

In ecFlow `suitedef` `vars` blocks, accept:

- Arbitrary user-defined variables if they do not start with `ECF_`
- A fixed set of `ECF_` vars accepted in ecFlow suite-definition files.

I've tried to define the correct set of `ECF_` variables based on the ecFlow documentation, but I'm not certain the docs are complete or correct, so we may need to update this as we learn more.

Note that, as stated [here](https://ecflow.readthedocs.io/en/5.16.0/ug/user_manual/ecflow_variables/generated_variables.html), variables automatically _generated_ by ecFlow are permitted to be overwritten by users in suite definitions. So, these variables appear in the new schema in addition to those defined [here](https://ecflow.readthedocs.io/en/5.16.0/ug/user_manual/ecflow_variables/ecflow_suite_definition_variables.html) explicitly as suite-definition variables.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
