### PR TITLE
Code reorg in uwtools.ecflow

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -20,6 +20,7 @@ from time import sleep
 from typing import TYPE_CHECKING, cast
 
 from ecflow import (  # type: ignore[import-untyped]
+    Client,
     Defs,
     DState,
     Family,
@@ -43,14 +44,132 @@ from uwtools.strings import STR
 from uwtools.utils.file import writable
 from uwtools.utils.processing import run_shell_cmd
 
-ECFLOW_PORT_MIN = 1024  # minimum TCP port number accepted by ecFlow
-ECFLOW_PORT_MAX = 49151  # maximum TCP port number accepted by ecFlow
-
 if TYPE_CHECKING:
     from types import FrameType
 
     from ecflow import NodeContainer
 
+
+# Public
+
+ECFLOW_PORT_MIN = 1024  # minimum TCP port number accepted by ecFlow
+ECFLOW_PORT_MAX = 49151  # maximum TCP port number accepted by ecFlow
+
+
+def realize(
+    config: YAMLConfig | Path | None,
+    output_path: Path | None = None,
+    scripts_path: Path | None = None,
+) -> str:
+    """
+    Realize the ecFlow suite defined in a given YAML as a Suite Definition and corresponding ecf
+    scripts (if 'scripts_path' is provided).
+
+    :param config: Path to YAML input file (None => read stdin), or YAMLConfig object.
+    :param output_path: Path to write the rendered Suite Definition file (None => write to stdout).
+    :param scripts_path: Path to write the rendered ecf scripts (None => do not write scripts).
+    :return: Suite Definition as a string.
+    """
+    suite = _ECFlowDef(config)
+    suite.write_suite_definition(output_path)
+    if scripts_path:
+        suite.write_ecf_scripts(scripts_path)
+    return str(suite)
+
+
+def server(
+    config: dict | YAMLConfig | Path | None,
+    port: int | None = None,
+    insecure: bool = False,
+    report: bool = False,
+) -> None:
+    """
+    Start an ecFlow server on an available TCP port, optionally with SSL security enabled.
+
+    The server runs in the foreground until interrupted (e.g. via CTRL-C), at which point it is shut
+    down gracefully via 'ecflow_client --terminate'.
+
+    :param config: A dict, a YAMLConfig, or a path to a YAML file providing server settings (None =>
+        read stdin).
+    :param port: TCP port to use (None => pick a random available port from the range
+        ECFLOW_PORT_MIN through ECFLOW_PORT_MAX).
+    :param insecure: Start the server without SSL security.
+    :param report: Output server details (e.g. hostname, port) as JSON to stdout.
+    :raises UWError: If the server fails to start.
+    """
+    cfg = YAMLConfig(config)
+    cfg.dereference()
+    validate(cfg)
+    server_cfg = cfg.data[STR.ecflow][STR.server]
+    # ECF_SSL in the YAML config can be: True (SSL on, default cert location), a <host>.<port>
+    # prefix string selecting named certificates in $HOME/.ecflowrc/ssl, False (SSL off), or absent
+    # (defaults to SSL on with auto-provisioned default certificates).
+    ecf_ssl = server_cfg.get("ECF_SSL")
+    ssl_on = not insecure and ecf_ssl is not False
+    if ssl_on:
+        try:
+            _ssl_check(ecf_ssl)
+        except UWSSLCertificateError:
+            if ecf_ssl in [None, True]:
+                _ssl_provision()
+    rundir = Path(server_cfg["ECF_HOME"])
+    # Exclude ECF_SSL from cfg_vars: it is handled explicitly below (it may be a bool in the YAML,
+    # and ecFlow interprets any non-empty env string as an SSL flag or cert path).
+    cfg_vars = {k: str(v) for k, v in server_cfg.items() if k != "ECF_SSL"}
+    env = {**os.environ, **cfg_vars}
+    if ssl_on:
+        env["ECF_SSL"] = ecf_ssl if isinstance(ecf_ssl, str) else "1"
+    else:
+        # ecFlow enables SSL if ECF_SSL is set to any value, so unset it for an insecure server.
+        env.pop("ECF_SSL", None)
+    # Server variables to echo back when reporting: all config-supplied ECF_* values plus the
+    # runtime-determined host and SSL setting. ECF_PORT is added once the port is known.
+    report_vars = {**cfg_vars, "ECF_HOST": socket.gethostname()}
+    if ssl_on:
+        report_vars["ECF_SSL"] = ecf_ssl if isinstance(ecf_ssl, str) else "1"
+    thread = _ServerThread(target=_server_start, args=[rundir, env, port, insecure])
+
+    def shutdown(_signum: int, _frame: FrameType | None) -> None:
+        log.info("Terminating")
+        thread.terminal.set()
+        if thread.port:
+            cmd = "ecflow_client %s--port %s --terminate=yes" % (
+                "" if insecure else "--ssh",
+                thread.port,
+            )
+            run_shell_cmd(cmd=cmd, quiet=True)
+
+    signal.signal(signal.SIGINT, shutdown)
+    thread.start()
+    _server_wait(thread, insecure, report_vars=report_vars if report else None)
+    thread.join()
+    if thread.error:
+        raise UWError(thread.error)
+
+
+def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
+    """
+    Validate an ecFlow config against the internal ecFlow schema.
+
+    :param config: A dict, a YAMLConfig, a path to a YAML file, or None (None => read stdin).
+    :return: True if the config conforms to the schema.
+    :raises: UWConfigError if validation fails.
+    """
+    kwargs: dict = {"schema_name": STR.ecflow, "desc": "ecFlow config"}
+    if isinstance(config, (dict, YAMLConfig)):
+        kwargs["config_data"] = config
+    else:
+        kwargs["config_path"] = config
+    validate_internal(**kwargs)
+    return True
+
+# Private
+
+_SSL_DIR = Path.home() / ".ecflowrc" / "ssl"
+_SSL_KEY = "server.key"
+_SSL_CERT = "server.crt"
+_SSL_DHPARAM = "dh2048.pem"
+_SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
 
 class _ECFlowDef:
     """
@@ -74,6 +193,8 @@ class _ECFlowDef:
 
     def __str__(self):
         return self._d.__str__()
+
+    # Public
 
     def write_ecf_scripts(self, path: Path | str) -> None:
         """
@@ -108,6 +229,8 @@ class _ECFlowDef:
             log.debug("No output path provided, writing the suite definition to stdout.")
         with writable(path) as f:
             print(str(self).rstrip("\n"), file=f)
+
+    # Private
 
     def _add_node(  # noqa: PLR0912
         self,
@@ -394,35 +517,24 @@ class _ECFlowDef:
         return tag, name
 
 
-def realize(
-    config: YAMLConfig | Path | None,
-    output_path: Path | None = None,
-    scripts_path: Path | None = None,
-) -> str:
+class _ServerThread(Thread):
     """
-    Realize the ecFlow suite defined in a given YAML as a Suite Definition and corresponding ecf
-    scripts (if 'scripts_path' is provided).
-
-    :param config: Path to YAML input file (None => read stdin), or YAMLConfig object.
-    :param output_path: Path to write the rendered Suite Definition file (None => write to stdout).
-    :param scripts_path: Path to write the rendered ecf scripts (None => do not write scripts).
-    :return: Suite Definition as a string.
+    A thread that runs an ecFlow server, tracking the port in use and shutdown state.
     """
-    suite = _ECFlowDef(config)
-    suite.write_suite_definition(output_path)
-    if scripts_path:
-        suite.write_ecf_scripts(scripts_path)
-    return str(suite)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.port: int | None = None
+        self.terminal = Event()
+        self.error: str | None = None
 
 
-# Private helpers
-
-
-_SSL_DIR = Path.home() / ".ecflowrc" / "ssl"
-_SSL_KEY = "server.key"
-_SSL_CERT = "server.crt"
-_SSL_DHPARAM = "dh2048.pem"
-_SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
+def _client(port: int, insecure: bool) -> Client:
+    hostname = socket.gethostname()
+    c = Client(hostname, str(port))
+    if not insecure:
+        c.enable_ssl()
+    return c
 
 
 def _node(cls: type[Node], name: str) -> Node:
@@ -443,173 +555,6 @@ def _openssl() -> Path:
         msg = "openssl not found on PATH"
         raise UWError(msg)
     return Path(path)
-
-
-def _ssl_check(prefix: str | None) -> None:
-    """
-    Verify that the appropriate SSL certificate triplet exists in $HOME/.ecflowrc/ssl.
-
-    The files comprising the triplet are <prefix>.{crt,key,pem} when 'prefix' is provided, otherwise
-    the default files specified by _SSL_FILES.
-
-    :param prefix: The <host>.<port> prefix identifying the certificate triplet.
-    :raises UWSSLCertificateError: If one or more of the required files are missing.
-    """
-    fns = [f"{prefix}{ext}" for ext in (".crt", ".key", ".pem")] if prefix else _SSL_FILES
-    paths = [_SSL_DIR / fn for fn in fns]
-    if missing := [path for path in paths if not path.is_file()]:
-        if _SSL_DIR.is_dir() or prefix:
-            log.error("Missing SSL certificate file(s): %s", ", ".join(map(str, missing)))
-        if _SSL_DIR.is_dir() and not prefix:
-            log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)
-        raise UWSSLCertificateError
-    log.info("Using SSL certificates %s in %s", ", ".join(fns), _SSL_DIR)
-
-
-def _ssl_provision() -> None:
-    """
-    Provision SSL certificates in $HOME/.ecflowrc/ssl.
-
-    :raises UWError: If or if certificate generation fails.
-    """
-    _SSL_DIR.mkdir(parents=True, exist_ok=True)
-    _ssl_generate_key(_SSL_DIR / _SSL_KEY)
-    _ssl_generate_cert(_SSL_DIR / _SSL_CERT, _SSL_DIR / _SSL_KEY)
-    _ssl_generate_dhparam(_SSL_DIR / _SSL_DHPARAM)
-    log.info("SSL certificate files written to %s", _SSL_DIR)
-
-
-def _ssl_generate_cert(path: Path, key_path: Path) -> None:
-    """
-    Generate a self-signed X.509 certificate at 'path' using the key at 'key_path'.
-
-    :param path: Destination for the certificate file.
-    :param key_path: Path to the existing RSA private key.
-    :raises UWError: If openssl reports failure.
-    """
-    hostname = socket.gethostname()
-    log.info("Generating SSL certificate: %s", path)
-    cmd = "umask 077 && %s req -x509 -key %s -new -out %s -days 3650 -subj /CN=%s" % (
-        _openssl(),
-        key_path,
-        path,
-        hostname,
-    )
-    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
-    if not success:
-        msg = f"Failed to generate SSL certificate at {path}"
-        raise UWError(msg)
-
-
-def _ssl_generate_dhparam(path: Path) -> None:
-    """
-    Generate 2048-bit Diffie-Hellman parameters at 'path'.
-
-    :param path: Destination for the DH parameters file.
-    :raises UWError: If openssl reports failure.
-    """
-    log.info("Generating DH parameters: %s", path)
-    cmd = "umask 077 && %s dhparam -out %s 2048" % (_openssl(), path)
-    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
-    if not success:
-        msg = f"Failed to generate DH parameters at {path}"
-        raise UWError(msg)
-
-
-def _ssl_generate_key(path: Path) -> None:
-    """
-    Generate a 2048-bit RSA private key (no password) at 'path'.
-
-    :param path: Destination for the private key file.
-    :raises UWError: If openssl reports failure.
-    """
-    log.info("Generating SSL private key: %s", path)
-    cmd = "umask 077 && %s genrsa -out %s 2048" % (_openssl(), path)
-    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
-    if not success:
-        msg = f"Failed to generate SSL private key at {path}"
-        raise UWError(msg)
-
-
-class _ServerThread(Thread):
-    """
-    A thread that runs an ecFlow server, tracking the port in use and shutdown state.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.port: int | None = None
-        self.terminal = Event()
-        self.error: str | None = None
-
-
-def server(
-    config: dict | YAMLConfig | Path | None,
-    port: int | None = None,
-    insecure: bool = False,
-    report: bool = False,
-) -> None:
-    """
-    Start an ecFlow server on an available TCP port, optionally with SSL security enabled.
-
-    The server runs in the foreground until interrupted (e.g. via CTRL-C), at which point it is shut
-    down gracefully via 'ecflow_client --terminate'.
-
-    :param config: A dict, a YAMLConfig, or a path to a YAML file providing server settings (None =>
-        read stdin).
-    :param port: TCP port to use (None => pick a random available port from the range
-        ECFLOW_PORT_MIN through ECFLOW_PORT_MAX).
-    :param insecure: Start the server without SSL security.
-    :param report: Output server details (e.g. hostname, port) as JSON to stdout.
-    :raises UWError: If the server fails to start.
-    """
-    cfg = YAMLConfig(config)
-    cfg.dereference()
-    validate(cfg)
-    server_cfg = cfg.data[STR.ecflow][STR.server]
-    # ECF_SSL in the YAML config can be: True (SSL on, default cert location), a <host>.<port>
-    # prefix string selecting named certificates in $HOME/.ecflowrc/ssl, False (SSL off), or absent
-    # (defaults to SSL on with auto-provisioned default certificates).
-    ecf_ssl = server_cfg.get("ECF_SSL")
-    ssl_on = not insecure and ecf_ssl is not False
-    if ssl_on:
-        try:
-            _ssl_check(ecf_ssl)
-        except UWSSLCertificateError:
-            if ecf_ssl in [None, True]:
-                _ssl_provision()
-    rundir = Path(server_cfg["ECF_HOME"])
-    # Exclude ECF_SSL from cfg_vars: it is handled explicitly below (it may be a bool in the YAML,
-    # and ecFlow interprets any non-empty env string as an SSL flag or cert path).
-    cfg_vars = {k: str(v) for k, v in server_cfg.items() if k != "ECF_SSL"}
-    env = {**os.environ, **cfg_vars}
-    if ssl_on:
-        env["ECF_SSL"] = ecf_ssl if isinstance(ecf_ssl, str) else "1"
-    else:
-        # ecFlow enables SSL if ECF_SSL is set to any value, so unset it for an insecure server.
-        env.pop("ECF_SSL", None)
-    # Server variables to echo back when reporting: all config-supplied ECF_* values plus the
-    # runtime-determined host and SSL setting. ECF_PORT is added once the port is known.
-    report_vars = {**cfg_vars, "ECF_HOST": socket.gethostname()}
-    if ssl_on:
-        report_vars["ECF_SSL"] = ecf_ssl if isinstance(ecf_ssl, str) else "1"
-    thread = _ServerThread(target=_server_start, args=[rundir, env, port, insecure])
-    # ecflow_client must speak SSL to a secure server, else requests fail with a TLS mismatch.
-    ssl_opt = "" if insecure else "--ssl "
-
-    def shutdown(_signum: int, _frame: FrameType | None) -> None:
-        log.info("Terminating")
-        thread.terminal.set()
-        if thread.port:
-            cmd = "ecflow_client %s--port %s --terminate=yes" % (ssl_opt, thread.port)
-            run_shell_cmd(cmd=cmd, quiet=True)
-
-    signal.signal(signal.SIGINT, shutdown)
-    thread.start()
-    _server_wait(thread, ssl_opt=ssl_opt, report_vars=report_vars if report else None)
-    thread.join()
-    if thread.error:
-        raise UWError(thread.error)
 
 
 def _server_start(rundir: Path, env: dict[str, str], port: int | None, insecure: bool) -> None:
@@ -666,27 +611,28 @@ def _server_start(rundir: Path, env: dict[str, str], port: int | None, insecure:
             return
 
 
-def _server_wait(thread: _ServerThread, ssl_opt: str, report_vars: dict[str, str] | None) -> None:
+def _server_wait(thread: _ServerThread, insecure: bool, report_vars: dict[str, str] | None) -> None:
     """
     Wait for the server to respond to a ping, then optionally report its details.
 
     :param thread: The running server thread.
-    :param ssl_opt: ecflow_client SSL option ('--ssl' for secure servers, else the empty string).
-    :param report_vars: Server variables to report as JSON once the server is up (None => do not
-        report).
+    :param insecure: Run without SSL?
+    :param report_vars: Server variables to report as JSON (None => do not report).
     """
     while not thread.terminal.is_set():
         if thread.port:
-            cmd = f"ecflow_client {ssl_opt}--port {thread.port} --ping"
-            success, _ = run_shell_cmd(cmd=cmd, quiet=True)
-            if success:
-                log.info("Server started on port %s", thread.port)
-                if report_vars is not None:
-                    _server_report(port=thread.port, report_vars=report_vars)
-                break
-        # Wait briefly before re-checking, so polling does not spin a CPU core or hammer
-        # ecflow_client while the server starts up (or fails to).
-        sleep(0.2)
+            try:
+                _client(thread.port, insecure).ping()
+            except RuntimeError as e:
+                if "Failed to connect" in str(e):
+                    log.debug("Waiting for server on %s:%s", hostname, thread.port)
+                    sleep(0.2)
+                    continue
+                raise
+            log.info("Server started on port %s", thread.port)
+            if report_vars is not None:
+                _server_report(port=thread.port, report_vars=report_vars)
+            break
 
 
 def _server_report(port: int, report_vars: dict[str, str]) -> None:
@@ -702,18 +648,87 @@ def _server_report(port: int, report_vars: dict[str, str]) -> None:
     print(json.dumps({"vars": vars_}, indent=2, sort_keys=True), flush=True)
 
 
-def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
+def _ssl_check(prefix: str | None) -> None:
     """
-    Validate an ecFlow config against the internal ecFlow schema.
+    Verify that the appropriate SSL certificate triplet exists in $HOME/.ecflowrc/ssl.
 
-    :param config: A dict, a YAMLConfig, a path to a YAML file, or None (None => read stdin).
-    :return: True if the config conforms to the schema.
-    :raises: UWConfigError if validation fails.
+    The files comprising the triplet are <prefix>.{crt,key,pem} when 'prefix' is provided, otherwise
+    the default files specified by _SSL_FILES.
+
+    :param prefix: The <host>.<port> prefix identifying the certificate triplet.
+    :raises UWSSLCertificateError: If one or more of the required files are missing.
     """
-    kwargs: dict = {"schema_name": STR.ecflow, "desc": "ecFlow config"}
-    if isinstance(config, (dict, YAMLConfig)):
-        kwargs["config_data"] = config
-    else:
-        kwargs["config_path"] = config
-    validate_internal(**kwargs)
-    return True
+    fns = [f"{prefix}{ext}" for ext in (".crt", ".key", ".pem")] if prefix else _SSL_FILES
+    paths = [_SSL_DIR / fn for fn in fns]
+    if missing := [path for path in paths if not path.is_file()]:
+        if _SSL_DIR.is_dir() or prefix:
+            log.error("Missing SSL certificate file(s): %s", ", ".join(map(str, missing)))
+        if _SSL_DIR.is_dir() and not prefix:
+            log.error("Provide these files or remove %s to automatically generate", _SSL_DIR)
+        raise UWSSLCertificateError
+    log.info("Using SSL certificates %s in %s", ", ".join(fns), _SSL_DIR)
+
+
+def _ssl_generate_cert(path: Path, key_path: Path) -> None:
+    """
+    Generate a self-signed X.509 certificate at 'path' using the key at 'key_path'.
+
+    :param path: Destination for the certificate file.
+    :param key_path: Path to the existing RSA private key.
+    :raises UWError: If openssl reports failure.
+    """
+    hostname = socket.gethostname()
+    log.info("Generating SSL certificate: %s", path)
+    cmd = "umask 077 && %s req -x509 -key %s -new -out %s -days 3650 -subj /CN=%s" % (
+        _openssl(),
+        key_path,
+        path,
+        hostname,
+    )
+    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+    if not success:
+        msg = f"Failed to generate SSL certificate at {path}"
+        raise UWError(msg)
+
+
+def _ssl_generate_dhparam(path: Path) -> None:
+    """
+    Generate 2048-bit Diffie-Hellman parameters at 'path'.
+
+    :param path: Destination for the DH parameters file.
+    :raises UWError: If openssl reports failure.
+    """
+    log.info("Generating DH parameters: %s", path)
+    cmd = "umask 077 && %s dhparam -out %s 2048" % (_openssl(), path)
+    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+    if not success:
+        msg = f"Failed to generate DH parameters at {path}"
+        raise UWError(msg)
+
+
+def _ssl_generate_key(path: Path) -> None:
+    """
+    Generate a 2048-bit RSA private key (no password) at 'path'.
+
+    :param path: Destination for the private key file.
+    :raises UWError: If openssl reports failure.
+    """
+    log.info("Generating SSL private key: %s", path)
+    cmd = "umask 077 && %s genrsa -out %s 2048" % (_openssl(), path)
+    success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+    if not success:
+        msg = f"Failed to generate SSL private key at {path}"
+        raise UWError(msg)
+
+
+def _ssl_provision() -> None:
+    """
+    Provision SSL certificates in $HOME/.ecflowrc/ssl.
+
+    :raises UWError: If or if certificate generation fails.
+    """
+    _SSL_DIR.mkdir(parents=True, exist_ok=True)
+    _ssl_generate_key(_SSL_DIR / _SSL_KEY)
+    _ssl_generate_cert(_SSL_DIR / _SSL_CERT, _SSL_DIR / _SSL_KEY)
+    _ssl_generate_dhparam(_SSL_DIR / _SSL_DHPARAM)
+    log.info("SSL certificate files written to %s", _SSL_DIR)

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -20,7 +20,6 @@ from time import sleep
 from typing import TYPE_CHECKING, cast
 
 from ecflow import (  # type: ignore[import-untyped]
-    Client,
     Defs,
     DState,
     Family,
@@ -526,14 +525,6 @@ class _ServerThread(Thread):
         self.port: int | None = None
         self.terminal = Event()
         self.error: str | None = None
-
-
-def _client(port: int, insecure: bool) -> Client:
-    hostname = socket.gethostname()
-    c = Client(hostname, str(port))
-    if not insecure:
-        c.enable_ssl()
-    return c
 
 
 def _node(cls: type[Node], name: str) -> Node:

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -84,19 +84,25 @@ def server(
     report: bool = False,
 ) -> None:
     """
-    Start an ecFlow server on an available TCP port, optionally with SSL security enabled.
+    Start an ecFlow server, optionally with SSL security enabled.
 
     The server runs in the foreground until interrupted (e.g. via CTRL-C), at which point it is shut
-    down gracefully via 'ecflow_client --terminate'.
+    down gracefully via the ecFlow client's terminate option.
 
-    :param config: A dict, a YAMLConfig, or a path to a YAML file providing server settings (None =>
-        read stdin).
-    :param port: TCP port to use (None => pick a random available port from the range
-        ECFLOW_PORT_MIN through ECFLOW_PORT_MAX).
+    :param config: Config providing server settings (None => read stdin).
+    :param port: TCP port to use (None => random port between ECFLOW_PORT_MIN and ECFLOW_PORT_MAX).
     :param insecure: Start the server without SSL security.
     :param report: Output server details (e.g. hostname, port) as JSON to stdout.
     :raises UWError: If the server fails to start.
     """
+
+    def shutdown(_signum: int, _frame: FrameType | None) -> None:
+        log.info("Terminating")
+        thread.terminal.set()
+        if thread.port:
+            cmd = "ecflow_client %s--port %s --terminate=yes" % (ssl_opt, thread.port)
+            run_shell_cmd(cmd=cmd, quiet=True)
+
     cfg = YAMLConfig(config)
     cfg.dereference()
     validate(cfg)
@@ -128,20 +134,11 @@ def server(
     if ssl_on:
         report_vars["ECF_SSL"] = ecf_ssl if isinstance(ecf_ssl, str) else "1"
     thread = _ServerThread(target=_server_start, args=[rundir, env, port, insecure])
-
-    def shutdown(_signum: int, _frame: FrameType | None) -> None:
-        log.info("Terminating")
-        thread.terminal.set()
-        if thread.port:
-            cmd = "ecflow_client %s--port %s --terminate=yes" % (
-                "" if insecure else "--ssh",
-                thread.port,
-            )
-            run_shell_cmd(cmd=cmd, quiet=True)
-
+    # ecflow_client must speak SSL to a secure server, else requests fail with a TLS mismatch.
+    ssl_opt = "" if insecure else "--ssl "
     signal.signal(signal.SIGINT, shutdown)
     thread.start()
-    _server_wait(thread, insecure, report_vars=report_vars if report else None)
+    _server_wait(thread, ssl_opt=ssl_opt, report_vars=report_vars if report else None)
     thread.join()
     if thread.error:
         raise UWError(thread.error)
@@ -163,6 +160,7 @@ def validate(config: dict | YAMLConfig | Path | None = None) -> bool:
     validate_internal(**kwargs)
     return True
 
+
 # Private
 
 _SSL_DIR = Path.home() / ".ecflowrc" / "ssl"
@@ -170,6 +168,7 @@ _SSL_KEY = "server.key"
 _SSL_CERT = "server.crt"
 _SSL_DHPARAM = "dh2048.pem"
 _SSL_FILES = [_SSL_DHPARAM, _SSL_CERT, _SSL_KEY]
+
 
 class _ECFlowDef:
     """
@@ -570,8 +569,7 @@ def _server_start(rundir: Path, env: dict[str, str], port: int | None, insecure:
 
     :param rundir: Directory to run the server in (ECF_HOME).
     :param env: Base environment variables for the server.
-    :param port: A specific port to use, or None to pick a random port from the range
-        ECFLOW_PORT_MIN through ECFLOW_PORT_MAX.
+    :param port: TCP port to use (None => random port between ECFLOW_PORT_MIN and ECFLOW_PORT_MAX).
     :param insecure: Start the server without SSL security.
     """
     thread = cast(_ServerThread, current_thread())
@@ -611,28 +609,27 @@ def _server_start(rundir: Path, env: dict[str, str], port: int | None, insecure:
             return
 
 
-def _server_wait(thread: _ServerThread, insecure: bool, report_vars: dict[str, str] | None) -> None:
+def _server_wait(thread: _ServerThread, ssl_opt: str, report_vars: dict[str, str] | None) -> None:
     """
     Wait for the server to respond to a ping, then optionally report its details.
 
     :param thread: The running server thread.
-    :param insecure: Run without SSL?
-    :param report_vars: Server variables to report as JSON (None => do not report).
+    :param ssl_opt: ecflow_client SSL option ('--ssl' for secure servers, else the empty string).
+    :param report_vars: Server variables to report as JSON once the server is up (None => do not
+        report).
     """
     while not thread.terminal.is_set():
         if thread.port:
-            try:
-                _client(thread.port, insecure).ping()
-            except RuntimeError as e:
-                if "Failed to connect" in str(e):
-                    log.debug("Waiting for server on %s:%s", hostname, thread.port)
-                    sleep(0.2)
-                    continue
-                raise
-            log.info("Server started on port %s", thread.port)
-            if report_vars is not None:
-                _server_report(port=thread.port, report_vars=report_vars)
-            break
+            cmd = f"ecflow_client {ssl_opt}--port {thread.port} --ping"
+            success, _ = run_shell_cmd(cmd=cmd, quiet=True)
+            if success:
+                log.info("Server started on port %s", thread.port)
+                if report_vars is not None:
+                    _server_report(port=thread.port, report_vars=report_vars)
+                break
+        # Wait briefly before re-checking, so polling does not spin a CPU core or hammer
+        # ecflow_client while the server starts up (or fails to).
+        sleep(0.2)
 
 
 def _server_report(port: int, report_vars: dict[str, str]) -> None:

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -72,6 +72,120 @@ class TestECFlowDef:
     Tests for class uwtools.ecflow._ECFlowDef.
     """
 
+    def test_ecflow__ECFlowDef__init__defs_check_bad_trigger(self):
+        config = {
+            "ecflow": {
+                "suitedef": {
+                    "suite_test": {
+                        "task_a": {
+                            "script": {
+                                "execution": {
+                                    "incantation": "/path/to/run.sh",
+                                }
+                            },
+                            "trigger": "nonexistent_task == complete",
+                        }
+                    }
+                }
+            }
+        }
+        with raises(AssertionError) as e:
+            _ECFlowDef(config=config)
+        assert "Could not find node 'nonexistent_task'" in str(e)
+
+    def test_ecflow__ECFlowDef__init__full_workflow(self, tmp_path):
+        config = {
+            "ecflow": {
+                "suitedef": {
+                    "suite_test": {
+                        "vars": {"SUITE_VAR": "value"},
+                        "family_prep": {
+                            "task_setup": {
+                                "trigger": "1==1",
+                                "script": {
+                                    "execution": {
+                                        "incantation": "/path/to/prep.sh",
+                                    },
+                                },
+                            },
+                        },
+                        "task_run": {
+                            "trigger": "/test/prep/setup == complete",
+                            "script": {
+                                "execution": {"incantation": "/path/to/run.sh"},
+                            },
+                        },
+                    }
+                }
+            }
+        }
+        ecf = _ECFlowDef(config=config)
+        # Verify suite definition was created.
+        suite_def = str(ecf)
+        assert "suite test" in suite_def
+        assert "family prep" in suite_def
+        assert "task setup" in suite_def
+        assert "task run" in suite_def
+        ecf.write_suite_definition(tmp_path)
+        assert (tmp_path / "suite.def").is_file()
+        ecf.write_ecf_scripts(tmp_path)
+        assert (tmp_path / "test" / "run.ecf").is_file()
+
+    def test_ecflow__ECFlowDef__init__missing_ecflow_key(self):
+        config: dict = {"not_ecflow": {}}
+        with raises(UWConfigError):
+            _ECFlowDef(config=config)
+
+    def test_ecflow__ECFlowDef__init__with_config_object(self, minimal_config):
+        cfg = YAMLConfig(minimal_config)
+        ecf = _ECFlowDef(config=cfg)
+        assert ecf._config == {}
+        assert isinstance(ecf._d, Defs)
+
+    def test_ecflow__ECFlowDef__init__with_dict(self, minimal_config):
+        ecf = _ECFlowDef(config=minimal_config)
+        assert ecf._config == {}
+        assert ecf._scheduler is None
+        assert isinstance(ecf._d, Defs)
+
+    def test_ecflow__ECFlowDef__init__with_expand(self):
+        config = {
+            "ecflow": {
+                "suitedef": {
+                    "suite_ensemble": {
+                        "tasks_member_{{ ec.MEM }}": {
+                            "expand": {"MEM": ["01", "02", "03"]},
+                            "script": {"execution": {"incantation": "hello.exe"}},
+                        }
+                    }
+                }
+            }
+        }
+        ecf = _ECFlowDef(config=config)
+        suite_def = str(ecf)
+        # All three members should be created.
+        assert "task member_01" in suite_def
+        assert "task member_02" in suite_def
+        assert "task member_03" in suite_def
+
+    def test_ecflow__ECFlowDef__init__with_path(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("ecflow:\n  suitedef:\n    scheduler: pbs\n")
+        ecf = _ECFlowDef(config=config_file)
+        assert ecf._scheduler == "pbs"
+        assert isinstance(ecf._d, Defs)
+
+    def test_ecflow__ECFlowDef__init__with_scheduler(self):
+        config = {"ecflow": {"suitedef": {"scheduler": "slurm"}}}
+        ecf = _ECFlowDef(config=config)
+        assert ecf._scheduler == "slurm"
+
+    def test_ecflow__ECFlowDef__str__(self, instance):
+        result = str(instance)
+        assert isinstance(result, str)
+
+    # Public
+
     def test_ecflow__ECFlowDef_write_ecf_scripts__no_scripts(self, instance, logged, tmp_path):
         instance.write_ecf_scripts(tmp_path)
         assert logged("No scripts are configured for this workflow")
@@ -103,6 +217,8 @@ class TestECFlowDef:
         nested_path = tmp_path / "nested" / "output"
         instance.write_suite_definition(nested_path)
         assert (nested_path / "suite.def").is_file()
+
+    # Private
 
     @mark.parametrize("prefix", ["family", "task"])
     def test_ecflow__ECFlowDef__add_node__bad_name_family_task(self, instance, prefix):
@@ -465,114 +581,6 @@ class TestECFlowDef:
         with raises(UWConfigError, match="same length"):
             instance._expand_block(config, "suite", Suite, suite)
 
-    def test_ecflow__ECFlowDef__init__defs_check_bad_trigger(self):
-        config = {
-            "ecflow": {
-                "suitedef": {
-                    "suite_test": {
-                        "task_a": {
-                            "script": {
-                                "execution": {
-                                    "incantation": "/path/to/run.sh",
-                                }
-                            },
-                            "trigger": "nonexistent_task == complete",
-                        }
-                    }
-                }
-            }
-        }
-        with raises(AssertionError) as e:
-            _ECFlowDef(config=config)
-        assert "Could not find node 'nonexistent_task'" in str(e)
-
-    def test_ecflow__ECFlowDef__init__full_workflow(self, tmp_path):
-        config = {
-            "ecflow": {
-                "suitedef": {
-                    "suite_test": {
-                        "vars": {"SUITE_VAR": "value"},
-                        "family_prep": {
-                            "task_setup": {
-                                "trigger": "1==1",
-                                "script": {
-                                    "execution": {
-                                        "incantation": "/path/to/prep.sh",
-                                    },
-                                },
-                            },
-                        },
-                        "task_run": {
-                            "trigger": "/test/prep/setup == complete",
-                            "script": {
-                                "execution": {"incantation": "/path/to/run.sh"},
-                            },
-                        },
-                    }
-                }
-            }
-        }
-        ecf = _ECFlowDef(config=config)
-        # Verify suite definition was created.
-        suite_def = str(ecf)
-        assert "suite test" in suite_def
-        assert "family prep" in suite_def
-        assert "task setup" in suite_def
-        assert "task run" in suite_def
-        ecf.write_suite_definition(tmp_path)
-        assert (tmp_path / "suite.def").is_file()
-        ecf.write_ecf_scripts(tmp_path)
-        assert (tmp_path / "test" / "run.ecf").is_file()
-
-    def test_ecflow__ECFlowDef__init__missing_ecflow_key(self):
-        config: dict = {"not_ecflow": {}}
-        with raises(UWConfigError):
-            _ECFlowDef(config=config)
-
-    def test_ecflow__ECFlowDef__init__with_config_object(self, minimal_config):
-        cfg = YAMLConfig(minimal_config)
-        ecf = _ECFlowDef(config=cfg)
-        assert ecf._config == {}
-        assert isinstance(ecf._d, Defs)
-
-    def test_ecflow__ECFlowDef__init__with_dict(self, minimal_config):
-        ecf = _ECFlowDef(config=minimal_config)
-        assert ecf._config == {}
-        assert ecf._scheduler is None
-        assert isinstance(ecf._d, Defs)
-
-    def test_ecflow__ECFlowDef__init__with_expand(self):
-        config = {
-            "ecflow": {
-                "suitedef": {
-                    "suite_ensemble": {
-                        "tasks_member_{{ ec.MEM }}": {
-                            "expand": {"MEM": ["01", "02", "03"]},
-                            "script": {"execution": {"incantation": "hello.exe"}},
-                        }
-                    }
-                }
-            }
-        }
-        ecf = _ECFlowDef(config=config)
-        suite_def = str(ecf)
-        # All three members should be created.
-        assert "task member_01" in suite_def
-        assert "task member_02" in suite_def
-        assert "task member_03" in suite_def
-
-    def test_ecflow__ECFlowDef__init__with_path(self, tmp_path):
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("ecflow:\n  suitedef:\n    scheduler: pbs\n")
-        ecf = _ECFlowDef(config=config_file)
-        assert ecf._scheduler == "pbs"
-        assert isinstance(ecf._d, Defs)
-
-    def test_ecflow__ECFlowDef__init__with_scheduler(self):
-        config = {"ecflow": {"suitedef": {"scheduler": "slurm"}}}
-        ecf = _ECFlowDef(config=config)
-        assert ecf._scheduler == "slurm"
-
     def test_ecflow__ECFlowDef__jobscheduler(self, instance_with_scheduler):
         execution = {"threads": 4, "batchargs": {"queue": "batch"}}
         with patch.object(ecflow.JobScheduler, "get_scheduler") as get_scheduler:
@@ -609,10 +617,6 @@ class TestECFlowDef:
             }
         )
 
-    def test_ecflow__ECFlowDef__str__(self, instance):
-        result = str(instance)
-        assert isinstance(result, str)
-
     @mark.parametrize(
         ("key", "expected"),
         [
@@ -625,6 +629,9 @@ class TestECFlowDef:
     )
     def test_ecflow__ECFlowDef__tag_name(self, instance, key, expected):
         assert instance._tag_name(key) == expected
+
+
+# realize
 
 
 def test_ecflow_realize__cfg_to_file(tmp_path, assets):
@@ -662,6 +669,206 @@ def test_ecflow_realize__write_scripts(capsys, assets):
         write_scripts.assert_called_once_with(script_path)
     output = capsys.readouterr().out
     assert output == expected
+
+
+# server
+
+
+@fixture
+def server_mocks():
+    """
+    Patch the collaborators of ecflow.server() and yield handles to the mocks.
+
+    The default config is a minimal valid secure-server config; tests that need
+    different data can reassign `m.cfg.data` before calling ecflow.server().
+    """
+    cfg = Mock()
+    cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf"}}}
+    with (
+        patch.object(ecflow, "YAMLConfig", return_value=cfg) as yamlconfig,
+        patch.object(ecflow, "_ServerThread") as thread_cls,
+        patch.object(ecflow, "_server_wait") as server_wait,
+        patch.object(ecflow, "_ssl_check") as ssl_check,
+        patch.object(ecflow, "_ssl_provision") as ssl_provision,
+        patch.object(ecflow, "validate") as validate,
+        patch.object(ecflow.signal, "signal") as signal,
+    ):
+        thread = thread_cls.return_value
+        thread.error = None
+        yield ns(
+            cfg=cfg,
+            config_path=Path("/some/server.yaml"),
+            server_wait=server_wait,
+            signal=signal,
+            ssl_check=ssl_check,
+            ssl_provision=ssl_provision,
+            thread=thread,
+            thread_cls=thread_cls,
+            validate=validate,
+            yamlconfig=yamlconfig,
+        )
+
+
+@mark.parametrize(
+    "config", [{"ECF_HOME": "/ecf"}, YAMLConfig({"ECF_HOME": "/ecf"}), Path("s.yaml")]
+)
+def test_ecflow_server__accepts_config_types(server_mocks, config):
+    ecflow.server(config=config, port=3141)
+    server_mocks.yamlconfig.assert_called_once_with(config)
+
+
+def test_ecflow_server__ecf_ssl_false_skips_ssl(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": False}}}
+    ecflow.server(config=m.config_path, port=3141)
+    m.ssl_provision.assert_not_called()
+    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
+    assert "ECF_SSL" not in env
+
+
+def test_ecflow_server__ecf_ssl_string_checks_named_cert(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "myhost.3141"}}}
+    ecflow.server(config=m.config_path, port=3141)
+    m.ssl_provision.assert_not_called()
+    m.ssl_check.assert_called_once_with("myhost.3141")
+    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
+    assert env["ECF_SSL"] == "myhost.3141"
+
+
+def test_ecflow_server__ecf_ssl_true_provisions_and_sets_env(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": True}}}
+    m.ssl_check.side_effect = UWSSLCertificateError
+    ecflow.server(config=m.config_path, port=3141)
+    m.ssl_provision.assert_called_once_with()
+    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
+    assert env["ECF_SSL"] == "1"
+
+
+def test_ecflow_server__insecure_skips_ssl(server_mocks):
+    ecflow.server(config=server_mocks.config_path, port=3141, insecure=True)
+    server_mocks.ssl_provision.assert_not_called()
+    server_mocks.ssl_check.assert_not_called()
+
+
+def test_ecflow_server__insecure_unsets_ecf_ssl_env(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "1"}}}
+    ecflow.server(config=m.config_path, port=3141, insecure=True)
+    _, env, _, insecure = m.thread_cls.call_args.kwargs["args"]
+    assert "ECF_SSL" not in env
+    assert insecure is True
+
+
+def test_ecflow_server__no_report_passes_none(server_mocks):
+    m = server_mocks
+    ecflow.server(config=m.config_path, port=54321)
+    assert m.server_wait.call_args.kwargs["report_vars"] is None
+
+
+def test_ecflow_server__raises_on_thread_error(server_mocks):
+    m = server_mocks
+    m.thread.error = "ecflow_server failed on port 3141: boom"
+    with raises(UWError, match="ecflow_server failed on port 3141"):
+        ecflow.server(config=m.config_path, port=3141)
+
+
+def test_ecflow_server__report_vars_include_config(server_mocks):
+    m = server_mocks
+    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_LOG": "my.log"}}}
+    with patch.object(ecflow.socket, "gethostname", return_value="server.hostname.com"):
+        ecflow.server(config=m.config_path, port=54321, report=True)
+    assert m.server_wait.call_args.kwargs["report_vars"] == {
+        "ECF_HOME": "/ecf",
+        "ECF_LOG": "my.log",
+        "ECF_HOST": "server.hostname.com",
+        "ECF_SSL": "1",
+    }
+
+
+def test_ecflow_server__report_vars_insecure_omits_ssl(server_mocks):
+    m = server_mocks
+    with patch.object(ecflow.socket, "gethostname", return_value="server.hostname.com"):
+        ecflow.server(config=m.config_path, port=54321, insecure=True, report=True)
+    assert m.server_wait.call_args.kwargs["report_vars"] == {
+        "ECF_HOME": "/ecf",
+        "ECF_HOST": "server.hostname.com",
+    }
+
+
+def test_ecflow_server__secure_sets_ecf_ssl_env(server_mocks):
+    ecflow.server(config=server_mocks.config_path, port=3141)
+    rundir, env, port, insecure = server_mocks.thread_cls.call_args.kwargs["args"]
+    assert rundir == Path("/ecf")
+    assert env["ECF_SSL"] == "1"
+    assert port == 3141
+    assert insecure is False
+
+
+def test_ecflow_server__shutdown_terminates(server_mocks):
+    m = server_mocks
+    m.thread.port = 54321
+    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as run:
+        ecflow.server(config=m.config_path, port=54321)
+        shutdown = m.signal.call_args.args[1]
+        shutdown(2, None)
+    m.thread.terminal.set.assert_called()
+    cmd = run.call_args.kwargs["cmd"]
+    assert "--ssl" in cmd
+    assert "--port 54321" in cmd
+    assert "--terminate=yes" in cmd
+
+
+def test_ecflow_server__shutdown_terminates_insecure_no_ssl(server_mocks):
+    m = server_mocks
+    m.thread.port = 54321
+    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as run:
+        ecflow.server(config=m.config_path, port=54321, insecure=True)
+        shutdown = m.signal.call_args.args[1]
+        shutdown(2, None)
+    cmd = run.call_args.kwargs["cmd"]
+    assert "--ssl" not in cmd
+    assert "--terminate=yes" in cmd
+
+
+def test_ecflow_server__shutdown_without_port_skips_terminate(server_mocks):
+    m = server_mocks
+    m.thread.port = None
+    with patch.object(ecflow, "run_shell_cmd") as run:
+        ecflow.server(config=m.config_path, port=54321)
+        shutdown = m.signal.call_args.args[1]
+        shutdown(2, None)
+    run.assert_not_called()
+
+
+@mark.parametrize("ecf_ssl", [None, True, False, "myhost.8888"])
+def test_ecflow_server__ssl_provision(ecf_ssl, server_mocks):
+    server_mocks.ssl_check.side_effect = UWSSLCertificateError
+    server_mocks.cfg.data["ecflow"]["server"]["ECF_SSL"] = ecf_ssl
+    ecflow.server(config=server_mocks.config_path, port=3141)
+    if ecf_ssl in [None, True]:
+        server_mocks.ssl_provision.assert_called_once_with()
+    else:
+        server_mocks.ssl_provision.assert_not_called()
+
+
+def test_ecflow_server__starts_thread_and_waits(server_mocks):
+    m = server_mocks
+    ecflow.server(config=m.config_path, port=3141)
+    m.signal.assert_called_once_with(ecflow.signal.SIGINT, m.signal.call_args.args[1])
+    m.thread.start.assert_called_once()
+    m.server_wait.assert_called_once()
+    m.thread.join.assert_called_once()
+
+
+def test_ecflow_server__validates_config(server_mocks):
+    m = server_mocks
+    ecflow.server(config=m.config_path, port=3141)
+    m.validate.assert_called_once_with(m.cfg)
+
+
+# validate
 
 
 def test_ecflow_validate__dict(minimal_config):
