### PR TITLE
Update SSL provisioning and tests

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -43,8 +43,8 @@ from uwtools.strings import STR
 from uwtools.utils.file import writable
 from uwtools.utils.processing import run_shell_cmd
 
-ECFLOW_PORT_MIN = 1024  # minimum port number accepted by ecFlow
-ECFLOW_PORT_MAX = 49151  # maximum port number accepted by ecFlow
+ECFLOW_PORT_MIN = 1024  # minimum TCP port number accepted by ecFlow
+ECFLOW_PORT_MAX = 49151  # maximum TCP port number accepted by ecFlow
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -36,16 +36,15 @@ from ecflow import (  # type: ignore[import-untyped]
 
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.validator import validate_internal
-from uwtools.exceptions import UWConfigError, UWError
+from uwtools.exceptions import UWConfigError, UWError, UWSSLCertificateError
 from uwtools.logging import log
 from uwtools.scheduler import JobScheduler
 from uwtools.strings import STR
 from uwtools.utils.file import writable
 from uwtools.utils.processing import run_shell_cmd
 
-# ecFlow accepts ports only in the registered range 1024-49151.
-ECFLOW_PORT_MIN = 1024
-ECFLOW_PORT_MAX = 49151
+ECFLOW_PORT_MIN = 1024  # minimum port number accepted by ecFlow
+ECFLOW_PORT_MAX = 49151  # maximum port number accepted by ecFlow
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -440,71 +439,37 @@ def _openssl() -> Path:
     return Path(path)
 
 
-def _provision_ssl() -> None:
+def _ssl_check(prefix: str | None) -> None:
     """
-    Ensure SSL certificates exist in $HOME/.ecflowrc/ssl.
+    Verify that the appropriate SSL certificate triplet exists in $HOME/.ecflowrc/ssl.
 
-    If all required files exist, logs that they will be reused. If the directory exists but is
-    missing one or more required files, logs an error and raises UWError. If the directory does not
-    exist, creates it and generates the required SSL files using openssl.
+    The files comprising the triplet are <prefix>.{crt,key,pem} when 'prefix' is provided, otherwise
+    the default files specified by _SSL_FILES.
 
-    :raises UWError: If the SSL directory exists but is incomplete, or if certificate generation
-        fails.
+    :param prefix: The <host>.<port> prefix identifying the certificate triplet.
+    :raises UWSSLCertificateError: If one or more of the required files are missing.
     """
-    existing = [f for f in _SSL_FILES if (_SSL_DIR / f).exists()]
-    if len(existing) == len(_SSL_FILES):
-        log.info("Using existing SSL certificates in %s", _SSL_DIR)
-        return
-    if existing:
-        missing = sorted(set(_SSL_FILES) - set(existing))
-        msg = (
-            f"SSL directory {_SSL_DIR} exists but is missing required file(s): {missing}. "
-            "Provide all required files or remove the directory to allow regeneration."
-        )
-        raise UWError(msg)
-    log.info("Creating SSL directory %s", _SSL_DIR)
+    fns = [f"{prefix}{ext}" for ext in (".crt", ".key", ".pem")] if prefix else _SSL_FILES
+    paths = [_SSL_DIR / fn for fn in fns]
+    if missing := [path for path in paths if not path.is_file()]:
+        msg = "Missing SSL certificate file(s): %s" % ", ".join(map(str, missing))
+        if not prefix:
+            msg += ". Provide these files or remove %s to automatically generate" % _SSL_DIR
+        raise UWSSLCertificateError(msg)
+    log.info("Using SSL certificates %s in %s", ", ".join(fns), _SSL_DIR)
+
+
+def _ssl_provision() -> None:
+    """
+    Provision SSL certificates in $HOME/.ecflowrc/ssl.
+
+    :raises UWError: If or if certificate generation fails.
+    """
     _SSL_DIR.mkdir(parents=True, exist_ok=True)
     _ssl_generate_key(_SSL_DIR / _SSL_KEY)
     _ssl_generate_cert(_SSL_DIR / _SSL_CERT, _SSL_DIR / _SSL_KEY)
     _ssl_generate_dhparam(_SSL_DIR / _SSL_DHPARAM)
-    log.info("SSL credentials written to %s", _SSL_DIR)
-
-
-def _check_ssl_named(prefix: str) -> None:
-    """
-    Verify that the named SSL certificate triplet for 'prefix' exists in $HOME/.ecflowrc/ssl.
-
-    The required files are <prefix>.crt, <prefix>.key, and <prefix>.pem. These files must be
-    supplied by the user; this function only checks for their existence and raises UWError if any
-    are missing.
-
-    :param prefix: The <host>.<port> prefix identifying the certificate triplet.
-    :raises UWError: If one or more of the required files are missing.
-    """
-    extensions = [".crt", ".key", ".pem"]
-    missing = [f"{prefix}{ext}" for ext in extensions if not (_SSL_DIR / f"{prefix}{ext}").exists()]
-    if missing:
-        msg = (
-            f"SSL certificate file(s) {missing} not found in {_SSL_DIR}. "
-            f"Provide all required files for prefix '{prefix}'."
-        )
-        raise UWError(msg)
-    log.info("Using existing SSL certificates for prefix '%s' in %s", prefix, _SSL_DIR)
-
-
-def _ssl_generate_key(path: Path) -> None:
-    """
-    Generate a 2048-bit RSA private key (no password) at 'path'.
-
-    :param path: Destination for the private key file.
-    :raises UWError: If openssl reports failure.
-    """
-    log.info("Generating SSL private key: %s", path)
-    cmd = f"umask 077 && {_openssl()} genrsa -out {path} 2048"
-    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
-    if not success:
-        msg = f"Failed to generate SSL private key at {path}"
-        raise UWError(msg)
+    log.info("SSL certificate files written to %s", _SSL_DIR)
 
 
 def _ssl_generate_cert(path: Path, key_path: Path) -> None:
@@ -539,6 +504,21 @@ def _ssl_generate_dhparam(path: Path) -> None:
     success, _ = run_shell_cmd(cmd=cmd, quiet=True)
     if not success:
         msg = f"Failed to generate DH parameters at {path}"
+        raise UWError(msg)
+
+
+def _ssl_generate_key(path: Path) -> None:
+    """
+    Generate a 2048-bit RSA private key (no password) at 'path'.
+
+    :param path: Destination for the private key file.
+    :raises UWError: If openssl reports failure.
+    """
+    log.info("Generating SSL private key: %s", path)
+    cmd = f"umask 077 && {_openssl()} genrsa -out {path} 2048"
+    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+    if not success:
+        msg = f"Failed to generate SSL private key at {path}"
         raise UWError(msg)
 
 
@@ -584,10 +564,10 @@ def server(
     ecf_ssl = server_cfg.get("ECF_SSL")
     ssl_on = not insecure and ecf_ssl is not False
     if ssl_on:
-        if isinstance(ecf_ssl, str):
-            _check_ssl_named(ecf_ssl)
-        else:
-            _provision_ssl()
+        try:
+            _ssl_check(ecf_ssl)
+        except UWSSLCertificateError:
+            _ssl_provision()
     rundir = Path(server_cfg["ECF_HOME"])
     # Exclude ECF_SSL from cfg_vars: it is handled explicitly below (it may be a bool in the YAML,
     # and ecFlow interprets any non-empty env string as an SSL flag or cert path).

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -452,10 +452,10 @@ def _ssl_check(prefix: str | None) -> None:
     fns = [f"{prefix}{ext}" for ext in (".crt", ".key", ".pem")] if prefix else _SSL_FILES
     paths = [_SSL_DIR / fn for fn in fns]
     if missing := [path for path in paths if not path.is_file()]:
-        msg = "Missing SSL certificate file(s): %s" % ", ".join(map(str, missing))
+        log.error("Missing SSL certificate file(s): %s", ", ".join(map(str, missing)))
         if not prefix:
-            msg += ". Provide these files or remove %s to automatically generate" % _SSL_DIR
-        raise UWSSLCertificateError(msg)
+            log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)
+        raise UWSSLCertificateError
     log.info("Using SSL certificates %s in %s", ", ".join(fns), _SSL_DIR)
 
 
@@ -567,7 +567,8 @@ def server(
         try:
             _ssl_check(ecf_ssl)
         except UWSSLCertificateError:
-            _ssl_provision()
+            if ecf_ssl in [None, True]:
+                _ssl_provision()
     rundir = Path(server_cfg["ECF_HOME"])
     # Exclude ECF_SSL from cfg_vars: it is handled explicitly below (it may be a bool in the YAML,
     # and ecFlow interprets any non-empty env string as an SSL flag or cert path).

--- a/src/uwtools/exceptions.py
+++ b/src/uwtools/exceptions.py
@@ -33,6 +33,12 @@ class UWNotImplementedError(UWError):
     """
 
 
+class UWSSLCertificateError(UWError):
+    """
+    Exception for signaling issues with SSL certificates.
+    """
+
+
 class UWTemplateRenderError(UWError):
     """
     Exception for issues arising from template rendering.

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from io import StringIO
 from pathlib import Path
 from subprocess import CalledProcessError
-from types import SimpleNamespace
+from types import SimpleNamespace as ns
 from unittest.mock import Mock, patch
 
 import ecflow as ecflowlib  # type: ignore[import-untyped]
@@ -18,7 +18,7 @@ from pytest import fixture, mark, raises
 from uwtools import ecflow
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.ecflow import _ECFlowDef
-from uwtools.exceptions import UWConfigError, UWError
+from uwtools.exceptions import UWConfigError, UWError, UWSSLCertificateError
 from uwtools.utils.file import _stdinproxy
 
 # Fixtures
@@ -700,28 +700,50 @@ def test_ecflow_validate__yamlconfig(minimal_config):
 # SSL provisioning tests
 
 
-def test_ecflow__provision_ssl__all_files_exist(logged, tmp_path):
-    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
-    ssl_dir.mkdir(parents=True)
-    for fname in ["dh2048.pem", "server.crt", "server.key"]:
-        (ssl_dir / fname).touch()
-    with patch.object(ecflow, "_SSL_DIR", ssl_dir):
-        ecflow._provision_ssl()
-    assert logged("Using existing SSL certificates in")
-
-
-def test_ecflow__provision_ssl__incomplete_dir_raises(tmp_path):
-    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
-    ssl_dir.mkdir(parents=True)
-    (ssl_dir / "server.crt").touch()
+def test_ecflow__openssl__not_found():
     with (
-        patch.object(ecflow, "_SSL_DIR", ssl_dir),
-        raises(UWError, match="missing required file"),
+        patch.object(ecflow.shutil, "which", return_value=None),
+        raises(UWError, match="openssl not found on PATH"),
     ):
-        ecflow._provision_ssl()
+        ecflow._openssl()
 
 
-def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
+def test_ecflow__ssl_check__all_files_exist(logged, tmp_path):
+    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
+    ssl_dir.mkdir(parents=True)
+    prefix = "myhost.3141"
+    fns = [f"{prefix}.{ext}" for ext in ("crt", "key", "pem")]
+    for fn in fns:
+        (ssl_dir / fn).touch()
+    with patch.object(ecflow, "_SSL_DIR", ssl_dir):
+        ecflow._ssl_check(prefix)
+    assert logged("Using SSL certificates %s in %s" % (", ".join(fns), ssl_dir))
+
+
+@mark.parametrize("excluded", ["dh2048.pem", "server.crt", "server.key"])
+def test_ecflow__ssl_check__missing_default_files_raises(excluded, tmp_path):
+    fns = ["dh2048.pem", "server.crt", "server.key"]
+    fns.remove(excluded)
+    for fn in fns:
+        (tmp_path / fn).touch()
+    with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError) as e:
+        ecflow._ssl_check(None)
+    assert "Missing SSL certificate file(s): %s" % (tmp_path / excluded) in str(e.value)
+
+
+@mark.parametrize("excluded", ["crt", "key", "pem"])
+def test_ecflow__ssl_check__missing_named_files_raises(excluded, tmp_path):
+    prefix = "myhost.3141"
+    for extension in [x for x in ("crt", "key", "pem") if x != excluded]:
+        (tmp_path / f"{prefix}.{extension}").touch()
+    with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError) as e:
+        ecflow._ssl_check(prefix)
+    assert "Missing SSL certificate file(s): %s" % (tmp_path / f"{prefix}.{excluded}") in str(
+        e.value
+    )
+
+
+def test_ecflow__ssl_provision__creates_dir_and_files(logged, tmp_path):
     ssl_dir = tmp_path / ".ecflowrc" / "ssl"
 
     def fake_run(cmd, **_kwargs):
