### PR TITLE
Run ecflow_server via run_shell_cmd

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -452,9 +452,10 @@ def _ssl_check(prefix: str | None) -> None:
     fns = [f"{prefix}{ext}" for ext in (".crt", ".key", ".pem")] if prefix else _SSL_FILES
     paths = [_SSL_DIR / fn for fn in fns]
     if missing := [path for path in paths if not path.is_file()]:
-        log.error("Missing SSL certificate file(s): %s", ", ".join(map(str, missing)))
-        if not prefix:
-            log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)
+        if _SSL_DIR.is_dir():
+            log.error("Missing SSL certificate file(s): %s", ", ".join(map(str, missing)))
+            if not prefix:
+                log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)
         raise UWSSLCertificateError
     log.info("Using SSL certificates %s in %s", ", ".join(fns), _SSL_DIR)
 

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -452,10 +452,10 @@ def _ssl_check(prefix: str | None) -> None:
     fns = [f"{prefix}{ext}" for ext in (".crt", ".key", ".pem")] if prefix else _SSL_FILES
     paths = [_SSL_DIR / fn for fn in fns]
     if missing := [path for path in paths if not path.is_file()]:
-        if prefix or _SSL_DIR.is_dir():
+        if _SSL_DIR.is_dir() or prefix:
             log.error("Missing SSL certificate file(s): %s", ", ".join(map(str, missing)))
-            if not prefix:
-                log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)
+        if _SSL_DIR.is_dir() and not prefix:
+            log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)
         raise UWSSLCertificateError
     log.info("Using SSL certificates %s in %s", ", ".join(fns), _SSL_DIR)
 

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -452,7 +452,7 @@ def _ssl_check(prefix: str | None) -> None:
     fns = [f"{prefix}{ext}" for ext in (".crt", ".key", ".pem")] if prefix else _SSL_FILES
     paths = [_SSL_DIR / fn for fn in fns]
     if missing := [path for path in paths if not path.is_file()]:
-        if _SSL_DIR.is_dir():
+        if prefix or _SSL_DIR.is_dir():
             log.error("Missing SSL certificate file(s): %s", ", ".join(map(str, missing)))
             if not prefix:
                 log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -13,7 +13,7 @@ import signal
 import socket
 from copy import deepcopy
 from pathlib import Path
-from subprocess import STDOUT, CalledProcessError, check_output
+from subprocess import CalledProcessError
 from textwrap import dedent
 from threading import Event, Thread, current_thread
 from time import sleep
@@ -482,9 +482,11 @@ def _ssl_generate_cert(path: Path, key_path: Path) -> None:
     """
     hostname = socket.gethostname()
     log.info("Generating SSL certificate: %s", path)
-    cmd = (
-        f"umask 077 && {_openssl()} req -x509 -key {key_path}"
-        f" -new -out {path} -days 3650 -subj /CN={hostname}"
+    cmd = "umask 077 && %s req -x509 -key %s -new -out %s -days 3650 -subj /CN=%s" % (
+        _openssl(),
+        key_path,
+        path,
+        hostname,
     )
     success, _ = run_shell_cmd(cmd=cmd, quiet=True)
     if not success:
@@ -500,7 +502,7 @@ def _ssl_generate_dhparam(path: Path) -> None:
     :raises UWError: If openssl reports failure.
     """
     log.info("Generating DH parameters: %s", path)
-    cmd = f"umask 077 && {_openssl()} dhparam -out {path} 2048"
+    cmd = "umask 077 && %s dhparam -out %s 2048" % (_openssl(), path)
     success, _ = run_shell_cmd(cmd=cmd, quiet=True)
     if not success:
         msg = f"Failed to generate DH parameters at {path}"