@@ -710,7 +917,7 @@ def test_ecflow_validate__yamlconfig(minimal_config):
     assert ecflow.validate(YAMLConfig(minimal_config))
 
 
-# SSL provisioning tests
+# _openssl
 
 
 def test_ecflow__openssl__not_found():
@@ -719,6 +926,203 @@ def test_ecflow__openssl__not_found():
         raises(UWError, match="openssl not found on PATH"),
     ):
         ecflow._openssl()
+
+
+# _server_report
+
+
+def test_ecflow__server_report(capsys):
+    ecflow._server_report(port=54321, report_vars={"ECF_HOST": "host.com", "ECF_SSL": "1"})
+    report = yaml.safe_load(capsys.readouterr().out)
+    assert report == {"vars": {"ECF_HOST": "host.com", "ECF_SSL": "1", "ECF_PORT": "54321"}}
+
+
+# _server_start
+
+
+def test_ecflow__server_start__fixed_port_ssl(tmp_path):
+    def fake_run_shell_cmd(*_args, **_kwargs):
+        thread.terminal.set()
+        return ""
+
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    with (
+        patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd) as run_shell_cmd,
+    ):
+        ecflow._server_start(rundir, {"ECF_HOME": str(rundir)}, 3141, False)
+    assert rundir.is_dir()
+    assert run_shell_cmd.call_args.kwargs["cmd"] == "ecflow_server --ssl"
+    assert run_shell_cmd.call_args.kwargs["cwd"] == rundir
+    assert run_shell_cmd.call_args.kwargs["env"]["ECF_PORT"] == "3141"
+    assert thread.port == 3141
+    assert thread.error is None
+
+
+def test_ecflow__server_start__fixed_port_insecure(tmp_path):
+    def fake_run_shell_cmd(*_args, **_kwargs):
+        thread.terminal.set()
+        return ""
+
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    with (
+        patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd) as run_shell_cmd,
+    ):
+        ecflow._server_start(rundir, {}, 3141, True)
+    assert run_shell_cmd.call_args.kwargs["cmd"] == "ecflow_server"
+
+
+def test_ecflow__server_start__fixed_port_other_failure(tmp_path):
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    err = CalledProcessError(1, "ecflow_server", output="something went wrong")
+    with (
+        patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
+    ):
+        ecflow._server_start(rundir, {}, 3141, False)
+    assert thread.error == "ecflow_server failed on port 3141: something went wrong"
+    assert thread.terminal.is_set()
+
+
+def test_ecflow__server_start__fixed_port_unavailable(tmp_path):
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    err = CalledProcessError(1, "ecflow_server", output="ecf: bind: Address already in use")
+    with (
+        patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
+    ):
+        ecflow._server_start(rundir, {}, 3141, False)
+    assert thread.error == "Requested port 3141 is unavailable"
+    assert thread.terminal.is_set()
+    assert thread.port is None
+
+
+def test_ecflow__server_start__launch_failure(tmp_path):
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    err = FileNotFoundError(2, "No such file or directory", "ecflow_server")
+    with (
+        patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
+    ):
+        ecflow._server_start(rundir, {}, 3141, False)
+    assert thread.error is not None
+    assert thread.error.startswith("Failed to launch ecflow_server:")
+    assert thread.terminal.is_set()
+
+
+def test_ecflow__server_start__random_port_failure(tmp_path):
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    err = CalledProcessError(1, "ecflow_server", output="something broke")
+    with (
+        patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow, "run_shell_cmd", side_effect=err),
+        patch.object(ecflow.random, "randint", return_value=31415),
+    ):
+        ecflow._server_start(rundir, {}, None, False)
+    assert thread.error == "ecflow_server failed on port 31415: something broke"
+    assert thread.terminal.is_set()
+
+
+def test_ecflow__server_start__random_port_retries_until_available(tmp_path):
+    def fake_run_shell_cmd(*_args, **kwargs):
+        ports.append(kwargs["env"]["ECF_PORT"])
+        if len(ports) == 1:
+            raise bind_err
+        thread.terminal.set()
+        return ""
+
+    thread = ecflow._ServerThread()
+    rundir = tmp_path / "ecf"
+    bind_err = CalledProcessError(1, "ecflow_server", output="ecf: bind: Address already in use")
+    ports: list[str] = []
+    with (
+        patch.object(ecflow, "current_thread", return_value=thread),
+        patch.object(ecflow.random, "randint", side_effect=[30000, 30001]),
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd),
+    ):
+        ecflow._server_start(rundir, {}, None, False)
+    assert ports == ["30000", "30001"]
+    assert thread.port == 30001
+    assert thread.error is None
+
+
+# _server_wait
+
+
+def test_ecflow__server_wait__exits_on_terminal():
+    thread = ecflow._ServerThread()
+    thread.terminal.set()
+    with patch.object(ecflow, "run_shell_cmd") as mock_cmd:
+        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
+    mock_cmd.assert_not_called()
+
+
+def test_ecflow__server_wait__insecure_ping_no_ssl():
+    thread = ecflow._ServerThread()
+    thread.port = 54321
+    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as mock_cmd:
+        ecflow._server_wait(thread, ssl_opt="", report_vars=None)
+    assert "--ssl" not in mock_cmd.call_args.kwargs["cmd"]
+
+
+def test_ecflow__server_wait__no_port_loops():
+    thread = ecflow._ServerThread()
+    thread.port = None
+    thread.terminal = Mock()
+    thread.terminal.is_set.side_effect = [False, True]
+    with (
+        patch.object(ecflow, "sleep") as mock_sleep,
+        patch.object(ecflow, "run_shell_cmd") as mock_cmd,
+    ):
+        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
+    mock_cmd.assert_not_called()
+    mock_sleep.assert_called_once_with(0.2)
+
+
+def test_ecflow__server_wait__no_report(capsys):
+    thread = ecflow._ServerThread()
+    thread.port = 54321
+    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")):
+        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
+    assert capsys.readouterr().out == ""
+
+
+def test_ecflow__server_wait__ping_fails_then_loops():
+    thread = ecflow._ServerThread()
+    thread.port = 54321
+    thread.terminal = Mock()
+    thread.terminal.is_set.side_effect = [False, True]
+    with (
+        patch.object(ecflow, "sleep") as mock_sleep,
+        patch.object(ecflow, "run_shell_cmd", return_value=(False, "")) as mock_cmd,
+    ):
+        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
+    mock_cmd.assert_called_once()
+    mock_sleep.assert_called_once_with(0.2)
+
+
+def test_ecflow__server_wait__pings_then_reports(capsys):
+    thread = ecflow._ServerThread()
+    thread.port = 54321
+    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as mock_cmd:
+        ecflow._server_wait(
+            thread, ssl_opt="--ssl ", report_vars={"ECF_HOME": "/ecf", "ECF_SSL": "1"}
+        )
+    cmd = mock_cmd.call_args.kwargs["cmd"]
+    assert "--ssl" in cmd
+    assert "--ping" in cmd
+    report = yaml.safe_load(capsys.readouterr().out)
+    assert report == {"vars": {"ECF_HOME": "/ecf", "ECF_SSL": "1", "ECF_PORT": "54321"}}
+
+
+# _ssl_check
 
 
 def test_ecflow__ssl_check__all_files_exist(logged, tmp_path):