@@ -734,72 +756,12 @@ def test_ecflow__provision_ssl__creates_dir_and_files(logged, tmp_path):
         patch.object(ecflow, "_SSL_DIR", ssl_dir),
         patch.object(ecflow, "run_shell_cmd", side_effect=fake_run),
     ):
-        ecflow._provision_ssl()
+        ecflow._ssl_provision()
     assert ssl_dir.is_dir()
     assert (ssl_dir / "server.key").is_file()
     assert (ssl_dir / "server.crt").is_file()
     assert (ssl_dir / "dh2048.pem").is_file()
-    assert logged("Creating SSL directory")
-    assert logged("SSL credentials written to")
-
-
-def test_ecflow__check_ssl_named__all_files_exist(logged, tmp_path):
-    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
-    ssl_dir.mkdir(parents=True)
-    prefix = "myhost.3141"
-    for ext in [".crt", ".key", ".pem"]:
-        (ssl_dir / f"{prefix}{ext}").touch()
-    with patch.object(ecflow, "_SSL_DIR", ssl_dir):
-        ecflow._check_ssl_named(prefix)
-    assert logged("Using existing SSL certificates for prefix")
-
-
-def test_ecflow__check_ssl_named__missing_files_raises(tmp_path):
-    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
-    ssl_dir.mkdir(parents=True)
-    prefix = "myhost.3141"
-    (ssl_dir / f"{prefix}.crt").touch()
-    with (
-        patch.object(ecflow, "_SSL_DIR", ssl_dir),
-        raises(UWError, match="not found in"),
-    ):
-        ecflow._check_ssl_named(prefix)
-
-
-def test_ecflow__openssl__not_found():
-    with (
-        patch.object(ecflow.shutil, "which", return_value=None),
-        raises(UWError, match="openssl not found on PATH"),
-    ):
-        ecflow._openssl()
-
-
-def test_ecflow__ssl_generate_key__success(tmp_path):
-    path = tmp_path / "server.key"
-    ecflow._ssl_generate_key(path)
-    assert path.is_file()
-    # umask 077 in the shell command yields owner-only permissions on generated files.
-    assert oct(path.stat().st_mode)[-3:] == "600"
-
-
-def test_ecflow__ssl_generate_key__failure(tmp_path):
-    path = tmp_path / "server.key"
-    with (
-        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
-        raises(UWError, match="Failed to generate SSL private key"),
-    ):
-        ecflow._ssl_generate_key(path)
-    assert not path.is_file()
-
-
-def test_ecflow__ssl_generate_cert__success(tmp_path):
-    cert_path = tmp_path / "server.crt"
-    key_path = tmp_path / "server.key"
-    ecflow._ssl_generate_key(key_path)
-    ecflow._ssl_generate_cert(cert_path, key_path)
-    assert cert_path.is_file()
-    # umask 077 in the shell command yields owner-only permissions on generated files.
-    assert oct(cert_path.stat().st_mode)[-3:] == "600"
+    assert logged("SSL certificate files written to %s" % ssl_dir)
 
 
 def test_ecflow__ssl_generate_cert__failure(tmp_path):
