### PR TITLE
Support ECF_SSL configuration for uw ecflow server

### DIFF
--- a/docs/sections/user_guide/cli/tools/ecflow.rst
+++ b/docs/sections/user_guide/cli/tools/ecflow.rst
@@ -125,7 +125,7 @@ Examples
 
      uw ecflow server --config-file server.yaml --port 54321
 
-* To start a server using a custom SSL certificate directory:
+bi* To start a server using a custom SSL certificate directory:
 
   .. code-block:: text
 
@@ -140,7 +140,7 @@ Examples
          ECF_HOME: /path/to/run
          ECF_SSL_DIR: /shared/certs/ecflow
 
-  ``ECF_SSL_DIR`` overrides the default certificate location (``$HOME/.ecflowrc/ssl``) for both the server and any ``ecflow_client`` commands that inherit the environment, including job child commands. See :ref:`ecflow_workflows` for full server YAML documentation.
+  ``ECF_SSL_DIR`` overrides the default certificate location (``$HOME/.ecflowrc/ssl``) used by ``uw ecflow server`` to provision SSL certificates. See :ref:`ecflow_workflows` for full server YAML documentation.
 
 * To emit a JSON report of the server details to ``stdout``:
 

--- a/docs/sections/user_guide/cli/tools/ecflow.rst
+++ b/docs/sections/user_guide/cli/tools/ecflow.rst
@@ -125,6 +125,23 @@ Examples
 
      uw ecflow server --config-file server.yaml --port 54321
 
+* To start a server using a custom SSL certificate directory:
+
+  .. code-block:: text
+
+     uw ecflow server --config-file server.yaml
+
+  Where ``server.yaml`` contains:
+
+  .. code-block:: yaml
+
+     ecflow:
+       server:
+         ECF_HOME: /path/to/run
+         ECF_SSL_DIR: /shared/certs/ecflow
+
+  ``ECF_SSL_DIR`` overrides the default certificate location (``$HOME/.ecflowrc/ssl``) for both the server and any ``ecflow_client`` commands that inherit the environment, including job child commands. See :ref:`ecflow_workflows` for full server YAML documentation.
+
 * To emit a JSON report of the server details to ``stdout``:
 
   .. code-block:: text
@@ -137,13 +154,15 @@ Examples
 
      {
        "vars": {
+         "ECF_HOME": "/path/to/run",
          "ECF_HOST": "server.hostname.com",
          "ECF_PORT": "54321",
-         "ECF_SSL": "1"
+         "ECF_SSL": "1",
+         "ECF_SSL_DIR": "/shared/certs/ecflow"
        }
      }
 
-  ``ECF_SSL`` is included only when SSL security is enabled (i.e. when ``--insecure`` is not given).
+  ``ECF_SSL`` is included only when SSL security is enabled (i.e. when ``--insecure`` is not given). ``ECF_SSL_DIR`` is included only when set in the config.
 
 .. _cli_ecflow_validate_examples:
 

--- a/docs/sections/user_guide/cli/tools/ecflow.rst
+++ b/docs/sections/user_guide/cli/tools/ecflow.rst
@@ -125,11 +125,11 @@ Examples
 
      uw ecflow server --config-file server.yaml --port 54321
 
-* To start a server using a custom SSL certificate:
+* To start a server using a named certificate triplet:
 
   .. code-block:: text
 
-     uw ecflow server --config-file server.yaml
+     uw ecflow server --config-file server.yaml --port 8888
 
   Where ``server.yaml`` contains:
 
@@ -138,9 +138,9 @@ Examples
      ecflow:
        server:
          ECF_HOME: /path/to/run
-         ECF_SSL: /shared/certs/server.crt
+         ECF_SSL: myhost.8888
 
-  ``ECF_SSL`` accepts ``true`` to enable SSL using the default certificate location (``$HOME/.ecflowrc/ssl/server.crt``), or a path string to use a specific certificate file. See :ref:`ecflow_workflows` for full server YAML documentation.
+  ``ECF_SSL`` accepts ``true`` to enable SSL using the default certificate triplet (``server.crt`` / ``server.key`` / ``dh2048.pem``) in ``$HOME/.ecflowrc/ssl``, or a ``<host>.<port>`` prefix string to select a named certificate triplet (``<host>.<port>.crt`` / ``.key`` / ``.pem``) from the same directory. The ``--port`` value must match the port in the prefix when using a named triplet. See :ref:`ecflow_workflows` for full server YAML documentation.
 
 * To emit a JSON report of the server details to ``stdout``:
 
@@ -156,8 +156,8 @@ Examples
        "vars": {
          "ECF_HOME": "/path/to/run",
          "ECF_HOST": "server.hostname.com",
-         "ECF_PORT": "54321",
-         "ECF_SSL": "/shared/certs/server.crt"
+         "ECF_PORT": "8888",
+         "ECF_SSL": "myhost.8888"
        }
      }
 

--- a/docs/sections/user_guide/cli/tools/ecflow.rst
+++ b/docs/sections/user_guide/cli/tools/ecflow.rst
@@ -125,7 +125,7 @@ Examples
 
      uw ecflow server --config-file server.yaml --port 54321
 
-bi* To start a server using a custom SSL certificate directory:
+* To start a server using a custom SSL certificate:
 
   .. code-block:: text
 
@@ -138,9 +138,9 @@ bi* To start a server using a custom SSL certificate directory:
      ecflow:
        server:
          ECF_HOME: /path/to/run
-         ECF_SSL_DIR: /shared/certs/ecflow
+         ECF_SSL: /shared/certs/server.crt
 
-  ``ECF_SSL_DIR`` overrides the default certificate location (``$HOME/.ecflowrc/ssl``) used by ``uw ecflow server`` to provision SSL certificates. See :ref:`ecflow_workflows` for full server YAML documentation.
+  ``ECF_SSL`` accepts ``true`` to enable SSL using the default certificate location (``$HOME/.ecflowrc/ssl/server.crt``), or a path string to use a specific certificate file. See :ref:`ecflow_workflows` for full server YAML documentation.
 
 * To emit a JSON report of the server details to ``stdout``:
 
@@ -157,12 +157,11 @@ bi* To start a server using a custom SSL certificate directory:
          "ECF_HOME": "/path/to/run",
          "ECF_HOST": "server.hostname.com",
          "ECF_PORT": "54321",
-         "ECF_SSL": "1",
-         "ECF_SSL_DIR": "/shared/certs/ecflow"
+         "ECF_SSL": "/shared/certs/server.crt"
        }
      }
 
-  ``ECF_SSL`` is included only when SSL security is enabled (i.e. when ``--insecure`` is not given). ``ECF_SSL_DIR`` is included only when set in the config.
+  ``ECF_SSL`` is included only when SSL security is enabled (i.e. when ``--insecure`` is not given and ``ECF_SSL`` is not ``false`` in the config).
 
 .. _cli_ecflow_validate_examples:
 

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -295,10 +295,10 @@ The ``uw ecflow server`` command reads configuration from an ``ecflow: server:``
 
 All keys in the ``server:`` block are passed as environment variables to ``ecflow_server``. ``ECF_HOME`` is the only required key.
 