@@ -515,7 +517,7 @@ def _ssl_generate_key(path: Path) -> None:
     :raises UWError: If openssl reports failure.
     """
     log.info("Generating SSL private key: %s", path)
-    cmd = f"umask 077 && {_openssl()} genrsa -out {path} 2048"
+    cmd = "umask 077 && %s genrsa -out %s 2048" % (_openssl(), path)
     success, _ = run_shell_cmd(cmd=cmd, quiet=True)
     if not success:
         msg = f"Failed to generate SSL private key at {path}"
@@ -592,9 +594,8 @@ def server(
         log.info("Terminating")
         thread.terminal.set()
         if thread.port:
-            run_shell_cmd(
-                cmd=f"ecflow_client {ssl_opt}--port {thread.port} --terminate=yes", quiet=True
-            )
+            cmd = "ecflow_client %s--port %s --terminate=yes" % (ssl_opt, thread.port)
+            run_shell_cmd(cmd=cmd, quiet=True)
 
     signal.signal(signal.SIGINT, shutdown)
     thread.start()
@@ -623,7 +624,6 @@ def _server_start(rundir: Path, env: dict[str, str], port: int | None, insecure:
     """
     thread = cast(_ServerThread, current_thread())
     fixed = port is not None
-    cmd = ["ecflow_server", *([] if insecure else ["--ssl"])]
     # Create the run directory (ECF_HOME) on the user's behalf if it does not already exist.
     rundir.mkdir(parents=True, exist_ok=True)
     while not thread.terminal.is_set():
@@ -634,15 +634,8 @@ def _server_start(rundir: Path, env: dict[str, str], port: int | None, insecure:
         log.debug("Trying to start server on port %s", candidate)
         thread.port = candidate
         try:
-            check_output(  # noqa: S603
-                cmd,
-                cwd=rundir,
-                encoding="utf-8",
-                env={**env, "ECF_PORT": str(candidate)},
-                start_new_session=True,
-                stderr=STDOUT,
-                text=True,
-            )
+            cmd = "ecflow_server%s" % ("" if insecure else " --ssl")
+            run_shell_cmd(cmd=cmd, cwd=rundir, env={**env, "ECF_PORT": str(candidate)}, quiet=True)
         except CalledProcessError as e:
             if "bind: Address already in use" in (e.stdout or ""):
                 thread.port = None

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -721,15 +721,26 @@ def test_ecflow__ssl_check__all_files_exist(logged, tmp_path):
 
 
 @mark.parametrize("excluded", ["dh2048.pem", "server.crt", "server.key"])
-def test_ecflow__ssl_check__missing_default_files_raises(excluded, tmp_path, uwcaplog):
-    fns = ["dh2048.pem", "server.crt", "server.key"]
-    fns.remove(excluded)
-    for fn in fns:
-        (tmp_path / fn).touch()
-    with patch.object(ecflow, "_SSL_DIR", tmp_path), raises(UWSSLCertificateError):
+@mark.parametrize("ssl_dir_exists", [True, False])
+def test_ecflow__ssl_check__missing_default_files_raises(
+    excluded, ssl_dir_exists, tmp_path, uwcaplog
+):
+    ssl_dir = tmp_path / "ssl"
+    if ssl_dir_exists:
+        ssl_dir.mkdir()
+        fns = ["dh2048.pem", "server.crt", "server.key"]
+        fns.remove(excluded)
+        for fn in fns:
+            (ssl_dir / fn).touch()
+    with patch.object(ecflow, "_SSL_DIR", ssl_dir), raises(UWSSLCertificateError):
         ecflow._ssl_check(None)
-    assert "Missing SSL certificate file(s): %s" % (tmp_path / excluded) in uwcaplog.text
-    assert "Provide these files or remove %s to automatically generate" % tmp_path in uwcaplog.text
+    msgs = [
+        "Missing SSL certificate file(s): %s" % (ssl_dir / excluded),
+        "Provide these files or remove %s to automatically generate" % ssl_dir,
+    ]
+    for msg in msgs:
+        if ssl_dir_exists:
+            assert msg in uwcaplog.text
 
 
 @mark.parametrize("excluded", ["crt", "key", "pem"])

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -1023,40 +1023,38 @@ def test_ecflow_server__no_report_passes_none(server_mocks):
 
 
 def test_ecflow__server_start__fixed_port_ssl(tmp_path):
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-
-    def fake_check_output(_cmd, **_kwargs):
+    def fake_run_shell_cmd(*_args, **_kwargs):
         thread.terminal.set()
         return ""
 
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
     with (
         patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "check_output", side_effect=fake_check_output) as mock_co,
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd) as run_shell_cmd,
     ):
         ecflow._server_start(rundir, {"ECF_HOME": str(rundir)}, 3141, False)
     assert rundir.is_dir()