@@ -812,6 +774,26 @@ def test_ecflow__ssl_generate_cert__failure(tmp_path):
         ecflow._ssl_generate_cert(cert_path, key_path)
     assert not cert_path.is_file()
     assert not key_path.is_file()
+
+
+def test_ecflow__ssl_generate_cert__success(tmp_path):
+    cert_path = tmp_path / "server.crt"
+    key_path = tmp_path / "server.key"
+    ecflow._ssl_generate_key(key_path)
+    ecflow._ssl_generate_cert(cert_path, key_path)
+    assert cert_path.is_file()
+    # umask 077 in the shell command yields owner-only permissions on generated files.
+    assert oct(cert_path.stat().st_mode)[-3:] == "600"
+
+
+def test_ecflow__ssl_generate_dhparam__failure(tmp_path):
+    path = tmp_path / "dh2048.pem"
+    with (
+        patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
+        raises(UWError, match="Failed to generate DH parameters"),
+    ):
+        ecflow._ssl_generate_dhparam(path)
+    assert not path.is_file()
 
 
 def test_ecflow__ssl_generate_dhparam__success(tmp_path):
@@ -828,14 +810,22 @@ def test_ecflow__ssl_generate_dhparam__success(tmp_path):
     assert f"dhparam -out {path} 2048" in cmd
 
 