-``ECF_SSL`` -- Optional. Controls SSL for the server. Accepts a boolean or a path string:
+``ECF_SSL`` -- Optional. Controls SSL for the server. Accepts a boolean or a ``<host>.<port>`` prefix string:
 
-- ``true`` (default when ``--insecure`` is not given): Enable SSL using the auto-provisioned certificate at ``$HOME/.ecflowrc/ssl/server.crt``.
-- A path string (e.g. ``/shared/certs/server.crt``): Enable SSL using the specified certificate file. The matching ``server.key`` and ``dh2048.pem`` must already exist alongside it.
+- ``true`` (default when ``--insecure`` is not given): Enable SSL using the auto-provisioned default certificate triplet (``server.crt`` / ``server.key`` / ``dh2048.pem``) in ``$HOME/.ecflowrc/ssl``.
+- A ``<host>.<port>`` string (e.g. ``myhost.8888``): Enable SSL using the named certificate triplet (``<host>.<port>.crt`` / ``.key`` / ``.pem``) in ``$HOME/.ecflowrc/ssl``. The files must already exist; they are not auto-generated.
 - ``false``: Disable SSL (equivalent to passing ``--insecure``).
 
 For example, to force use of a named certificate triplet when running on a static port:

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -282,6 +282,32 @@ Multiple expand variables of the same length may be provided together:
        MEM: ["01", "02"]
        LABEL: ["ctrl", "pert"]
 
+Server Configuration
+--------------------
+
+The ``uw ecflow server`` command reads configuration from an ``ecflow: server:`` block:
+
+.. code-block:: yaml
+
+   ecflow:
+     server:
+       ECF_HOME: /path/to/run
+
+All keys in the ``server:`` block are passed as environment variables to ``ecflow_server``. ``ECF_HOME`` is the only required key.
+
+``ECF_SSL_DIR`` -- Optional. A path to a directory containing SSL certificate files (``dh2048.pem``, ``server.crt``, ``server.key``). When set, overrides the default location of ``$HOME/.ecflowrc/ssl``. For example:
+
+.. code-block:: yaml
+
+   ecflow:
+     server:
+       ECF_HOME: /path/to/run
+       ECF_SSL_DIR: /shared/certs/ecflow
+
+Because ``ECF_SSL_DIR`` is a native ecflow environment variable, both ``ecflow_server`` and ``ecflow_client`` (including job child commands) read certificates from this directory automatically. Jobs that inherit ``ECF_SSL_DIR`` from the server environment will locate certificates without any additional symlinking.
+
+When ``--insecure`` is given to ``uw ecflow server``, SSL is disabled entirely and ``ECF_SSL_DIR`` is ignored.
+
 Generated Artifacts
 -------------------
 

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -285,7 +285,7 @@ Multiple expand variables of the same length may be provided together:
 Server Configuration
 --------------------
 
-The ``uw ecflow server`` command reads configuration from an ``ecflow: server:`` block:
+The ``uw ecflow server`` command reads configuration from an ``ecflow.server`` block:
 
 .. code-block:: yaml
 
@@ -295,13 +295,13 @@ The ``uw ecflow server`` command reads configuration from an ``ecflow: server:``
 
 All keys in the ``server:`` block are passed as environment variables to ``ecflow_server``. ``ECF_HOME`` is the only required key.
 
-``ECF_SSL`` -- Optional. Controls SSL for the server. Accepts a boolean or a ``<host>.<port>`` prefix string:
+``ECF_SSL`` -- Optional. Controls SSL for the server. Accepts a boolean or a certificate-filename prefix string:
 
 - ``true`` (default when ``--insecure`` is not given): Enable SSL using the auto-provisioned default certificate triplet (``server.crt`` / ``server.key`` / ``dh2048.pem``) in ``$HOME/.ecflowrc/ssl``.
-- A ``<host>.<port>`` string (e.g. ``myhost.8888``): Enable SSL using the named certificate triplet (``<host>.<port>.crt`` / ``.key`` / ``.pem``) in ``$HOME/.ecflowrc/ssl``. The files must already exist; they are not auto-generated.
+- A certificate-filename prefix string (e.g. ``myhost.8888``): Enable SSL using the specified certificate files. Files with the given prefix and the extensions ``.crt``, ``.key``, and ``.pem`` must exist under ``$HOME/.ecflowrc/ssl/``.
 - ``false``: Disable SSL (equivalent to passing ``--insecure``).
 
-For example, to force use of a named certificate triplet when running on a static port:
+For example, to use a certificate-filename prefix when running on a static port:
 
 .. code-block:: yaml
 

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -304,8 +304,6 @@ All keys in the ``server:`` block are passed as environment variables to ``ecflo
        ECF_HOME: /path/to/run
        ECF_SSL_DIR: /shared/certs/ecflow
 
-Because ``ECF_SSL_DIR`` is a native ecflow environment variable, both ``ecflow_server`` and ``ecflow_client`` (including job child commands) read certificates from this directory automatically. Jobs that inherit ``ECF_SSL_DIR`` from the server environment will locate certificates without any additional symlinking.
-
 When ``--insecure`` is given to ``uw ecflow server``, SSL is disabled entirely (no certificate provisioning occurs) and ``ECF_SSL_DIR`` has no effect.
 
 Generated Artifacts

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -306,7 +306,7 @@ All keys in the ``server:`` block are passed as environment variables to ``ecflo
 
 Because ``ECF_SSL_DIR`` is a native ecflow environment variable, both ``ecflow_server`` and ``ecflow_client`` (including job child commands) read certificates from this directory automatically. Jobs that inherit ``ECF_SSL_DIR`` from the server environment will locate certificates without any additional symlinking.
 
-When ``--insecure`` is given to ``uw ecflow server``, SSL is disabled entirely and ``ECF_SSL_DIR`` is ignored.
+When ``--insecure`` is given to ``uw ecflow server``, SSL is disabled entirely (no certificate provisioning occurs) and ``ECF_SSL_DIR`` has no effect.
 
 Generated Artifacts
 -------------------

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -301,14 +301,16 @@ All keys in the ``server:`` block are passed as environment variables to ``ecflo
 - A path string (e.g. ``/shared/certs/server.crt``): Enable SSL using the specified certificate file. The matching ``server.key`` and ``dh2048.pem`` must already exist alongside it.
 - ``false``: Disable SSL (equivalent to passing ``--insecure``).
 
-For example, to use a shared certificate:
+For example, to force use of a named certificate triplet when running on a static port:
 
 .. code-block:: yaml
 
    ecflow:
      server:
        ECF_HOME: /path/to/run
-       ECF_SSL: /shared/certs/server.crt
+       ECF_SSL: myhost.8888
+
+The ``--port`` value passed to ``uw ecflow server`` must match the port in the prefix. The three files ``myhost.8888.crt``, ``myhost.8888.key``, and ``myhost.8888.pem`` must already exist in ``$HOME/.ecflowrc/ssl``; they are not auto-generated.
 
 When ``--insecure`` is given to ``uw ecflow server``, SSL is disabled entirely regardless of the ``ECF_SSL`` setting.
 

--- a/docs/sections/user_guide/yaml/ecflow.rst
+++ b/docs/sections/user_guide/yaml/ecflow.rst
@@ -295,16 +295,22 @@ The ``uw ecflow server`` command reads configuration from an ``ecflow: server:``
 
 All keys in the ``server:`` block are passed as environment variables to ``ecflow_server``. ``ECF_HOME`` is the only required key.
 
