### PR TITLE
Improve handing of bad ecFlow node names

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -125,7 +125,6 @@ class _ECFlowDef:
         :param refs: Optional references from expanded nodes from higher in the tree.
         """
         parent.add(node)
-
         add_items = lambda method, cfg: [method(*args) for args in cfg]
         for key, subconfig in config.items():
             tag, name = self._tag_name(key)
@@ -133,11 +132,11 @@ class _ECFlowDef:
                 # Tree buiding cases
 
                 case STR.family:
-                    self._add_node(subconfig, Family(name), node, refs)
+                    self._add_node(subconfig, _node(Family, name), node, refs)
                 case STR.families:
                     self._expand_block(subconfig, name, Family, node, refs)
                 case STR.task:
-                    self._add_node(subconfig, Task(name), node, refs)
+                    self._add_node(subconfig, _node(Task, name), node, refs)
                 case STR.tasks:
                     self._expand_block(subconfig, name, Task, node, refs)
 
@@ -218,7 +217,7 @@ class _ECFlowDef:
                 case STR.vars:
                     self._d.add_variable(subconfig)
                 case STR.suite:
-                    self._add_node(subconfig, Suite(name), self._d)
+                    self._add_node(subconfig, _node(Suite, name), self._d)
                 case STR.suites:
                     self._expand_block(subconfig, name, Suite, self._d)
 
@@ -356,7 +355,7 @@ class _ECFlowDef:
             new_name = list(new_block.keys())[0]
             args = {
                 STR.config: new_block[new_name],
-                STR.node: nodetype(new_name),
+                STR.node: _node(nodetype, new_name),
                 STR.parent: parent,
                 STR.refs: new_refs,
             }
@@ -424,6 +423,13 @@ _SSL_KEY = "server.key"
 _SSL_CERT = "server.crt"
 _SSL_DHPARAM = "dh2048.pem"
 _SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
+
+
+def _node(cls: type[Node], name: str) -> Node:
+    try:
+        return cls(name)
+    except RuntimeError as e:
+        raise UWConfigError(str(e)) from e
 
 
 def _openssl() -> Path:

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -2,6 +2,7 @@
 Tests for uwtools.ecflow module.
 """
 
+import re
 import sys
 from copy import deepcopy
 from io import StringIO
@@ -102,6 +103,11 @@ class TestECFlowDef:
         nested_path = tmp_path / "nested" / "output"
         instance.write_suite_definition(nested_path)
         assert (nested_path / "suite.def").is_file()
+
+    def test_ecflow__ECFlowDef__add_node__bad_name(self, instance):
+        with raises(UWConfigError) as e:
+            instance._add_node({"task_%bad%": {}}, Suite("test"), instance._d)
+        assert re.match(r"^Invalid node name .*: %bad%", str(e.value))
 
     def test_ecflow__ECFlowDef__add_node__basic(self, instance):
         suite = Suite("test")
@@ -470,8 +476,9 @@ class TestECFlowDef:
                 }
             }
         }
-        with raises(AssertionError):
+        with raises(AssertionError) as e:
             _ECFlowDef(config=config)