-def test_ecflow__ssl_generate_dhparam__failure(tmp_path):
-    path = tmp_path / "dh2048.pem"
+def test_ecflow__ssl_generate_key__failure(tmp_path):
+    path = tmp_path / "server.key"
     with (
         patch.object(ecflow, "run_shell_cmd", return_value=(False, "error")),
-        raises(UWError, match="Failed to generate DH parameters"),
+        raises(UWError, match="Failed to generate SSL private key"),
     ):
-        ecflow._ssl_generate_dhparam(path)
+        ecflow._ssl_generate_key(path)
     assert not path.is_file()
+
+
+def test_ecflow__ssl_generate_key__success(tmp_path):
+    path = tmp_path / "server.key"
+    ecflow._ssl_generate_key(path)
+    assert path.is_file()
+    # umask 077 in the shell command yields owner-only permissions on generated files.
+    assert oct(path.stat().st_mode)[-3:] == "600"
 
 
 @fixture
@@ -850,26 +840,26 @@ def server_mocks():
     cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf"}}}
     with (
         patch.object(ecflow, "YAMLConfig", return_value=cfg) as yamlconfig,
-        patch.object(ecflow, "validate") as validate,
-        patch.object(ecflow, "_provision_ssl") as provision_ssl,
-        patch.object(ecflow, "_check_ssl_named") as check_ssl_named,
         patch.object(ecflow, "_ServerThread") as thread_cls,
-        patch.object(ecflow.signal, "signal") as signal,
         patch.object(ecflow, "_server_wait") as server_wait,
+        patch.object(ecflow, "_ssl_check") as ssl_check,
+        patch.object(ecflow, "_ssl_provision") as ssl_provision,
+        patch.object(ecflow, "validate") as validate,
+        patch.object(ecflow.signal, "signal") as signal,
     ):
         thread = thread_cls.return_value
         thread.error = None
