### PR TITLE
Handle ECF_HOME mkdir failure

### DIFF
--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -495,10 +495,14 @@ def _server_start(env: dict[str, str], port: int | None) -> None:
 
     cmd = ["ecflow_server"]
     cwd = Path(env[STR.ECF_HOME])
-    cwd.mkdir(parents=True, exist_ok=True)
     env = {**os.environ, **env}
-    thread = cast(_ServerThread, current_thread())
     static = port is not None
+    thread = cast(_ServerThread, current_thread())
+    try:
+        cwd.mkdir(parents=True, exist_ok=True)
+    except Exception as e:  # noqa: BLE001
+        complain(f"Failed to create ECF_HOME directory {cwd}", str(e))
+        return
     while not thread.terminal.is_set():
         port = port if static else random.randint(ECFLOW_PORT_MIN, ECFLOW_PORT_MAX)  # noqa: S311
         log.debug("Trying to start server on port %s", port)

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -859,6 +859,19 @@ def test_ecflow__server_start__doa(tmp_path):
     assert thread.proc is None
 
 
+def test_ecflow__server_start__bad_ecf_home(tmp_path):
+    ecf_home = tmp_path / "home"
+    tmp_path.chmod(0o555)
+    thread = ecflow._ServerThread()
+    with patch.object(ecflow, "current_thread", return_value=thread):
+        ecflow._server_start(env={STR.ECF_HOME: ecf_home}, port=9999)
+    assert thread.error == f"Failed to create ECF_HOME directory {ecf_home}"
+    assert not thread.initial.is_set()
+    assert thread.port is None
+    assert thread.proc is None
+    tmp_path.chmod(0o755)
+
+
 def test_ecflow__server_start__fixed_port_ssl(tmp_path):
     def f(*_args, **_kwargs):
         run_shell_cmd.call_args.kwargs["callback"](proc)


### PR DESCRIPTION
**Synopsis**

I noticed that, if the `ECF_HOME` directory cannot be created, e.g. due to permissions errors, then `uw ecflow server` would not exit cleanly, but would have to be manually killed, as it would not even respond to ctrl-c.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