+        assert "Could not find node 'nonexistent_task'" in str(e)
 
     def test_ecflow__ECFlowDef__init__full_workflow(self, tmp_path):
         config = {

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -108,12 +108,12 @@ class TestECFlowDef:
     def test_ecflow__ECFlowDef__add_node__bad_name_family_task(self, instance, prefix):
         with raises(UWConfigError) as e:
             instance._add_node({f"{prefix}_%bad%": {}}, Suite("test"), instance._d)
-        assert re.match(r"^Invalid node name .*: %bad%", str(e.value))
+        assert re.match(r"^Invalid node name .*: %bad%$", str(e.value))
 
     def test_ecflow__ECFlowDef__add_node__bad_name_suite(self):
         with raises(UWConfigError) as e:
             _ECFlowDef({"ecflow": {"suitedef": {"suite_%bad%": {}}}})
-        assert re.match(r"^Invalid node name .*: %bad%", str(e.value))
+        assert re.match(r"^Invalid node name .*: %bad%$", str(e.value))
 
     def test_ecflow__ECFlowDef__add_node__basic(self, instance):
         suite = Suite("test")

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -104,9 +104,15 @@ class TestECFlowDef:
         instance.write_suite_definition(nested_path)
         assert (nested_path / "suite.def").is_file()
 
-    def test_ecflow__ECFlowDef__add_node__bad_name(self, instance):
+    @mark.parametrize("prefix", ["family", "task"])
+    def test_ecflow__ECFlowDef__add_node__bad_name_family_task(self, instance, prefix):
         with raises(UWConfigError) as e:
-            instance._add_node({"task_%bad%": {}}, Suite("test"), instance._d)
+            instance._add_node({f"{prefix}_%bad%": {}}, Suite("test"), instance._d)
+        assert re.match(r"^Invalid node name .*: %bad%", str(e.value))
+
+    def test_ecflow__ECFlowDef__add_node__bad_name_suite(self):
+        with raises(UWConfigError) as e:
+            _ECFlowDef({"ecflow": {"suitedef": {"suite_%bad%": {}}}})
         assert re.match(r"^Invalid node name .*: %bad%", str(e.value))
 
     def test_ecflow__ECFlowDef__add_node__basic(self, instance):


### PR DESCRIPTION
**Synopsis**

Instead of letting ecFlow raise an unhandled `RuntimeError`, catch the error and re-raise it as a `UWConfigError` so that it can be handled by the CLI. For example, given

`config.yaml`
```
ecflow:
  suitedef:
    suite_.bad.: {}
```

Old behavior:
```
$ uw ecflow realize -c config.yaml 
[2026-06-25T19:26:43]     INFO Validating config against internal schema: ecflow
[2026-06-25T19:26:43]     INFO Schema validation succeeded for ecFlow config
Traceback (most recent call last):
  File "/home/maddenp/sw/conda/envs/DEV-uwtools/bin/uw", line 6, in <module>
    sys.exit(main())
  File "/home/maddenp/git/uwtools/src/uwtools/cli.py", line 109, in main
    sys.exit(0 if modes[args[STR.mode]](args) else 1)
  File "/home/maddenp/git/uwtools/src/uwtools/cli.py", line 189, in _dispatch_ecflow
    return actions[args[STR.action]](args)
  File "/home/maddenp/git/uwtools/src/uwtools/cli.py", line 198, in _dispatch_ecflow_realize
    return uwtools.api.ecflow.realize(
  File "/home/maddenp/git/uwtools/src/uwtools/api/ecflow.py", line 42, in realize
    _realize(
  File "/home/maddenp/git/uwtools/src/uwtools/ecflow.py", line 412, in realize
    suite = _ECFlowDef(config)
  File "/home/maddenp/git/uwtools/src/uwtools/ecflow.py", line 70, in __init__
    self._add_workflow_components()
  File "/home/maddenp/git/uwtools/src/uwtools/ecflow.py", line 221, in _add_workflow_components
    self._add_node(subconfig, Suite(name), self._d)
RuntimeError: Invalid node name : Valid names can only consist of alphanumeric characters, underscores and dots (The first character cannot be a dot). The first character is not valid (only alphanumeric or an underscore is allowed): .bad.
```

New behavior:
```
$ uw ecflow realize -c config.yaml 
[2026-06-25T19:27:05]     INFO Validating config against internal schema: ecflow
[2026-06-25T19:27:05]     INFO Schema validation succeeded for ecFlow config
[2026-06-25T19:27:05]    ERROR Invalid node name : Valid names can only consist of alphanumeric characters, underscores and dots (The first character cannot be a dot). The first character is not valid (only alphanumeric or an underscore is allowed): .bad.
```

Shore this up with some unit tests.

We are already checking the overall `Def` [here](https://github.com/ufs-community/uwtools/blob/main/src/uwtools/ecflow.py#L72-L73), but the checking of individual node names is done at the time of instantiation of `Family`, `Suite`, and `Task` objects.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