-    assert mock_co.call_args.args[0] == ["ecflow_server", "--ssl"]
-    assert mock_co.call_args.kwargs["env"]["ECF_PORT"] == "3141"
-    assert mock_co.call_args.kwargs["cwd"] == rundir
+    assert run_shell_cmd.call_args.kwargs["cmd"] == "ecflow_server --ssl"
+    assert run_shell_cmd.call_args.kwargs["cwd"] == rundir
+    assert run_shell_cmd.call_args.kwargs["env"]["ECF_PORT"] == "3141"
     assert thread.port == 3141
     assert thread.error is None
 
 
 def test_ecflow__server_start__fixed_port_insecure(tmp_path):
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-
-    def fake_check_output(_cmd, **_kwargs):
+    def fake_run_shell_cmd(*_args, **_kwargs):
         thread.terminal.set()
         return ""
 
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
     with (
         patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "check_output", side_effect=fake_check_output) as mock_co,
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd) as run_shell_cmd,
     ):
         ecflow._server_start(rundir, {}, 3141, True)
-    assert mock_co.call_args.args[0] == ["ecflow_server"]
+    assert run_shell_cmd.call_args.kwargs["cmd"] == "ecflow_server"
 
 
 def test_ecflow__server_start__fixed_port_unavailable(tmp_path):
@@ -1065,7 +1063,7 @@ def test_ecflow__server_start__fixed_port_unavailable(tmp_path):
     err = CalledProcessError(1, "ecflow_server", output="ecf: bind: Address already in use")
     with (
         patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "check_output", side_effect=err),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
     ):
         ecflow._server_start(rundir, {}, 3141, False)
     assert thread.error == "Requested port 3141 is unavailable"
@@ -1079,7 +1077,7 @@ def test_ecflow__server_start__fixed_port_other_failure(tmp_path):
     err = CalledProcessError(1, "ecflow_server", output="something went wrong")
     with (
         patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "check_output", side_effect=err),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
     ):
         ecflow._server_start(rundir, {}, 3141, False)
     assert thread.error == "ecflow_server failed on port 3141: something went wrong"
@@ -1092,7 +1090,7 @@ def test_ecflow__server_start__launch_failure(tmp_path):
     err = FileNotFoundError(2, "No such file or directory", "ecflow_server")
     with (
         patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "check_output", side_effect=err),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
     ):
         ecflow._server_start(rundir, {}, 3141, False)
     assert thread.error is not None
@@ -1101,22 +1099,21 @@ def test_ecflow__server_start__launch_failure(tmp_path):
 
 
 def test_ecflow__server_start__random_port_retries_until_available(tmp_path):
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    bind_err = CalledProcessError(1, "ecflow_server", output="ecf: bind: Address already in use")
-    ports = []
-
-    def fake_check_output(_cmd, **kwargs):
+    def fake_run_shell_cmd(*_args, **kwargs):
         ports.append(kwargs["env"]["ECF_PORT"])
         if len(ports) == 1:
             raise bind_err
         thread.terminal.set()
         return ""
 
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    bind_err = CalledProcessError(1, "ecflow_server", output="ecf: bind: Address already in use")
+    ports: list[str] = []
     with (
         patch.object(ecflow, "current_thread", return_value=thread),
         patch.object(ecflow.random, "randint", side_effect=[30000, 30001]),
-        patch.object(ecflow, "check_output", side_effect=fake_check_output),
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd),
     ):
         ecflow._server_start(rundir, {}, None, False)
     assert ports == ["30000", "30001"]
