### PR TITLE
Remove unused 'family' and 'task' schemas

### DIFF
--- a/src/uwtools/resources/jsonschema/ecflow.jsonschema
+++ b/src/uwtools/resources/jsonschema/ecflow.jsonschema
@@ -377,19 +377,6 @@
       ],
       "type": "object"
     },
-    "family": {
-      "$ref": "#/$defs/familycontainer",
-      "propertyNames": {
-        "anyOf": [
-          {
-            "$ref": "#/$defs/addon_property_names"
-          },
-          {
-            "pattern": "^(families|family|task|tasks)_.+$"
-          }
-        ]
-      }
-    },
     "familycontainer": {
       "allOf": [
         {
@@ -477,19 +464,6 @@
         }
       },
       "type": "object"
-    },
-    "task": {
-      "$ref": "#/$defs/taskcontainer",
-      "propertyNames": {
-        "anyOf": [
-          {
-            "const": "script"
-          },
-          {
-            "$ref": "#/$defs/addon_property_names"
-          }
-        ]
-      }
     },
     "taskcontainer": {
       "allOf": [

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -992,14 +992,6 @@ def test_schema_ecflow_suitedef_refs_nodecontainer_task():
     assert not errors({**config, "defstatus": "suspended"})
 
 
-def test_schema_ecflow_suitedef_refs_family():
-    errors = schema_validator("ecflow", "$defs", "family")
-    # Basic spec:
-    config = {"family_one": {}, "vars": {"MEMBER": "00", "LEAD": "006"}}
-    assert not errors(config)
-    assert "is not valid under any of the given schemas" in errors({**config, "extra": 2})
-
-
 def test_schema_ecflow_suitedef_refs_familycontainer():
     errors = schema_validator("ecflow", "$defs", "familycontainer")
     # Basic spec:
@@ -1014,18 +1006,6 @@ def test_schema_ecflow_suitedef_refs_nodecontainer():
     config = {"family_one": {}, "vars": {"MEMBER": "00", "LEAD": "006"}}
     assert not errors(config)
     # Note: expected to allow additional properties since it's used to compose higher-level refs.
-
-
-def test_schema_ecflow_suitedef_refs_task():
-    errors = schema_validator("ecflow", "$defs", "task")
-    # Basic spec:
-    config = {
-        "script": {"execution": {"incantation": "/path/to/run.sh"}},
-        "vars": {"MEMBER": "00", "LEAD": "006"},
-    }
-    assert not errors(config)
-    assert "'script' is a required property" in errors({"defstatus": "complete"})
-    assert "is not valid under any of the given schemas" in errors({**config, "extra": 2})
 
 
 def test_schema_ecflow_suitedef_refs_taskcontainer():


### PR DESCRIPTION
**Synopsis**

Remove unused `family` and `task` schemas from ecFlow schema `$defs` section.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