@@ -767,25 +1171,7 @@ def test_ecflow__ssl_check__missing_named_files_raises(excluded, tmp_path, uwcap
     assert msg in uwcaplog.text
 
 
-def test_ecflow__ssl_provision__creates_dir_and_files(logged, tmp_path):
-    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
-
-    def fake_run(cmd, **_kwargs):
-        # Emulate openssl by creating the file named after its "-out" argument.
-        parts = cmd.split()
-        Path(parts[parts.index("-out") + 1]).touch()
-        return (True, "")
-
-    with (
-        patch.object(ecflow, "_SSL_DIR", ssl_dir),
-        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run),
-    ):
-        ecflow._ssl_provision()
-    assert ssl_dir.is_dir()
-    assert (ssl_dir / "server.key").is_file()
-    assert (ssl_dir / "server.crt").is_file()
-    assert (ssl_dir / "dh2048.pem").is_file()
-    assert logged("SSL certificate files written to %s" % ssl_dir)
+# _ssl_generate_cert
 
 
 def test_ecflow__ssl_generate_cert__failure(tmp_path):
@@ -808,6 +1194,9 @@ def test_ecflow__ssl_generate_cert__success(tmp_path):
     assert cert_path.is_file()
     # umask 077 in the shell command yields owner-only permissions on generated files.
     assert oct(cert_path.stat().st_mode)[-3:] == "600"
