### PR TITLE
Create server.h header file

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -593,7 +593,7 @@ def _server_start(env: dict[str, str], port: int | None) -> None:
         export ECF_TRYNO=%ECF_TRYNO%
         export PATH={conda}/bin/:$PATH
         """.format(conda=os.environ["CONDA_PREFIX"])
-        Path(env[STR.ECF_HOME], "server.h").write_text(dedent(s).strip())
+        Path(env[STR.ECF_HOME], "server.h").write_text(dedent(s).lstrip())
         thread.port = port
         thread.proc = proc
         thread.initial.set()

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -585,15 +585,10 @@ def _server_start(env: dict[str, str], port: int | None) -> None:
                 log.error(line)
 
     def post(proc: Popen) -> None:
-        s = """
-        export ECF_HOST=%ECF_HOST%
-        export ECF_NAME=%ECF_NAME%
-        export ECF_PASS=%ECF_PASS%
-        export ECF_PORT=%ECF_PORT%
-        export ECF_TRYNO=%ECF_TRYNO%
-        export PATH={conda}/bin/:$PATH
-        """.format(conda=os.environ["CONDA_PREFIX"])
-        Path(env[STR.ECF_HOME], "server.h").write_text(dedent(s).lstrip())
+        keys = (STR.ECF_HOST, STR.ECF_NAME, STR.ECF_PASS, STR.ECF_PORT, STR.ECF_TRYNO)
+        lines = [f"export {k}=%{k}%" for k in keys]
+        lines.append("export PATH=%s/bin/:$PATH" % os.environ["CONDA_PREFIX"])
+        Path(env[STR.ECF_HOME], "server.h").write_text("\n".join(lines) + "\n")
         thread.port = port
         thread.proc = proc
         thread.initial.set()

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -585,6 +585,15 @@ def _server_start(env: dict[str, str], port: int | None) -> None:
                 log.error(line)
 
     def post(proc: Popen) -> None:
+        s = """
+        export ECF_HOST=%ECF_HOST%
+        export ECF_NAME=%ECF_NAME%
+        export ECF_PASS=%ECF_PASS%
+        export ECF_PORT=%ECF_PORT%
+        export ECF_TRYNO=%ECF_TRYNO%
+        export PATH={conda}/bin/:$PATH
+        """.format(conda=os.environ["CONDA_PREFIX"])
+        Path(env[STR.ECF_HOME], "server.h").write_text(dedent(s).strip())
         thread.port = port
         thread.proc = proc
         thread.initial.set()

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -69,8 +69,10 @@ class _STR(_ValsMatchKeys):
     ECF_HOST: str = _
     ECF_LOG: str = _
     ECF_NAME: str = _
+    ECF_PASS: str = _
     ECF_PORT: str = _
     ECF_SSL: str = _
+    ECF_TRYNO: str = _
     account: str = _
     action: str = _
     base_file: str = _

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -2,12 +2,14 @@
 Tests for uwtools.ecflow module.
 """
 
+import os
 import re
 import socket
 import sys
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
+from textwrap import dedent
 from types import SimpleNamespace as ns
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -948,6 +950,8 @@ def test_ecflow__server_start__fixed_port_ssl(tmp_path):
         thread.terminal.set()
         return True, "all good"
 
+    header = tmp_path / "server.h"
+    assert not header.is_file()
     proc = object()
     thread = ecflow._ServerThread()
     with (
@@ -961,6 +965,16 @@ def test_ecflow__server_start__fixed_port_ssl(tmp_path):
     assert thread.initial.is_set()
     assert thread.port == 3141
     assert thread.proc is proc
+    assert header.is_file()
+    expected = """
+    export ECF_HOST=%ECF_HOST%
+    export ECF_NAME=%ECF_NAME%
+    export ECF_PASS=%ECF_PASS%
+    export ECF_PORT=%ECF_PORT%
+    export ECF_TRYNO=%ECF_TRYNO%
+    export PATH={conda}/bin/:$PATH
+    """.format(conda=os.environ["CONDA_PREFIX"])
+    assert header.read_text() == dedent(expected).lstrip()
 
 
 def test_ecflow__server_start__fixed_port_insecure(tmp_path):


### PR DESCRIPTION
**Synopsis**

Create a `server.h` header file in the `ECF_HOME` directory, which can be optionally included by users in their `.ecf` files to set environment variables commonly needed in rendered `.job` files. In particular, `server.h` extends `PATH` to include the `bin/` directory from the conda environment providing ecFlow, such that `ecflow_client` will be readily accessible from task scripts.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