-``ECF_SSL_DIR`` -- Optional. A path to a directory containing SSL certificate files (``dh2048.pem``, ``server.crt``, ``server.key``). When set, overrides the default location of ``$HOME/.ecflowrc/ssl``. For example:
+``ECF_SSL`` -- Optional. Controls SSL for the server. Accepts a boolean or a path string:
+
+- ``true`` (default when ``--insecure`` is not given): Enable SSL using the auto-provisioned certificate at ``$HOME/.ecflowrc/ssl/server.crt``.
+- A path string (e.g. ``/shared/certs/server.crt``): Enable SSL using the specified certificate file. The matching ``server.key`` and ``dh2048.pem`` must already exist alongside it.
+- ``false``: Disable SSL (equivalent to passing ``--insecure``).
+
+For example, to use a shared certificate:
 
 .. code-block:: yaml
 
    ecflow:
      server:
        ECF_HOME: /path/to/run
-       ECF_SSL_DIR: /shared/certs/ecflow
+       ECF_SSL: /shared/certs/server.crt
 
-When ``--insecure`` is given to ``uw ecflow server``, SSL is disabled entirely (no certificate provisioning occurs) and ``ECF_SSL_DIR`` has no effect.
+When ``--insecure`` is given to ``uw ecflow server``, SSL is disabled entirely regardless of the ``ECF_SSL`` setting.
 
 Generated Artifacts
 -------------------

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -5,7 +5,7 @@ Custom Tags
 
 Tags are used to denote the type of a YAML node when converting to a Python object.
 
-UW supports the use of standard YAML tags, denoted by `!!` as defined `here <http://yaml.org/type/index.html>`_. Additionally, UW defines the following tags to support use cases not covered by standard tags, denoted by `!` and described in detail below. Where standard YAML tags are applied to their values immediately, application of UW YAML tags is delayed until after Jinja2 expressions in tagged values are dereferenced.
+UW supports the use of standard YAML tags, denoted by `!!` as defined `here <https://yaml.org/spec/1.2.2/#tags>`_. Additionally, UW defines the following tags to support use cases not covered by standard tags, denoted by `!` and described in detail below. Where standard YAML tags are applied to their values immediately, application of UW YAML tags is delayed until after Jinja2 expressions in tagged values are dereferenced.
 
 Tags may be implicit:
 

--- a/docs/sections/user_guide/yaml/tags.rst
+++ b/docs/sections/user_guide/yaml/tags.rst
@@ -5,7 +5,7 @@ Custom Tags
 
 Tags are used to denote the type of a YAML node when converting to a Python object.
 
-UW supports the use of standard YAML tags, denoted by `!!` as defined `here <https://yaml.org/spec/1.2.2/#tags>`_. Additionally, UW defines the following tags to support use cases not covered by standard tags, denoted by `!` and described in detail below. Where standard YAML tags are applied to their values immediately, application of UW YAML tags is delayed until after Jinja2 expressions in tagged values are dereferenced.
+UW supports the use of standard YAML tags, denoted by `!!` as defined in the `YAML specification <https://yaml.org/>`_. Additionally, UW defines the following tags to support use cases not covered by standard tags, denoted by `!` and described in detail below. Where standard YAML tags are applied to their values immediately, application of UW YAML tags is delayed until after Jinja2 expressions in tagged values are dereferenced.
 
 Tags may be implicit:
 

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -8,11 +8,13 @@ import json
 import os
 import random
 import re
+import shutil
 import signal
 import socket
 from copy import deepcopy
 from pathlib import Path
 from subprocess import STDOUT, CalledProcessError, check_output
+from subprocess import run as subprocess_run
 from textwrap import dedent
 from threading import Event, Thread, current_thread
 from time import sleep
@@ -426,6 +428,19 @@ _SSL_DHPARAM = "dh2048.pem"
 _SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
 
 
+def _openssl() -> str:
+    """
+    Return the absolute path to the openssl executable.
+
+    :raises UWError: If openssl is not found on PATH.
+    """
+    path = shutil.which("openssl")
+    if path is None:
+        msg = "openssl not found on PATH"
+        raise UWError(msg)
+    return path
+
+
 def _provision_ssl(ssl_dir: Path | None = None) -> None:
     """
     Ensure SSL certificates exist in the given directory (or the default $HOME/.ecflowrc/ssl).
@@ -467,8 +482,16 @@ def _ssl_generate_key(path: Path) -> None:
     :raises UWError: If openssl reports failure.
     """
     log.info("Generating SSL private key: %s", path)