+
+
+# _ssl_generate_dhparam
 
 
 def test_ecflow__ssl_generate_dhparam__failure(tmp_path):
@@ -834,6 +1223,9 @@ def test_ecflow__ssl_generate_dhparam__success(tmp_path):
     assert f"dhparam -out {path} 2048" in cmd
 
 
+# _ssl_generate_key
+
+
 def test_ecflow__ssl_generate_key__failure(tmp_path):
     path = tmp_path / "server.key"
     with (
@@ -852,380 +1244,25 @@ def test_ecflow__ssl_generate_key__success(tmp_path):
     assert oct(path.stat().st_mode)[-3:] == "600"
 
 
-@fixture
-def server_mocks():
-    """
-    Patch the collaborators of ecflow.server() and yield handles to the mocks.
+# _ssl_provision
 
-    The default config is a minimal valid secure-server config; tests that need
-    different data can reassign `m.cfg.data` before calling ecflow.server().
-    """
-    cfg = Mock()
-    cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf"}}}
+
+def test_ecflow__ssl_provision__creates_dir_and_files(logged, tmp_path):
+    ssl_dir = tmp_path / ".ecflowrc" / "ssl"
+
+    def fake_run(cmd, **_kwargs):
+        # Emulate openssl by creating the file named after its "-out" argument.
+        parts = cmd.split()
+        Path(parts[parts.index("-out") + 1]).touch()
+        return (True, "")
+
     with (
-        patch.object(ecflow, "YAMLConfig", return_value=cfg) as yamlconfig,
-        patch.object(ecflow, "_ServerThread") as thread_cls,
-        patch.object(ecflow, "_server_wait") as server_wait,
-        patch.object(ecflow, "_ssl_check") as ssl_check,
-        patch.object(ecflow, "_ssl_provision") as ssl_provision,
-        patch.object(ecflow, "validate") as validate,
-        patch.object(ecflow.signal, "signal") as signal,
+        patch.object(ecflow, "_SSL_DIR", ssl_dir),
+        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run),
     ):