-        yield SimpleNamespace(
-            config_path=Path("/some/server.yaml"),
+        yield ns(
             cfg=cfg,
-            yamlconfig=yamlconfig,
-            validate=validate,
-            provision_ssl=provision_ssl,
-            check_ssl_named=check_ssl_named,
-            thread_cls=thread_cls,
-            thread=thread,
-            signal=signal,
+            config_path=Path("/some/server.yaml"),
             server_wait=server_wait,
+            signal=signal,
+            ssl_check=ssl_check,
+            ssl_provision=ssl_provision,
+            thread=thread,
+            thread_cls=thread_cls,
+            validate=validate,
+            yamlconfig=yamlconfig,
         )
 
 
@@ -887,16 +877,18 @@ def test_ecflow_server__accepts_config_types(server_mocks, config):
     server_mocks.yamlconfig.assert_called_once_with(config)
 
 
-def test_ecflow_server__calls_provision_ssl(server_mocks):
+def test_ecflow_server__calls_ssl_provision(server_mocks):
+    server_mocks.ssl_check.side_effect = UWSSLCertificateError
     ecflow.server(config=server_mocks.config_path, port=3141)
-    server_mocks.provision_ssl.assert_called_once_with()
+    server_mocks.ssl_provision.assert_called_once_with()
 
 
 def test_ecflow_server__ecf_ssl_true_provisions_and_sets_env(server_mocks):
     m = server_mocks
     m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": True}}}
+    m.ssl_check.side_effect = UWSSLCertificateError
     ecflow.server(config=m.config_path, port=3141)
-    m.provision_ssl.assert_called_once_with()
+    m.ssl_provision.assert_called_once_with()
     _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
     assert env["ECF_SSL"] == "1"
 
@@ -905,8 +897,8 @@ def test_ecflow_server__ecf_ssl_string_checks_named_cert(server_mocks):
     m = server_mocks
     m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "myhost.3141"}}}
     ecflow.server(config=m.config_path, port=3141)
-    m.provision_ssl.assert_not_called()
-    m.check_ssl_named.assert_called_once_with("myhost.3141")
+    m.ssl_provision.assert_not_called()
+    m.ssl_check.assert_called_once_with("myhost.3141")
     _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
     assert env["ECF_SSL"] == "myhost.3141"
 
@@ -915,15 +907,15 @@ def test_ecflow_server__ecf_ssl_false_skips_ssl(server_mocks):
     m = server_mocks
     m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": False}}}
     ecflow.server(config=m.config_path, port=3141)
-    m.provision_ssl.assert_not_called()
+    m.ssl_provision.assert_not_called()
     _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
     assert "ECF_SSL" not in env
 
 
 def test_ecflow_server__insecure_skips_ssl(server_mocks):
     ecflow.server(config=server_mocks.config_path, port=3141, insecure=True)
-    server_mocks.provision_ssl.assert_not_called()
-    server_mocks.check_ssl_named.assert_not_called()
+    server_mocks.ssl_provision.assert_not_called()
+    server_mocks.ssl_check.assert_not_called()
 
 
 def test_ecflow_server__secure_sets_ecf_ssl_env(server_mocks):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -721,27 +721,26 @@ def test_ecflow__ssl_check__all_files_exist(logged, tmp_path):
 
 
 @mark.parametrize("excluded", ["dh2048.pem", "server.crt", "server.key"])