-    success, _ = run_shell_cmd(f"umask 0077 && openssl genrsa -out {path} 2048")
-    if not success:
+    old_umask = os.umask(0o077)
+    try:
+        result = subprocess_run(  # noqa: S603
+            [_openssl(), "genrsa", "-out", str(path), "2048"],
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        os.umask(old_umask)
+    if result.returncode != 0:
         msg = f"Failed to generate SSL private key at {path}"
         raise UWError(msg)
 
@@ -483,12 +506,29 @@ def _ssl_generate_cert(path: Path, key_path: Path) -> None:
     """
     hostname = socket.gethostname()
     log.info("Generating SSL certificate: %s", path)
-    cmd = (
-        f"umask 0077 && openssl req -x509 -key {key_path} -new -out {path} "
-        f"-days 3650 -subj '/CN={hostname}'"
-    )
-    success, _ = run_shell_cmd(cmd)
-    if not success:
+    old_umask = os.umask(0o077)
+    try:
+        result = subprocess_run(  # noqa: S603
+            [
+                _openssl(),
+                "req",
+                "-x509",
+                "-key",
+                str(key_path),
+                "-new",
+                "-out",
+                str(path),
+                "-days",
+                "3650",
+                "-subj",
+                f"/CN={hostname}",
+            ],
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        os.umask(old_umask)
+    if result.returncode != 0:
         msg = f"Failed to generate SSL certificate at {path}"
         raise UWError(msg)
 
@@ -501,8 +541,16 @@ def _ssl_generate_dhparam(path: Path) -> None:
     :raises UWError: If openssl reports failure.
     """
     log.info("Generating DH parameters: %s", path)
-    success, _ = run_shell_cmd(f"umask 0077 && openssl dhparam -out {path} 2048")
-    if not success:
+    old_umask = os.umask(0o077)
+    try:
+        result = subprocess_run(  # noqa: S603
+            [_openssl(), "dhparam", "-out", str(path), "2048"],
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        os.umask(old_umask)
+    if result.returncode != 0:
         msg = f"Failed to generate DH parameters at {path}"
         raise UWError(msg)
 

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -470,6 +470,28 @@ def _provision_ssl() -> None:
     log.info("SSL credentials written to %s", _SSL_DIR)
 
 
+def _check_ssl_named(prefix: str) -> None:
+    """
+    Verify that the named SSL certificate triplet for 'prefix' exists in $HOME/.ecflowrc/ssl.
+
+    The required files are <prefix>.crt, <prefix>.key, and <prefix>.pem. These files must be
+    supplied by the user; this function only checks for their existence and raises UWError if any
+    are missing.
+
+    :param prefix: The <host>.<port> prefix identifying the certificate triplet.
+    :raises UWError: If one or more of the required files are missing.
+    """
+    extensions = [".crt", ".key", ".pem"]
+    missing = [f"{prefix}{ext}" for ext in extensions if not (_SSL_DIR / f"{prefix}{ext}").exists()]
+    if missing:
+        msg = (
+            f"SSL certificate file(s) {missing} not found in {_SSL_DIR}. "
+            f"Provide all required files for prefix '{prefix}'."
+        )
+        raise UWError(msg)
+    log.info("Using existing SSL certificates for prefix '%s' in %s", prefix, _SSL_DIR)
+
+
 def _ssl_generate_key(path: Path) -> None:
     """
     Generate a 2048-bit RSA private key (no password) at 'path'.
@@ -556,12 +578,16 @@ def server(
     cfg.dereference()
     validate(cfg)
     server_cfg = cfg.data[STR.ecflow][STR.server]
-    # ECF_SSL in the YAML config can be: True (SSL on, default cert location), a string path to a
-    # specific certificate file, False (SSL off), or absent (defaults to SSL on).
+    # ECF_SSL in the YAML config can be: True (SSL on, default cert location), a <host>.<port>
+    # prefix string selecting named certificates in $HOME/.ecflowrc/ssl, False (SSL off), or absent
+    # (defaults to SSL on with auto-provisioned default certificates).
     ecf_ssl = server_cfg.get("ECF_SSL")
     ssl_on = not insecure and ecf_ssl is not False
-    if ssl_on and not isinstance(ecf_ssl, str):
-        _provision_ssl()
+    if ssl_on:
+        if isinstance(ecf_ssl, str):
+            _check_ssl_named(ecf_ssl)
+        else:
+            _provision_ssl()
     rundir = Path(server_cfg["ECF_HOME"])
     # Exclude ECF_SSL from cfg_vars: it is handled explicitly below (it may be a bool in the YAML,
     # and ecFlow interprets any non-empty env string as an SSL flag or cert path).

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -419,41 +419,44 @@ def realize(
 # Private helpers
 
 
-_SSL_DIR = Path.home() / ".ecflowrc" / "ssl"
+_SSL_DEFAULT_DIR = Path.home() / ".ecflowrc" / "ssl"
 _SSL_KEY = "server.key"
 _SSL_CERT = "server.crt"
 _SSL_DHPARAM = "dh2048.pem"
 _SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
 
 
-def _provision_ssl() -> None:
+def _provision_ssl(ssl_dir: Path | None = None) -> None:
     """
-    Ensure SSL certificates exist in $HOME/.ecflowrc/ssl.
+    Ensure SSL certificates exist in the given directory (or the default $HOME/.ecflowrc/ssl).
 
     If all required files exist, logs that they will be reused. If the directory exists but is
     missing one or more required files, logs an error and raises UWError. If the directory does not
     exist, creates it and generates the required SSL files using openssl.
 
+    :param ssl_dir: Directory in which to provision certificates. Defaults to $HOME/.ecflowrc/ssl
+        when None.
     :raises UWError: If the SSL directory exists but is incomplete, or if certificate generation
         fails.
     """
-    existing = [f for f in _SSL_FILES if (_SSL_DIR / f).exists()]
+    cert_dir = ssl_dir if ssl_dir is not None else _SSL_DEFAULT_DIR
+    existing = [f for f in _SSL_FILES if (cert_dir / f).exists()]
     if len(existing) == len(_SSL_FILES):
-        log.info("Using existing SSL certificates in %s", _SSL_DIR)
+        log.info("Using existing SSL certificates in %s", cert_dir)
         return
     if existing:
         missing = sorted(set(_SSL_FILES) - set(existing))
         msg = (
-            f"SSL directory {_SSL_DIR} exists but is missing required file(s): {missing}. "
+            f"SSL directory {cert_dir} exists but is missing required file(s): {missing}. "
             "Provide all required files or remove the directory to allow regeneration."
         )
         raise UWError(msg)
-    log.info("Creating SSL directory %s", _SSL_DIR)
-    _SSL_DIR.mkdir(parents=True, exist_ok=True)
-    _ssl_generate_key(_SSL_DIR / _SSL_KEY)
-    _ssl_generate_cert(_SSL_DIR / _SSL_CERT, _SSL_DIR / _SSL_KEY)
-    _ssl_generate_dhparam(_SSL_DIR / _SSL_DHPARAM)
-    log.info("SSL credentials written to %s", _SSL_DIR)
+    log.info("Creating SSL directory %s", cert_dir)
+    cert_dir.mkdir(parents=True, exist_ok=True)
+    _ssl_generate_key(cert_dir / _SSL_KEY)
+    _ssl_generate_cert(cert_dir / _SSL_CERT, cert_dir / _SSL_KEY)
+    _ssl_generate_dhparam(cert_dir / _SSL_DHPARAM)
+    log.info("SSL credentials written to %s", cert_dir)
 
 
 def _ssl_generate_key(path: Path) -> None:
@@ -541,7 +544,8 @@ def server(
     validate(cfg)
     server_cfg = cfg.data[STR.ecflow][STR.server]
     if not insecure:
-        _provision_ssl()
+        ssl_dir = Path(v) if (v := server_cfg.get("ECF_SSL_DIR")) is not None else None
+        _provision_ssl(ssl_dir=ssl_dir)
     rundir = Path(server_cfg["ECF_HOME"])
     cfg_vars = {k: str(v) for k, v in server_cfg.items()}
     env = {**os.environ, **cfg_vars}

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -14,7 +14,6 @@ import socket
 from copy import deepcopy
 from pathlib import Path
 from subprocess import STDOUT, CalledProcessError, check_output
-from subprocess import run as subprocess_run
 from textwrap import dedent
 from threading import Event, Thread, current_thread
 from time import sleep
@@ -428,7 +427,7 @@ _SSL_DHPARAM = "dh2048.pem"
 _SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
 
 
-def _openssl() -> str:
+def _openssl() -> Path:
     """
     Return the absolute path to the openssl executable.
 
@@ -438,7 +437,7 @@ def _openssl() -> str:
     if path is None:
         msg = "openssl not found on PATH"
         raise UWError(msg)
-    return path
+    return Path(path)
 
 
 def _provision_ssl(ssl_dir: Path | None = None) -> None:
@@ -482,16 +481,9 @@ def _ssl_generate_key(path: Path) -> None:
     :raises UWError: If openssl reports failure.
     """
     log.info("Generating SSL private key: %s", path)
-    old_umask = os.umask(0o077)
-    try:
-        result = subprocess_run(  # noqa: S603
-            [_openssl(), "genrsa", "-out", str(path), "2048"],
-            capture_output=True,
-            check=False,
-        )
-    finally:
-        os.umask(old_umask)
-    if result.returncode != 0:
+    cmd = f"umask 077 && {_openssl()} genrsa -out {path} 2048"
+    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+    if not success:
         msg = f"Failed to generate SSL private key at {path}"
         raise UWError(msg)
 
@@ -506,29 +498,12 @@ def _ssl_generate_cert(path: Path, key_path: Path) -> None:
     """
     hostname = socket.gethostname()
     log.info("Generating SSL certificate: %s", path)
-    old_umask = os.umask(0o077)
-    try:
-        result = subprocess_run(  # noqa: S603
-            [
-                _openssl(),
-                "req",
-                "-x509",
-                "-key",
-                str(key_path),
-                "-new",
-                "-out",
-                str(path),
-                "-days",
-                "3650",
-                "-subj",
-                f"/CN={hostname}",
-            ],
-            capture_output=True,
-            check=False,
-        )
-    finally:
-        os.umask(old_umask)
-    if result.returncode != 0:
+    cmd = (
+        f"umask 077 && {_openssl()} req -x509 -key {key_path}"
+        f" -new -out {path} -days 3650 -subj /CN={hostname}"
+    )
+    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+    if not success:
         msg = f"Failed to generate SSL certificate at {path}"
         raise UWError(msg)
 
@@ -541,16 +516,9 @@ def _ssl_generate_dhparam(path: Path) -> None:
     :raises UWError: If openssl reports failure.
     """
     log.info("Generating DH parameters: %s", path)
-    old_umask = os.umask(0o077)
-    try:
-        result = subprocess_run(  # noqa: S603
-            [_openssl(), "dhparam", "-out", str(path), "2048"],
-            capture_output=True,
-            check=False,
-        )
-    finally:
-        os.umask(old_umask)
-    if result.returncode != 0:
+    cmd = f"umask 077 && {_openssl()} dhparam -out {path} 2048"
+    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+    if not success:
         msg = f"Failed to generate DH parameters at {path}"
         raise UWError(msg)
 

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -420,7 +420,7 @@ def realize(
 # Private helpers
 
 
-_SSL_DEFAULT_DIR = Path.home() / ".ecflowrc" / "ssl"
+_SSL_DIR = Path.home() / ".ecflowrc" / "ssl"
 _SSL_KEY = "server.key"
 _SSL_CERT = "server.crt"
 _SSL_DHPARAM = "dh2048.pem"
@@ -440,37 +440,34 @@ def _openssl() -> Path:
     return Path(path)
 
 
-def _provision_ssl(ssl_dir: Path | None = None) -> None:
+def _provision_ssl() -> None:
     """
-    Ensure SSL certificates exist in the given directory (or the default $HOME/.ecflowrc/ssl).
+    Ensure SSL certificates exist in $HOME/.ecflowrc/ssl.
 
     If all required files exist, logs that they will be reused. If the directory exists but is
     missing one or more required files, logs an error and raises UWError. If the directory does not
     exist, creates it and generates the required SSL files using openssl.
 
-    :param ssl_dir: Directory in which to provision certificates. Defaults to $HOME/.ecflowrc/ssl
-        when None.
     :raises UWError: If the SSL directory exists but is incomplete, or if certificate generation
         fails.
     """
-    cert_dir = ssl_dir if ssl_dir is not None else _SSL_DEFAULT_DIR
-    existing = [f for f in _SSL_FILES if (cert_dir / f).exists()]
+    existing = [f for f in _SSL_FILES if (_SSL_DIR / f).exists()]
     if len(existing) == len(_SSL_FILES):
-        log.info("Using existing SSL certificates in %s", cert_dir)
+        log.info("Using existing SSL certificates in %s", _SSL_DIR)
         return
     if existing:
         missing = sorted(set(_SSL_FILES) - set(existing))
         msg = (
-            f"SSL directory {cert_dir} exists but is missing required file(s): {missing}. "
+            f"SSL directory {_SSL_DIR} exists but is missing required file(s): {missing}. "
             "Provide all required files or remove the directory to allow regeneration."
         )
         raise UWError(msg)
-    log.info("Creating SSL directory %s", cert_dir)
-    cert_dir.mkdir(parents=True, exist_ok=True)
-    _ssl_generate_key(cert_dir / _SSL_KEY)
-    _ssl_generate_cert(cert_dir / _SSL_CERT, cert_dir / _SSL_KEY)
-    _ssl_generate_dhparam(cert_dir / _SSL_DHPARAM)
-    log.info("SSL credentials written to %s", cert_dir)
+    log.info("Creating SSL directory %s", _SSL_DIR)
+    _SSL_DIR.mkdir(parents=True, exist_ok=True)
+    _ssl_generate_key(_SSL_DIR / _SSL_KEY)
+    _ssl_generate_cert(_SSL_DIR / _SSL_CERT, _SSL_DIR / _SSL_KEY)
+    _ssl_generate_dhparam(_SSL_DIR / _SSL_DHPARAM)
+    log.info("SSL credentials written to %s", _SSL_DIR)
 
 
 def _ssl_generate_key(path: Path) -> None:
@@ -559,22 +556,27 @@ def server(
     cfg.dereference()
     validate(cfg)
     server_cfg = cfg.data[STR.ecflow][STR.server]
-    if not insecure:
-        ssl_dir = Path(v) if (v := server_cfg.get("ECF_SSL_DIR")) is not None else None
-        _provision_ssl(ssl_dir=ssl_dir)
+    # ECF_SSL in the YAML config can be: True (SSL on, default cert location), a string path to a
+    # specific certificate file, False (SSL off), or absent (defaults to SSL on).
+    ecf_ssl = server_cfg.get("ECF_SSL")
+    ssl_on = not insecure and ecf_ssl is not False
+    if ssl_on and not isinstance(ecf_ssl, str):
+        _provision_ssl()
     rundir = Path(server_cfg["ECF_HOME"])
-    cfg_vars = {k: str(v) for k, v in server_cfg.items()}
+    # Exclude ECF_SSL from cfg_vars: it is handled explicitly below (it may be a bool in the YAML,
+    # and ecFlow interprets any non-empty env string as an SSL flag or cert path).
+    cfg_vars = {k: str(v) for k, v in server_cfg.items() if k != "ECF_SSL"}
     env = {**os.environ, **cfg_vars}
-    if insecure:
+    if ssl_on:
+        env["ECF_SSL"] = ecf_ssl if isinstance(ecf_ssl, str) else "1"
+    else:
         # ecFlow enables SSL if ECF_SSL is set to any value, so unset it for an insecure server.
         env.pop("ECF_SSL", None)
-    else:
-        env["ECF_SSL"] = "1"
     # Server variables to echo back when reporting: all config-supplied ECF_* values plus the
     # runtime-determined host and SSL setting. ECF_PORT is added once the port is known.
     report_vars = {**cfg_vars, "ECF_HOST": socket.gethostname()}
-    if not insecure:
-        report_vars["ECF_SSL"] = "1"
+    if ssl_on:
+        report_vars["ECF_SSL"] = ecf_ssl if isinstance(ecf_ssl, str) else "1"
     thread = _ServerThread(target=_server_start, args=[rundir, env, port, insecure])
     # ecflow_client must speak SSL to a secure server, else requests fail with a TLS mismatch.
     ssl_opt = "" if insecure else "--ssl "

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -810,7 +810,7 @@
               "type": "integer"
             },
             "ECF_SSL_DIR": {
-              "description": "Custom SSL certificate directory; overrides the default $HOME/.ecflowrc/ssl. Recognized by ecflow_server and ecflow_client (including job child commands), so jobs inheriting this variable will also locate certificates here without symlinking.",
+              "description": "Custom SSL certificate directory; overrides the default $HOME/.ecflowrc/ssl",
               "type": "string"
             },
             "ECF_STATUS_CMD": {

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -810,7 +810,7 @@
               "type": "integer"
             },
             "ECF_SSL": {
-              "description": "SSL mode: true to enable SSL using the default certificate location ($HOME/.ecflowrc/ssl/server.crt), a path string to use a specific certificate file, or false to disable SSL",
+              "description": "SSL mode: true to enable SSL using the default certificate triplet (server.crt/server.key/dh2048.pem) in $HOME/.ecflowrc/ssl, a <host>.<port> prefix string to select a named certificate triplet (<host>.<port>.crt/.key/.pem) from $HOME/.ecflowrc/ssl, or false to disable SSL",
               "oneOf": [
                 {
                   "type": "boolean"

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -809,9 +809,17 @@
               "minimum": 0,
               "type": "integer"
             },
-            "ECF_SSL_DIR": {
-              "description": "Custom SSL certificate directory; overrides the default $HOME/.ecflowrc/ssl",
-              "type": "string"
+            "ECF_SSL": {
+              "description": "SSL mode: true to enable SSL using the default certificate location ($HOME/.ecflowrc/ssl/server.crt), a path string to use a specific certificate file, or false to disable SSL",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              ]
             },
             "ECF_STATUS_CMD": {
               "description": "Command executed by the server to obtain the current status of a job",

--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -809,6 +809,10 @@
               "minimum": 0,
               "type": "integer"
             },
+            "ECF_SSL_DIR": {
+              "description": "Custom SSL certificate directory; overrides the default $HOME/.ecflowrc/ssl. Recognized by ecflow_server and ecflow_client (including job child commands), so jobs inheriting this variable will also locate certificates here without symlinking.",
+              "type": "string"
+            },
             "ECF_STATUS_CMD": {
               "description": "Command executed by the server to obtain the current status of a job",
               "type": "string"

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -705,7 +705,8 @@ def test_ecflow__provision_ssl__all_files_exist(logged, tmp_path):
     ssl_dir.mkdir(parents=True)
     for fname in ["dh2048.pem", "server.crt", "server.key"]:
         (ssl_dir / fname).touch()
-    ecflow._provision_ssl(ssl_dir=ssl_dir)
+    with patch.object(ecflow, "_SSL_DIR", ssl_dir):
+        ecflow._provision_ssl()
     assert logged("Using existing SSL certificates in")
 
 
@@ -713,8 +714,11 @@ def test_ecflow__provision_ssl__incomplete_dir_raises(tmp_path):
     ssl_dir = tmp_path / ".ecflowrc" / "ssl"
     ssl_dir.mkdir(parents=True)
     (ssl_dir / "server.crt").touch()
-    with raises(UWError, match="missing required file"):
-        ecflow._provision_ssl(ssl_dir=ssl_dir)
+    with (
+        patch.object(ecflow, "_SSL_DIR", ssl_dir),
+        raises(UWError, match="missing required file"),
+    ):
+        ecflow._provision_ssl()
 
 
 def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
@@ -726,8 +730,11 @@ def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
         Path(parts[parts.index("-out") + 1]).touch()
         return (True, "")
 
-    with patch.object(ecflow, "run_shell_cmd", side_effect=fake_run):
-        ecflow._provision_ssl(ssl_dir=ssl_dir)
+    with (
+        patch.object(ecflow, "_SSL_DIR", ssl_dir),
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run),
+    ):
+        ecflow._provision_ssl()
     assert ssl_dir.is_dir()
     assert (ssl_dir / "server.key").is_file()
     assert (ssl_dir / "server.crt").is_file()
@@ -857,22 +864,34 @@ def test_ecflow_server__accepts_config_types(server_mocks, config):
 
 def test_ecflow_server__calls_provision_ssl(server_mocks):
     ecflow.server(config=server_mocks.config_path, port=3141)
-    server_mocks.provision_ssl.assert_called_once_with(ssl_dir=None)
+    server_mocks.provision_ssl.assert_called_once_with()
 
 
-def test_ecflow_server__custom_ssl_dir_passed_to_provision(server_mocks):
+def test_ecflow_server__ecf_ssl_true_provisions_and_sets_env(server_mocks):
     m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL_DIR": "/shared/certs"}}}
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": True}}}
     ecflow.server(config=m.config_path, port=3141)
-    m.provision_ssl.assert_called_once_with(ssl_dir=Path("/shared/certs"))
-
-
-def test_ecflow_server__ecf_ssl_dir_in_env(server_mocks):
-    m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL_DIR": "/shared/certs"}}}
-    ecflow.server(config=m.config_path, port=3141)
+    m.provision_ssl.assert_called_once_with()
     _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
-    assert env["ECF_SSL_DIR"] == "/shared/certs"
+    assert env["ECF_SSL"] == "1"
+
+
+def test_ecflow_server__ecf_ssl_string_skips_provision_sets_cert(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "/shared/certs/server.crt"}}}
+    ecflow.server(config=m.config_path, port=3141)
+    m.provision_ssl.assert_not_called()
+    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
+    assert env["ECF_SSL"] == "/shared/certs/server.crt"
+
+
+def test_ecflow_server__ecf_ssl_false_skips_ssl(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": False}}}
+    ecflow.server(config=m.config_path, port=3141)
+    m.provision_ssl.assert_not_called()
+    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
+    assert "ECF_SSL" not in env
 
 
 def test_ecflow_server__insecure_skips_ssl(server_mocks):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -705,8 +705,7 @@ def test_ecflow__provision_ssl__all_files_exist(logged, tmp_path):
     ssl_dir.mkdir(parents=True)
     for fname in ["dh2048.pem", "server.crt", "server.key"]:
         (ssl_dir / fname).touch()
-    with patch.object(ecflow, "_SSL_DIR", ssl_dir):
-        ecflow._provision_ssl()
+    ecflow._provision_ssl(ssl_dir=ssl_dir)
     assert logged("Using existing SSL certificates in")
 
 
@@ -714,8 +713,8 @@ def test_ecflow__provision_ssl__incomplete_dir_raises(tmp_path):
     ssl_dir = tmp_path / ".ecflowrc" / "ssl"
     ssl_dir.mkdir(parents=True)
     (ssl_dir / "server.crt").touch()
-    with patch.object(ecflow, "_SSL_DIR", ssl_dir), raises(UWError, match="missing required file"):
-        ecflow._provision_ssl()
+    with raises(UWError, match="missing required file"):
+        ecflow._provision_ssl(ssl_dir=ssl_dir)
 
 
 def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
@@ -726,11 +725,8 @@ def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
         Path(cmd.split("-out ", 1)[1].split()[0]).touch()
         return (True, "")
 
-    with (
-        patch.object(ecflow, "_SSL_DIR", ssl_dir),
-        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run),
-    ):
-        ecflow._provision_ssl()
+    with patch.object(ecflow, "run_shell_cmd", side_effect=fake_run):
+        ecflow._provision_ssl(ssl_dir=ssl_dir)
     assert ssl_dir.is_dir()
     assert (ssl_dir / "server.key").is_file()
     assert (ssl_dir / "server.crt").is_file()
@@ -852,7 +848,22 @@ def test_ecflow_server__accepts_config_types(server_mocks, config):
 
 def test_ecflow_server__calls_provision_ssl(server_mocks):
     ecflow.server(config=server_mocks.config_path, port=3141)
-    server_mocks.provision_ssl.assert_called_once()
+    server_mocks.provision_ssl.assert_called_once_with(ssl_dir=None)
+
+
+def test_ecflow_server__custom_ssl_dir_passed_to_provision(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL_DIR": "/shared/certs"}}}
+    ecflow.server(config=m.config_path, port=3141)
+    m.provision_ssl.assert_called_once_with(ssl_dir=Path("/shared/certs"))
+
+
+def test_ecflow_server__ecf_ssl_dir_in_env(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL_DIR": "/shared/certs"}}}
+    ecflow.server(config=m.config_path, port=3141)
+    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
+    assert env["ECF_SSL_DIR"] == "/shared/certs"
 
 
 def test_ecflow_server__insecure_skips_ssl(server_mocks):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -743,6 +743,29 @@ def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
     assert logged("SSL credentials written to")
 
 
+def test_ecflow__check_ssl_named__all_files_exist(logged, tmp_path):
+    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
+    ssl_dir.mkdir(parents=True)
+    prefix = "myhost.3141"
+    for ext in [".crt", ".key", ".pem"]:
+        (ssl_dir / f"{prefix}{ext}").touch()
+    with patch.object(ecflow, "_SSL_DIR", ssl_dir):
+        ecflow._check_ssl_named(prefix)
+    assert logged("Using existing SSL certificates for prefix")
+
+
+def test_ecflow__check_ssl_named__missing_files_raises(tmp_path):
+    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
+    ssl_dir.mkdir(parents=True)
+    prefix = "myhost.3141"
+    (ssl_dir / f"{prefix}.crt").touch()
+    with (
+        patch.object(ecflow, "_SSL_DIR", ssl_dir),
+        raises(UWError, match="not found in"),
+    ):
+        ecflow._check_ssl_named(prefix)
+
+
 def test_ecflow__openssl__not_found():
     with (
         patch.object(ecflow.shutil, "which", return_value=None),
@@ -829,6 +852,7 @@ def server_mocks():
         patch.object(ecflow, "YAMLConfig", return_value=cfg) as yamlconfig,
         patch.object(ecflow, "validate") as validate,
         patch.object(ecflow, "_provision_ssl") as provision_ssl,
+        patch.object(ecflow, "_check_ssl_named") as check_ssl_named,
         patch.object(ecflow, "_ServerThread") as thread_cls,
         patch.object(ecflow.signal, "signal") as signal,
         patch.object(ecflow, "_server_wait") as server_wait,
@@ -841,6 +865,7 @@ def server_mocks():
             yamlconfig=yamlconfig,
             validate=validate,
             provision_ssl=provision_ssl,
+            check_ssl_named=check_ssl_named,
             thread_cls=thread_cls,
             thread=thread,
             signal=signal,
@@ -876,13 +901,14 @@ def test_ecflow_server__ecf_ssl_true_provisions_and_sets_env(server_mocks):
     assert env["ECF_SSL"] == "1"
 
 
-def test_ecflow_server__ecf_ssl_string_skips_provision_sets_cert(server_mocks):
+def test_ecflow_server__ecf_ssl_string_checks_named_cert(server_mocks):
     m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "/shared/certs/server.crt"}}}
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "myhost.3141"}}}
     ecflow.server(config=m.config_path, port=3141)
     m.provision_ssl.assert_not_called()
+    m.check_ssl_named.assert_called_once_with("myhost.3141")
     _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
-    assert env["ECF_SSL"] == "/shared/certs/server.crt"
+    assert env["ECF_SSL"] == "myhost.3141"
 
 
 def test_ecflow_server__ecf_ssl_false_skips_ssl(server_mocks):
@@ -897,6 +923,7 @@ def test_ecflow_server__ecf_ssl_false_skips_ssl(server_mocks):
 def test_ecflow_server__insecure_skips_ssl(server_mocks):
     ecflow.server(config=server_mocks.config_path, port=3141, insecure=True)
     server_mocks.provision_ssl.assert_not_called()
+    server_mocks.check_ssl_named.assert_not_called()
 
 
 def test_ecflow_server__secure_sets_ecf_ssl_env(server_mocks):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -720,12 +720,13 @@ def test_ecflow__provision_ssl__incomplete_dir_raises(tmp_path):
 def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
     ssl_dir = tmp_path / ".ecflowrc" / "ssl"
 
-    def fake_run(args, **_kwargs):
+    def fake_run(cmd, **_kwargs):
         # Emulate openssl by creating the file named after its "-out" argument.
-        Path(args[args.index("-out") + 1]).touch()
-        return Mock(returncode=0)
+        parts = cmd.split()
+        Path(parts[parts.index("-out") + 1]).touch()
+        return (True, "")
 
-    with patch.object(ecflow, "subprocess_run", side_effect=fake_run):
+    with patch.object(ecflow, "run_shell_cmd", side_effect=fake_run):
         ecflow._provision_ssl(ssl_dir=ssl_dir)
     assert ssl_dir.is_dir()
     assert (ssl_dir / "server.key").is_file()
@@ -747,14 +748,14 @@ def test_ecflow__ssl_generate_key__success(tmp_path):
     path = tmp_path / "server.key"
     ecflow._ssl_generate_key(path)
     assert path.is_file()
-    # os.umask(0o077) yields owner-only permissions on generated files.
+    # umask 077 in the shell command yields owner-only permissions on generated files.
     assert oct(path.stat().st_mode)[-3:] == "600"
 
 
 def test_ecflow__ssl_generate_key__failure(tmp_path):
     path = tmp_path / "server.key"
     with (
-        patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=1)),
+        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
         raises(UWError, match="Failed to generate SSL private key"),
     ):
         ecflow._ssl_generate_key(path)
@@ -767,7 +768,7 @@ def test_ecflow__ssl_generate_cert__success(tmp_path):
     ecflow._ssl_generate_key(key_path)
     ecflow._ssl_generate_cert(cert_path, key_path)
     assert cert_path.is_file()
-    # os.umask(0o077) yields owner-only permissions on generated files.
+    # umask 077 in the shell command yields owner-only permissions on generated files.
     assert oct(cert_path.stat().st_mode)[-3:] == "600"
 
 
@@ -775,7 +776,7 @@ def test_ecflow__ssl_generate_cert__failure(tmp_path):
     cert_path = tmp_path / "server.crt"
     key_path = tmp_path / "server.key"
     with (
-        patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=1)),
+        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
         raises(UWError, match="Failed to generate SSL certificate"),
     ):
         ecflow._ssl_generate_cert(cert_path, key_path)
@@ -785,21 +786,21 @@ def test_ecflow__ssl_generate_cert__failure(tmp_path):
 
 def test_ecflow__ssl_generate_dhparam__success(tmp_path):
     # DH-parameter generation is slow and entropy-dependent, so (unlike the key and cert tests,
-    # which exercise real openssl) mock the subprocess call and assert the argument list. The
+    # which exercise real openssl) mock the subprocess call and assert the command string. The
     # resulting 0600 permissions are verified for real by the key and cert tests, which share the
-    # os.umask(0o077) mechanism.
+    # umask 077 shell mechanism.
     path = tmp_path / "dh2048.pem"
-    with patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=0)) as mock_run:
+    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as mock_run:
         ecflow._ssl_generate_dhparam(path)
     mock_run.assert_called_once()
-    args = mock_run.call_args[0][0]
-    assert args == [ecflow._openssl(), "dhparam", "-out", str(path), "2048"]
-
+    cmd = mock_run.call_args.kwargs["cmd"]
+    assert "umask 077" in cmd
+    assert f"dhparam -out {path} 2048" in cmd
 
 def test_ecflow__ssl_generate_dhparam__failure(tmp_path):
     path = tmp_path / "dh2048.pem"
     with (
-        patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=1)),
+        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
         raises(UWError, match="Failed to generate DH parameters"),
     ):
         ecflow._ssl_generate_dhparam(path)

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -797,6 +797,7 @@ def test_ecflow__ssl_generate_dhparam__success(tmp_path):
     assert "umask 077" in cmd
     assert f"dhparam -out {path} 2048" in cmd
 
+
 def test_ecflow__ssl_generate_dhparam__failure(tmp_path):
     path = tmp_path / "dh2048.pem"
     with (

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -720,12 +720,12 @@ def test_ecflow__provision_ssl__incomplete_dir_raises(tmp_path):
 def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
     ssl_dir = tmp_path / ".ecflowrc" / "ssl"
 
-    def fake_run(cmd, **_kwargs):
+    def fake_run(args, **_kwargs):
         # Emulate openssl by creating the file named after its "-out" argument.
-        Path(cmd.split("-out ", 1)[1].split()[0]).touch()
-        return (True, "")
+        Path(args[args.index("-out") + 1]).touch()
+        return Mock(returncode=0)
 
-    with patch.object(ecflow, "run_shell_cmd", side_effect=fake_run):
+    with patch.object(ecflow, "subprocess_run", side_effect=fake_run):
         ecflow._provision_ssl(ssl_dir=ssl_dir)
     assert ssl_dir.is_dir()
     assert (ssl_dir / "server.key").is_file()
@@ -735,18 +735,26 @@ def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
     assert logged("SSL credentials written to")
 
 
+def test_ecflow__openssl__not_found():
+    with (
+        patch.object(ecflow.shutil, "which", return_value=None),
+        raises(UWError, match="openssl not found on PATH"),
+    ):
+        ecflow._openssl()
+
+
 def test_ecflow__ssl_generate_key__success(tmp_path):
     path = tmp_path / "server.key"
     ecflow._ssl_generate_key(path)
     assert path.is_file()
-    # The 'umask 0077 &&' prefix on the openssl call must yield owner-only permissions.
+    # os.umask(0o077) yields owner-only permissions on generated files.
     assert oct(path.stat().st_mode)[-3:] == "600"
 
 
 def test_ecflow__ssl_generate_key__failure(tmp_path):
     path = tmp_path / "server.key"
     with (
-        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
+        patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=1)),
         raises(UWError, match="Failed to generate SSL private key"),
     ):
         ecflow._ssl_generate_key(path)
@@ -759,7 +767,7 @@ def test_ecflow__ssl_generate_cert__success(tmp_path):
     ecflow._ssl_generate_key(key_path)
     ecflow._ssl_generate_cert(cert_path, key_path)
     assert cert_path.is_file()
-    # The 'umask 0077 &&' prefix on the openssl call must yield owner-only permissions.
+    # os.umask(0o077) yields owner-only permissions on generated files.
     assert oct(cert_path.stat().st_mode)[-3:] == "600"
 
 
@@ -767,7 +775,7 @@ def test_ecflow__ssl_generate_cert__failure(tmp_path):
     cert_path = tmp_path / "server.crt"
     key_path = tmp_path / "server.key"
     with (
-        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
+        patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=1)),
         raises(UWError, match="Failed to generate SSL certificate"),
     ):
         ecflow._ssl_generate_cert(cert_path, key_path)
@@ -777,22 +785,21 @@ def test_ecflow__ssl_generate_cert__failure(tmp_path):
 
 def test_ecflow__ssl_generate_dhparam__success(tmp_path):
     # DH-parameter generation is slow and entropy-dependent, so (unlike the key and cert tests,
-    # which exercise real openssl) mock the shell call and assert the umask-prefixed command. The
-    # resulting 0600 permissions are verified for real by the key and cert tests, which share this
-    # umask mechanism.
+    # which exercise real openssl) mock the subprocess call and assert the argument list. The
+    # resulting 0600 permissions are verified for real by the key and cert tests, which share the
+    # os.umask(0o077) mechanism.
     path = tmp_path / "dh2048.pem"
-    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as mock_cmd:
+    with patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=0)) as mock_run:
         ecflow._ssl_generate_dhparam(path)
-    mock_cmd.assert_called_once()
-    cmd = mock_cmd.call_args[0][0]
-    assert cmd.startswith("umask 0077 && openssl dhparam")
-    assert f"-out {path}" in cmd
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args == [ecflow._openssl(), "dhparam", "-out", str(path), "2048"]
 
 
 def test_ecflow__ssl_generate_dhparam__failure(tmp_path):
     path = tmp_path / "dh2048.pem"
     with (
-        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
+        patch.object(ecflow, "subprocess_run", return_value=Mock(returncode=1)),
         raises(UWError, match="Failed to generate DH parameters"),
     ):
         ecflow._ssl_generate_dhparam(path)


### PR DESCRIPTION


- Add `_check_ssl_named()` helper to verify that a named certificate triplet (`<host>.<port>.crt`/`.key`/`.pem`) exists in `$HOME/.ecflowrc/ssl` before starting the server
- Update `server()` to route to `_check_ssl_named()` when `ECF_SSL` is a `<host>.<port>` string, and to `_provision_ssl()` for the default case (boolean or absent)
- Fix inline comment and JSON schema description for `ECF_SSL`: the string form is a `<host>.<port>` prefix, not a certificate file path
- Fix docs (`yaml/ecflow.rst`, `cli/tools/ecflow.rst`): replace incorrect file-path examples with `<host>.<port>` examples; clarify that all cert files must reside in `$HOME/.ecflowrc/ssl`
- Update existing SSL string test to use `<host>.<port>` format; add tests for `_check_ssl_named()` (all files present, missing files)

Closes #924

**Synopsis**

Adds proper support for the `ECF_SSL` config key in `uw ecflow server`. When `ECF_SSL` is absent or true, the default certificate triplet (`server.crt`/`server.key`/`dh2048.pem`) is auto-provisioned in `$HOME/.ecflowrc/ssl`. When `ECF_SSL` is a `<host>.<port>` string, the named triplet (`<host>.<port>.crt`/`.key`/`.pem`) is verified to exist there before the server starts. When `ECF_SSL` is `false` or `--insecure` is given, SSL is disabled entirely. All cert files must reside in `$HOME/.ecflowrc/ssl`; no custom directory is supported by ecflow.


**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [X] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [X] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [X] I have added myself and any co-authors to the PR's _Assignees_ list.
- [X] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