-        thread = thread_cls.return_value
-        thread.error = None
-        yield ns(
-            cfg=cfg,
-            config_path=Path("/some/server.yaml"),
-            server_wait=server_wait,
-            signal=signal,
-            ssl_check=ssl_check,
-            ssl_provision=ssl_provision,
-            thread=thread,
-            thread_cls=thread_cls,
-            validate=validate,
-            yamlconfig=yamlconfig,
-        )
-
-
-def test_ecflow_server__validates_config(server_mocks):
-    m = server_mocks
-    ecflow.server(config=m.config_path, port=3141)
-    m.validate.assert_called_once_with(m.cfg)
-
-
-@mark.parametrize(
-    "config", [{"ECF_HOME": "/ecf"}, YAMLConfig({"ECF_HOME": "/ecf"}), Path("s.yaml")]
-)
-def test_ecflow_server__accepts_config_types(server_mocks, config):
-    ecflow.server(config=config, port=3141)
-    server_mocks.yamlconfig.assert_called_once_with(config)
-
-
-def test_ecflow_server__ecf_ssl_true_provisions_and_sets_env(server_mocks):
-    m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": True}}}
-    m.ssl_check.side_effect = UWSSLCertificateError
-    ecflow.server(config=m.config_path, port=3141)
-    m.ssl_provision.assert_called_once_with()
-    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
-    assert env["ECF_SSL"] == "1"
-
-
-def test_ecflow_server__ecf_ssl_string_checks_named_cert(server_mocks):
-    m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "myhost.3141"}}}
-    ecflow.server(config=m.config_path, port=3141)
-    m.ssl_provision.assert_not_called()
-    m.ssl_check.assert_called_once_with("myhost.3141")
-    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
-    assert env["ECF_SSL"] == "myhost.3141"
-
-
-def test_ecflow_server__ecf_ssl_false_skips_ssl(server_mocks):
-    m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": False}}}
-    ecflow.server(config=m.config_path, port=3141)
-    m.ssl_provision.assert_not_called()
-    _, env, _, _ = m.thread_cls.call_args.kwargs["args"]
-    assert "ECF_SSL" not in env
-
-
-def test_ecflow_server__insecure_skips_ssl(server_mocks):
-    ecflow.server(config=server_mocks.config_path, port=3141, insecure=True)
-    server_mocks.ssl_provision.assert_not_called()
-    server_mocks.ssl_check.assert_not_called()
-
-
-def test_ecflow_server__secure_sets_ecf_ssl_env(server_mocks):
-    ecflow.server(config=server_mocks.config_path, port=3141)
-    rundir, env, port, insecure = server_mocks.thread_cls.call_args.kwargs["args"]
-    assert rundir == Path("/ecf")
-    assert env["ECF_SSL"] == "1"
-    assert port == 3141
-    assert insecure is False
-
-
-@mark.parametrize("ecf_ssl", [None, True, False, "myhost.8888"])
-def test_ecflow_server__ssl_provision(ecf_ssl, server_mocks):
-    server_mocks.ssl_check.side_effect = UWSSLCertificateError
-    server_mocks.cfg.data["ecflow"]["server"]["ECF_SSL"] = ecf_ssl
-    ecflow.server(config=server_mocks.config_path, port=3141)
-    if ecf_ssl in [None, True]:
-        server_mocks.ssl_provision.assert_called_once_with()
-    else:
-        server_mocks.ssl_provision.assert_not_called()
-
-
-def test_ecflow_server__insecure_unsets_ecf_ssl_env(server_mocks):
-    m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_SSL": "1"}}}
-    ecflow.server(config=m.config_path, port=3141, insecure=True)
-    _, env, _, insecure = m.thread_cls.call_args.kwargs["args"]
-    assert "ECF_SSL" not in env
-    assert insecure is True
-
-
-def test_ecflow_server__starts_thread_and_waits(server_mocks):
-    m = server_mocks
-    ecflow.server(config=m.config_path, port=3141)
-    m.signal.assert_called_once_with(ecflow.signal.SIGINT, m.signal.call_args.args[1])
-    m.thread.start.assert_called_once()
-    m.server_wait.assert_called_once()
-    m.thread.join.assert_called_once()
-
-
-def test_ecflow_server__raises_on_thread_error(server_mocks):
-    m = server_mocks
-    m.thread.error = "ecflow_server failed on port 3141: boom"
-    with raises(UWError, match="ecflow_server failed on port 3141"):
-        ecflow.server(config=m.config_path, port=3141)
-
-
-def test_ecflow_server__shutdown_terminates(server_mocks):
-    m = server_mocks
-    m.thread.port = 54321
-    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as run:
-        ecflow.server(config=m.config_path, port=54321)
-        shutdown = m.signal.call_args.args[1]
-        shutdown(2, None)
-    m.thread.terminal.set.assert_called()
-    cmd = run.call_args.kwargs["cmd"]
-    assert "--ssl" in cmd
-    assert "--port 54321" in cmd
-    assert "--terminate=yes" in cmd
-
-
-def test_ecflow_server__shutdown_terminates_insecure_no_ssl(server_mocks):
-    m = server_mocks
-    m.thread.port = 54321
-    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as run:
-        ecflow.server(config=m.config_path, port=54321, insecure=True)
-        shutdown = m.signal.call_args.args[1]
-        shutdown(2, None)
-    cmd = run.call_args.kwargs["cmd"]
-    assert "--ssl" not in cmd
-    assert "--terminate=yes" in cmd
-
-
-def test_ecflow_server__shutdown_without_port_skips_terminate(server_mocks):
-    m = server_mocks
-    m.thread.port = None
-    with patch.object(ecflow, "run_shell_cmd") as run:
-        ecflow.server(config=m.config_path, port=54321)
-        shutdown = m.signal.call_args.args[1]
-        shutdown(2, None)
-    run.assert_not_called()
-
-
-def test_ecflow_server__report_vars_include_config(server_mocks):
-    m = server_mocks
-    m.cfg.data = {"ecflow": {"server": {"ECF_HOME": "/ecf", "ECF_LOG": "my.log"}}}
-    with patch.object(ecflow.socket, "gethostname", return_value="server.hostname.com"):
-        ecflow.server(config=m.config_path, port=54321, report=True)
-    assert m.server_wait.call_args.kwargs["report_vars"] == {
-        "ECF_HOME": "/ecf",
-        "ECF_LOG": "my.log",
-        "ECF_HOST": "server.hostname.com",
-        "ECF_SSL": "1",
-    }
-
-
-def test_ecflow_server__report_vars_insecure_omits_ssl(server_mocks):
-    m = server_mocks
-    with patch.object(ecflow.socket, "gethostname", return_value="server.hostname.com"):
-        ecflow.server(config=m.config_path, port=54321, insecure=True, report=True)
-    assert m.server_wait.call_args.kwargs["report_vars"] == {
-        "ECF_HOME": "/ecf",
-        "ECF_HOST": "server.hostname.com",
-    }
-
-
-def test_ecflow_server__no_report_passes_none(server_mocks):
-    m = server_mocks
-    ecflow.server(config=m.config_path, port=54321)
-    assert m.server_wait.call_args.kwargs["report_vars"] is None
-
-
-def test_ecflow__server_start__fixed_port_ssl(tmp_path):
-    def fake_run_shell_cmd(*_args, **_kwargs):
-        thread.terminal.set()
-        return ""
-
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    with (
-        patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd) as run_shell_cmd,
-    ):
-        ecflow._server_start(rundir, {"ECF_HOME": str(rundir)}, 3141, False)
-    assert rundir.is_dir()
-    assert run_shell_cmd.call_args.kwargs["cmd"] == "ecflow_server --ssl"
-    assert run_shell_cmd.call_args.kwargs["cwd"] == rundir
-    assert run_shell_cmd.call_args.kwargs["env"]["ECF_PORT"] == "3141"
-    assert thread.port == 3141
-    assert thread.error is None
-
-
-def test_ecflow__server_start__fixed_port_insecure(tmp_path):
-    def fake_run_shell_cmd(*_args, **_kwargs):
-        thread.terminal.set()
-        return ""
-
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    with (
-        patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd) as run_shell_cmd,
-    ):
-        ecflow._server_start(rundir, {}, 3141, True)
-    assert run_shell_cmd.call_args.kwargs["cmd"] == "ecflow_server"
-
-
-def test_ecflow__server_start__fixed_port_unavailable(tmp_path):
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    err = CalledProcessError(1, "ecflow_server", output="ecf: bind: Address already in use")
-    with (
-        patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "run_shell_cmd", side_effect=err),
-    ):
-        ecflow._server_start(rundir, {}, 3141, False)
-    assert thread.error == "Requested port 3141 is unavailable"
-    assert thread.terminal.is_set()
-    assert thread.port is None
-
-
-def test_ecflow__server_start__fixed_port_other_failure(tmp_path):
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    err = CalledProcessError(1, "ecflow_server", output="something went wrong")
-    with (
-        patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "run_shell_cmd", side_effect=err),
-    ):
-        ecflow._server_start(rundir, {}, 3141, False)
-    assert thread.error == "ecflow_server failed on port 3141: something went wrong"
-    assert thread.terminal.is_set()
-
-
-def test_ecflow__server_start__launch_failure(tmp_path):
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    err = FileNotFoundError(2, "No such file or directory", "ecflow_server")
-    with (
-        patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "run_shell_cmd", side_effect=err),
-    ):
-        ecflow._server_start(rundir, {}, 3141, False)
-    assert thread.error is not None
-    assert thread.error.startswith("Failed to launch ecflow_server:")
-    assert thread.terminal.is_set()
-
-
-def test_ecflow__server_start__random_port_retries_until_available(tmp_path):
-    def fake_run_shell_cmd(*_args, **kwargs):
-        ports.append(kwargs["env"]["ECF_PORT"])
-        if len(ports) == 1:
-            raise bind_err
-        thread.terminal.set()
-        return ""
-
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    bind_err = CalledProcessError(1, "ecflow_server", output="ecf: bind: Address already in use")
-    ports: list[str] = []
-    with (
-        patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow.random, "randint", side_effect=[30000, 30001]),
-        patch.object(ecflow, "run_shell_cmd", side_effect=fake_run_shell_cmd),
-    ):
-        ecflow._server_start(rundir, {}, None, False)
-    assert ports == ["30000", "30001"]
-    assert thread.port == 30001
-    assert thread.error is None
-
-
-def test_ecflow__server_start__random_port_failure(tmp_path):
-    thread = ecflow._ServerThread()
-    rundir = tmp_path / "ecf"
-    err = CalledProcessError(1, "ecflow_server", output="something broke")
-    with (
-        patch.object(ecflow, "current_thread", return_value=thread),
-        patch.object(ecflow, "run_shell_cmd", side_effect=err),
-        patch.object(ecflow.random, "randint", return_value=31415),
-    ):
-        ecflow._server_start(rundir, {}, None, False)
-    assert thread.error == "ecflow_server failed on port 31415: something broke"
-    assert thread.terminal.is_set()
-
-
-def test_ecflow__server_wait__pings_then_reports(capsys):
-    thread = ecflow._ServerThread()
-    thread.port = 54321
-    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as mock_cmd:
-        ecflow._server_wait(
-            thread, ssl_opt="--ssl ", report_vars={"ECF_HOME": "/ecf", "ECF_SSL": "1"}
-        )
-    cmd = mock_cmd.call_args.kwargs["cmd"]
-    assert "--ssl" in cmd
-    assert "--ping" in cmd
-    report = yaml.safe_load(capsys.readouterr().out)
-    assert report == {"vars": {"ECF_HOME": "/ecf", "ECF_SSL": "1", "ECF_PORT": "54321"}}
-
-
-def test_ecflow__server_wait__insecure_ping_no_ssl():
-    thread = ecflow._ServerThread()
-    thread.port = 54321
-    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")) as mock_cmd:
-        ecflow._server_wait(thread, ssl_opt="", report_vars=None)
-    assert "--ssl" not in mock_cmd.call_args.kwargs["cmd"]
-
-
-def test_ecflow__server_wait__no_report(capsys):
-    thread = ecflow._ServerThread()
-    thread.port = 54321
-    with patch.object(ecflow, "run_shell_cmd", return_value=(True, "")):
-        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
-    assert capsys.readouterr().out == ""
-
-
-def test_ecflow__server_wait__exits_on_terminal():
-    thread = ecflow._ServerThread()
-    thread.terminal.set()
-    with patch.object(ecflow, "run_shell_cmd") as mock_cmd:
-        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
-    mock_cmd.assert_not_called()
-
-
-def test_ecflow__server_wait__no_port_loops():
-    thread = ecflow._ServerThread()
-    thread.port = None
-    thread.terminal = Mock()
-    thread.terminal.is_set.side_effect = [False, True]
-    with (
-        patch.object(ecflow, "sleep") as mock_sleep,
-        patch.object(ecflow, "run_shell_cmd") as mock_cmd,
-    ):
-        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
-    mock_cmd.assert_not_called()
-    mock_sleep.assert_called_once_with(0.2)
-
-
-def test_ecflow__server_wait__ping_fails_then_loops():
-    thread = ecflow._ServerThread()
-    thread.port = 54321
-    thread.terminal = Mock()
-    thread.terminal.is_set.side_effect = [False, True]
-    with (
-        patch.object(ecflow, "sleep") as mock_sleep,
-        patch.object(ecflow, "run_shell_cmd", return_value=(False, "")) as mock_cmd,
-    ):
-        ecflow._server_wait(thread, ssl_opt="--ssl ", report_vars=None)
-    mock_cmd.assert_called_once()
-    mock_sleep.assert_called_once_with(0.2)
-
-
-def test_ecflow__server_report(capsys):
-    ecflow._server_report(port=54321, report_vars={"ECF_HOST": "host.com", "ECF_SSL": "1"})
-    report = yaml.safe_load(capsys.readouterr().out)
-    assert report == {"vars": {"ECF_HOST": "host.com", "ECF_SSL": "1", "ECF_PORT": "54321"}}
+        ecflow._ssl_provision()
+    assert ssl_dir.is_dir()
+    assert (ssl_dir / "server.key").is_file()
+    assert (ssl_dir / "server.crt").is_file()
+    assert (ssl_dir / "dh2048.pem").is_file()
+    assert logged("SSL certificate files written to %s" % ssl_dir)


### PR DESCRIPTION
**Synopsis**

Reorder code in module `uwtools.ecflow`, separating public and private classes/methods/functions and reordering lexicographically. Simplify a handful of docstrings. Reorder unit-test code to match.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