@@ -1130,8 +1127,8 @@ def test_ecflow__server_start__random_port_failure(tmp_path):
     err = CalledProcessError(1, "ecflow_server", output="something broke")
     with (
         patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
         patch.object(ecflow.random, "randint", return_value=31415),
-        patch.object(ecflow, "check_output", side_effect=err),
     ):
         ecflow._server_start(rundir, {}, None, False)
     assert thread.error == "ecflow_server failed on port 31415: something broke"

--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -3,6 +3,7 @@ Tests for uwtools.utils.processing module.
 """
 
 import logging
+from textwrap import dedent
 
 from pytest import mark
 
@@ -28,8 +29,9 @@ def test_utils_processing_run_shell_cmd__failure(caplog, logged, quiet):
 @mark.parametrize("executable", ["/bin/bash", None])
 @mark.parametrize("log_output", [True, False])
 @mark.parametrize("quiet", [True, False])
+@mark.parametrize("taskname", ["test", None])
 def test_utils_processing_run_shell_cmd__success(
-    caplog, executable, logged, log_output, quiet, tmp_path
+    executable, log_output, quiet, taskname, tmp_path, uwcaplog
 ):
     cmd = "echo hello $FOO"
     if quiet:
@@ -39,14 +41,22 @@ def test_utils_processing_run_shell_cmd__success(
         cwd=tmp_path,
         env={"FOO": "bar"},
         log_output=log_output,
+        taskname=taskname,
         quiet=quiet,
         executable=executable,
     )
     assert success
     if quiet:
-        assert not caplog.messages
+        assert not uwcaplog.messages
     elif log_output:
-        assert logged("Running in %s with environment variables FOO=bar:" % tmp_path)
-        assert logged("  %s" % cmd)
-        assert logged("Output:")
-        assert logged("  hello bar")
+        pre = f"[{taskname}] " if taskname else ""
+        expected = """
+        %sRunning: %s
+          in directory
+            %s
+          with environment
+            FOO=bar
+        %sOutput:
+        %s  hello bar
+        """ % (pre, cmd, tmp_path, pre, pre)
+        assert uwcaplog.text.strip() == dedent(expected).strip()

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -34,17 +34,16 @@ def run_shell_cmd(
     :param executable: Interpreter to use (e.g. "/bin/bash")
     :return: A result object providing combined stder/stdout output and success values.
     """
-    pre = f"{taskname}: " if taskname else ""
-    msg = "%sRunning"
-    if cwd:
-        msg += f" in {cwd}"
-    if env:
-        kvpairs = " ".join(f"{k}={v}" for k, v in env.items())
-        msg += f" with environment variables {kvpairs}"
-    msg += ":"
+    pre = f"[{taskname}] " if taskname else ""
     logfunc = log.debug if quiet else log.info
-    logfunc(msg, pre)
-    logfunc("%s  %s", pre, cmd)
+    logfunc("%sRunning: %s", pre, cmd)
+    if cwd:
+        logfunc("  in directory")
+        logfunc("    %s", cwd)
+    if env:
+        logfunc("  with environment")
+        for k in sorted(env):
+            logfunc("    %s=%s", k, env[k])
     kwargs: dict = dict(cwd=cwd, encoding="utf=8", env=env, shell=True, stderr=STDOUT, text=True)  # noqa: S604
     if executable:
         kwargs["executable"] = executable


### PR DESCRIPTION
**Synopsis**

A [question came up](https://github.com/ufs-community/uwtools/pull/933#discussion_r3431362586) in #933 about using the `uwtools` function `run_shell_cmd` instead of direct `subprocess` calls. In that PR we switched to `run_shell_cmd` for new calls, but that left the one that starts `ecflow_server` still running via `subprocess.check_output`. This PR updates that call to also use `run_shell_cmd`.

It also:

- Makes the calls to `run_shell_cmd` in the `uwtools.ecflow` module more consistent,
- Makes necessary unit-test updates to reflect the code changes, and
- Updates `run_shell_cmd` itself to avoid `%` string formatting when logging environment-variable values.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
