### PR TITLE
Remove 'vars' level from server-report JSON

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -566,7 +566,7 @@ def _server_report(port: int, env: dict[str, str] | None) -> None:
         vars_ = {**env, STR.ECF_PORT: str(port)}
         # Flush so downstream consumers (e.g. a piped jq) see the report while the server runs,
         # rather than only when the block-buffered stream is flushed at server exit.
-        print(json.dumps({"vars": vars_}, indent=2, sort_keys=True), flush=True)
+        print(json.dumps(vars_, indent=2, sort_keys=True), flush=True)
 
 
 def _server_start(env: dict[str, str], port: int | None) -> None:

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -926,7 +926,7 @@ def test_ecflow__openssl__not_found():
 def test_ecflow__server_report(capsys):
     ecflow._server_report(port=54321, env={STR.ECF_HOST: "host.com", STR.ECF_SSL: "1"})
     report = yaml.safe_load(capsys.readouterr().out)
-    assert report == {"vars": {STR.ECF_HOST: "host.com", STR.ECF_SSL: "1", STR.ECF_PORT: "54321"}}
+    assert report == {STR.ECF_HOST: "host.com", STR.ECF_SSL: "1", STR.ECF_PORT: "54321"}
 
 
 def test_ecflow__server_start__doa(tmp_path):


### PR DESCRIPTION
**Synopsis**

Simplify the ecFlow server report from e.g.
```
{
  "vars": {
    "ECF_HOME": /some/path
  }
}
```
to
```
{
  "ECF_HOME": /some/path
}
```
The additional `"vars"` level doesn't seem to add value, and makes queries of the JSON more verbose. IIRC we initially weren't sure what would go in this report and thought we might need to distinguish different types of information, but I think that has turned out not to be the case.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)

Not really a behavior change since we haven't released the `server` feature yet.

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

Not-breaking for the same reason.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