-def test_ecflow__ssl_check__missing_default_files_raises(excluded, tmp_path):
+def test_ecflow__ssl_check__missing_default_files_raises(excluded, tmp_path, uwcaplog):
     fns = ["dh2048.pem", "server.crt", "server.key"]
     fns.remove(excluded)
     for fn in fns:
         (tmp_path / fn).touch()
-    with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError) as e:
+    with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError):
         ecflow._ssl_check(None)
-    assert "Missing SSL certificate file(s): %s" % (tmp_path / excluded) in str(e.value)
-    assert "Provide these files or remove %s to automatically generate" % tmp_path in str(e.value)
+    assert "Missing SSL certificate file(s): %s" % (tmp_path / excluded) in uwcaplog.text
+    assert "Provide these files or remove %s to automatically generate" % tmp_path in uwcaplog.text
 
 
 @mark.parametrize("excluded", ["crt", "key", "pem"])
-def test_ecflow__ssl_check__missing_named_files_raises(excluded, tmp_path):
+def test_ecflow__ssl_check__missing_named_files_raises(excluded, tmp_path, uwcaplog):
     prefix = "myhost.3141"
     for extension in [x for x in ("crt", "key", "pem") if x != excluded]:
         (tmp_path / f"{prefix}.{extension}").touch()
-    with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError) as e:
+    with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError):
         ecflow._ssl_check(prefix)
-    assert "Missing SSL certificate file(s): %s" % (tmp_path / f"{prefix}.{excluded}") in str(
-        e.value
-    )
+    msg = "Missing SSL certificate file(s): %s" % (tmp_path / f"{prefix}.{excluded}")
+    assert msg in uwcaplog.text
 
 
 def test_ecflow__ssl_provision__creates_dir_and_files(logged, tmp_path):
@@ -878,12 +877,6 @@ def test_ecflow_server__accepts_config_types(server_mocks, config):
     server_mocks.yamlconfig.assert_called_once_with(config)
 
 
-def test_ecflow_server__calls_ssl_provision(server_mocks):
-    server_mocks.ssl_check.side_effect = UWSSLCertificateError
-    ecflow.server(config=server_mocks.config_path, port=3141)
-    server_mocks.ssl_provision.assert_called_once_with()
-
-
 def test_ecflow_server__ecf_ssl_true_provisions_and_sets_env(server_mocks):
     m = server_mocks
     m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": True}}}
@@ -926,6 +919,17 @@ def test_ecflow_server__secure_sets_ecf_ssl_env(server_mocks):
     assert env["ECF_SSL"] == "1"
     assert port == 3141
     assert insecure is False
+
+
+@mark.parametrize("ecf_ssl", [None, True, False, "myhost.8888"])
+def test_ecflow_server__ssl_provision(ecf_ssl, server_mocks):
+    server_mocks.ssl_check.side_effect = UWSSLCertificateError
+    server_mocks.cfg.data["ecflow"]["server"]["ECF_SSL"] = ecf_ssl
+    ecflow.server(config=server_mocks.config_path, port=3141)
+    if ecf_ssl in [None, True]:
+        server_mocks.ssl_provision.assert_called_once_with()
+    else:
+        server_mocks.ssl_provision.assert_not_called()
 
 
 def test_ecflow_server__insecure_unsets_ecf_ssl_env(server_mocks):

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -729,6 +729,7 @@ def test_ecflow__ssl_check__missing_default_files_raises(excluded, tmp_path):
     with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError) as e:
         ecflow._ssl_check(None)
     assert "Missing SSL certificate file(s): %s" % (tmp_path / excluded) in str(e.value)
+    assert "Provide these files or remove %s to automatically generate" % tmp_path in str(e.value)
 
 
 @mark.parametrize("excluded", ["crt", "key", "pem"])


### PR DESCRIPTION
**Synopsis**

- Rename `_provision_ssl` -> `_ssl_provision` for cleaner ordering with the `_ssl_generate_*` functions.
- Rename `_check_ssl_named` -> `_check_ssl`, and factor similar logic for checking that all expected SSL certificate files exist out of `_ssl_provision` and into this function.
- Reorder library code and tests lexicographically based on their updated names.
- Expand unit tests.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
