### PR TITLE
Expand server.h

### DIFF
--- a/docs/sections/user_guide/cli/Makefile
+++ b/docs/sections/user_guide/cli/Makefile
@@ -5,4 +5,4 @@ SUBDIRS = $(shell find . -maxdepth 1 -mindepth 1 -type d | sort)
 all: $(SUBDIRS)
 
 $(SUBDIRS):
-	@$(MAKE) -C $@ -j
+	@env -u MAKELEVEL $(MAKE) -C $@ -j4

--- a/docs/sections/user_guide/cli/drivers/Makefile
+++ b/docs/sections/user_guide/cli/drivers/Makefile
@@ -5,4 +5,4 @@ SUBDIRS = $(filter-out ./shared,$(shell find . -maxdepth 1 -mindepth 1 -type d |
 all: $(SUBDIRS)
 
 $(SUBDIRS):
-	@$(MAKE) -C $@ -j
+	@$(MAKE) -C $@

--- a/docs/sections/user_guide/cli/tools/Makefile
+++ b/docs/sections/user_guide/cli/tools/Makefile
@@ -1,1 +1,8 @@
-../Makefile
+SUBDIRS = $(shell find . -maxdepth 1 -mindepth 1 -type d | sort)
+
+.PHONY: all $(SUBDIRS)
+
+all: $(SUBDIRS)
+
+$(SUBDIRS):
+	@$(MAKE) -C $@

--- a/docs/static/ecflow.html
+++ b/docs/static/ecflow.html
@@ -8037,7 +8037,7 @@ wxvx:
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>[1] 421986
+<pre>[1] 885735
 </pre>
 </div>
 </div>
@@ -8075,7 +8075,7 @@ wxvx:
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<p>View <code>server.log</code> and note that there were no errors, and the the server is using a random available TCP port.</p>
+<p>View <code>server.log</code>. Note that there were no errors, and that the server is using a random available TCP port.</p>
 <p>Also note that, since <code>~/.ecflowrc/ssl</code> did not already contain the SSL certificate files required for secure communication with the ecFlow server, these were generated.</p>
 </div>
 </div>
@@ -8101,13 +8101,13 @@ wxvx:
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>[2026-07-16T22:52:47]     INFO Validating config against internal schema: ecflow
-[2026-07-16T22:52:47]     INFO Schema validation succeeded for ecFlow config
-[2026-07-16T22:52:47]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key
-[2026-07-16T22:52:47]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt
-[2026-07-16T22:52:47]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem
-[2026-07-16T22:53:19]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl
-[2026-07-16T22:53:19]     INFO Server started on port 4912
+<pre>[2026-07-17T14:34:50]     INFO Validating config against internal schema: ecflow
+[2026-07-17T14:34:50]     INFO Schema validation succeeded for ecFlow config
+[2026-07-17T14:34:50]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key
+[2026-07-17T14:34:50]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt
+[2026-07-17T14:34:50]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem
+[2026-07-17T14:34:51]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl
+[2026-07-17T14:34:51]     INFO Server started on port 4822
 </pre>
 </div>
 </div>
@@ -8193,7 +8193,7 @@ export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/en
 <pre><span class="ansi-bold">{</span>
   <span class="ansi-blue-intense-fg ansi-bold">"ECF_HOME"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow"</span><span class="ansi-bold">,</span>
   <span class="ansi-blue-intense-fg ansi-bold">"ECF_HOST"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"uecflow01"</span><span class="ansi-bold">,</span>
-  <span class="ansi-blue-intense-fg ansi-bold">"ECF_PORT"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"4912"</span><span class="ansi-bold">,</span>
+  <span class="ansi-blue-intense-fg ansi-bold">"ECF_PORT"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"4822"</span><span class="ansi-bold">,</span>
   <span class="ansi-blue-intense-fg ansi-bold">"ECF_SSL"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"1"</span>
 <span class="ansi-bold">}</span>
 </pre>
@@ -8238,7 +8238,7 @@ export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/en
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre>ECF_HOME: /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow
 ECF_HOST: uecflow01
-ECF_PORT: 4912
+ECF_PORT: 4822
 ECF_SSL: 1
 </pre>
 </div>
@@ -8277,7 +8277,7 @@ ECF_SSL: 1
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>ping server(uecflow01:4912) succeeded in 00:00:00.004491  ~4 milliseconds
+<pre>ping server(uecflow01:4822) succeeded in 00:00:00.012204  ~12 milliseconds
 </pre>
 </div>
 </div>
@@ -8358,7 +8358,7 @@ ecflow_client<span class="w"> </span>--stats<span class="w"> </span><span class=
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>2026-07-15T18:00:00
+<pre>2026-07-16T12:00:00
 </pre>
 </div>
 </div>
@@ -8396,8 +8396,8 @@ ecflow_client<span class="w"> </span>--stats<span class="w"> </span><span class=
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>[2026-07-16T22:53:22]     INFO Validating config against internal schema: ecflow
-[2026-07-16T22:53:22]     INFO Schema validation succeeded for ecFlow config
+<pre>[2026-07-17T14:34:54]     INFO Validating config against internal schema: ecflow
+[2026-07-17T14:34:55]     INFO Schema validation succeeded for ecFlow config
 </pre>
 </div>
 </div>
@@ -8535,7 +8535,7 @@ endsuite
 %include server.h
 
 init $$
-test -f gfs.t18z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f006
+test -f gfs.t12z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260716/12/atmos/gfs.t12z.pgrb2.1p00.f006
 
 %manual
 Fetch GRIB truth data
@@ -8641,7 +8641,7 @@ set -euxo pipefail
 %include server.h
 
 init $$
-export CYCLE="2026-07-15 18:00:00"
+export CYCLE="2026-07-16 12:00:00"
 uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx &gt;/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml
 wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids
 
@@ -8856,15 +8856,6 @@ verification:  queued
 extract_grids: active
 verification:  queued
   fetch_truth: complete
-extract_grids: active
-verification:  queued
-  fetch_truth: complete
-extract_grids: complete
-verification:  active
-  fetch_truth: complete
-extract_grids: complete
-verification:  active
-  fetch_truth: complete
 extract_grids: complete
 verification:  active
   fetch_truth: complete
@@ -8918,7 +8909,7 @@ verification:  complete
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>-rw-r--r-- 1 Paul.Madden gsd-hpcs 4411 Jul 16 22:54 uecflow01.4912.ecf.log
+<pre>-rw-r--r-- 1 Paul.Madden gsd-hpcs 3691 Jul 17 14:35 uecflow01.4822.ecf.log
 </pre>
 </div>
 </div>
@@ -8964,27 +8955,27 @@ verification:  complete
 ├── fetch_truth.ecf
 ├── <span class="ansi-green-intense-fg ansi-bold">fetch_truth.job1</span>
 ├── <span class="ansi-blue-intense-fg ansi-bold">forecast</span>
-│   └── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
-│       └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
+│   └── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
+│       └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
 │           └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
 │               ├── 2t-heightAboveGround-0002.grib2
-│               └── gfs.t18z.pgrb2.1p00.f006.ecidx
+│               └── gfs.t12z.pgrb2.1p00.f006.ecidx
 ├── <span class="ansi-blue-intense-fg ansi-bold">run</span>
 │   └── <span class="ansi-blue-intense-fg ansi-bold">stats</span>
-│       └── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
-│           └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
+│       └── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
+│           └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
 │               └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
-│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt
-│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config
-│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log
-│                   ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh</span>
-│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat
+│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V_cnt.txt
+│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.config
+│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.log
+│                   ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.sh</span>
+│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.stat
 ├── <span class="ansi-blue-intense-fg ansi-bold">truth</span>
 │   └── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
-│       └── <span class="ansi-blue-intense-fg ansi-bold">00</span>
+│       └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
 │           └── <span class="ansi-blue-intense-fg ansi-bold">000</span>
 │               ├── 2t-heightAboveGround-0002.grib2
-│               └── gfs.t18z.pgrb2.1p00.f000.idx
+│               └── gfs.t12z.pgrb2.1p00.f000.idx
 ├── verification.ecf
 ├── <span class="ansi-green-intense-fg ansi-bold">verification.job1</span>
 └── verification.out
@@ -9004,7 +8995,7 @@ verification:  complete
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
 <p>We previously saw the <code>extract_grids.ecf</code>, <code>fetch_truth.ecf</code>, and <code>verification.ecf</code> template files. The server rendered these to ready-to-run scripts <code>extract_grids.job1</code>, <code>fetch_truth.job1</code>, and <code>verification.job1</code>, respectively. (The <code>1</code> in the <code>.job1</code> filename extensions indicates that these files belong to the first of potentially multiple attempts to run this task. If it had been necessary to retry any of these jobs, corresponding <code>.job2</code> files would have been created.)</p>
 <p>Let's examine the files created for the <code>extract_grids</code> task as an example.</p>
-<p>The file <code>extract_grids.job1</code> is the concatenation of the header file <code>common.h</code>, the header file <code>server.h</code>, and the value of <code>ecflow.suitedef.suite_vs.task_extract_grids.script.body</code> from <code>config.yaml</code>. Here it is:</p>
+<p>The file <code>extract_grids.job1</code> is the concatenation of the header file <code>common.h</code>, the header file <code>server.h</code>, and the value of <code>ecflow.suitedef.suite_vx.task_extract_grids.script.body</code> from <code>config.yaml</code>. Here it is:</p>
 </div>
 </div>
 </div>
@@ -9056,13 +9047,13 @@ export ECF_HOST=uecflow01
 export ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1
 export ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1
 export ECF_NAME=/vx/extract_grids
-export ECF_PASS=QUvRh64X
-export ECF_PORT=4912
+export ECF_PASS=cVaK4CxG
+export ECF_PORT=4822
 export ECF_TRYNO=1
 export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:$PATH
 
 init $$
-export CYCLE="2026-07-15 18:00:00"
+export CYCLE="2026-07-16 12:00:00"
 uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx &gt;/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml
 wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids
 </pre>
@@ -9110,42 +9101,42 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 + ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1
 + export ECF_NAME=/vx/extract_grids
 + ECF_NAME=/vx/extract_grids
-+ export ECF_PASS=QUvRh64X
-+ ECF_PASS=QUvRh64X
-+ export ECF_PORT=4912
-+ ECF_PORT=4912
++ export ECF_PASS=cVaK4CxG
++ ECF_PASS=cVaK4CxG
++ export ECF_PORT=4822
++ ECF_PORT=4822
 + export ECF_TRYNO=1
 + ECF_TRYNO=1
 + export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin
 + PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin
-+ init 422501
-+ export ECF_RID=422501
-+ ECF_RID=422501
-+ ecflow_client --ssl --init=422501
-+ export 'CYCLE=2026-07-15 18:00:00'
-+ CYCLE='2026-07-15 18:00:00'
++ init 885788
++ export ECF_RID=885788
++ ECF_RID=885788
++ ecflow_client --ssl --init=885788
++ export 'CYCLE=2026-07-16 12:00:00'
++ CYCLE='2026-07-16 12:00:00'
 + uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx
 + wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids
-[2026-07-16T22:53:42]     INFO Schema validation succeeded for config
-[2026-07-16T22:53:42]     INFO Preparing task graph for 'grids'
-[2026-07-16T22:53:42]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Executing
-[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx
-[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Ready
-[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Executing
-[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000.idx
-[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx
-[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Ready
-[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Executing
-[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Ready
-[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Executing
-[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Ready
-[2026-07-16T22:53:45]     INFO Forecast grids for GFSFCST: Ready
-[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Executing
-[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000 bytes=34705919-34754296
-[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2
-[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Ready
-[2026-07-16T22:53:45]     INFO Truth grids for GFS: Ready
-[2026-07-16T22:53:45]     INFO Grids: Ready
+[2026-07-17T14:35:05]     INFO Schema validation succeeded for config
+[2026-07-17T14:35:05]     INFO Preparing task graph for 'grids'
+[2026-07-17T14:35:05]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260716 12Z 006: Executing
+[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260716 12Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx
+[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260716 12Z 006: Ready
+[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Executing
+[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260716/12/atmos/gfs.t12z.pgrb2.1p00.f000.idx
+[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx
+[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Ready
+[2026-07-17T14:35:06]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/2t-heightAboveGround-0002.grib2: Executing
+[2026-07-17T14:35:06]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/2t-heightAboveGround-0002.grib2: Ready
+[2026-07-17T14:35:06]     INFO GRIB index data at 20260716 18Z 000: Executing
+[2026-07-17T14:35:06]     INFO GRIB index data at 20260716 18Z 000: Ready
+[2026-07-17T14:35:06]     INFO Forecast grids for GFSFCST: Ready
+[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Executing
+[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260716/12/atmos/gfs.t12z.pgrb2.1p00.f000 bytes=34068933-34117172
+[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2
+[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Ready
+[2026-07-17T14:35:06]     INFO Truth grids for GFS: Ready
+[2026-07-17T14:35:06]     INFO Grids: Ready
 + complete
 + ecflow_client --ssl --complete
 </pre>
@@ -9197,11 +9188,11 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre><span class="ansi-blue-intense-fg ansi-bold">vx/forecast/</span>
-└── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
-    └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
+└── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
+    └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
         └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
             ├── 2t-heightAboveGround-0002.grib2
-            └── gfs.t18z.pgrb2.1p00.f006.ecidx
+            └── gfs.t12z.pgrb2.1p00.f006.ecidx
 
 4 directories, 2 files
 </pre>
@@ -9243,10 +9234,10 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre><span class="ansi-blue-intense-fg ansi-bold">vx/truth/</span>
 └── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
-    └── <span class="ansi-blue-intense-fg ansi-bold">00</span>
+    └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
         └── <span class="ansi-blue-intense-fg ansi-bold">000</span>
             ├── 2t-heightAboveGround-0002.grib2
-            └── gfs.t18z.pgrb2.1p00.f000.idx
+            └── gfs.t12z.pgrb2.1p00.f000.idx
 
 4 directories, 2 files
 </pre>
@@ -9288,14 +9279,14 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre><span class="ansi-blue-intense-fg ansi-bold">vx/run/</span>
 └── <span class="ansi-blue-intense-fg ansi-bold">stats</span>
-    └── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
-        └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
+    └── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
+        └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
             └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
-                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt
-                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config
-                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log
-                ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh</span>
-                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat
+                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V_cnt.txt
+                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.config
+                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.log
+                ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.sh</span>
+                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.stat
 
 5 directories, 5 files
 </pre>

--- a/docs/static/ecflow.html
+++ b/docs/static/ecflow.html
@@ -7875,7 +7875,7 @@ conda<span class="w"> </span>activate<span class="w"> </span>demo
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre>app:
   basedir: '{{ "BASEDIR" | env }}'
-  cycle: 2026-07-14T12:00:00
+  cycle: !datetime '{{ "CYCLE" | env }}'
   fcst:
     fn: gfs.t{{ app.hh }}z.pgrb2.1p00.f{{ "%03d" % app.leadtime }}
     url: '{{ app.prefix }}/{{ app.fcst.fn }}'
@@ -7893,6 +7893,7 @@ ecflow:
         script:
           body: |
             init $$
+            export CYCLE="{{ app.cycle }}"
             uw config realize -i {{ app.basedir }}/config.yaml --key-path wxvx &gt;{{ app.basedir }}/vx.yaml
             wxvx -c {{ app.basedir }}/vx.yaml -t grids
           includes:
@@ -8036,7 +8037,7 @@ wxvx:
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>[1] 658054
+<pre>[1] 421986
 </pre>
 </div>
 </div>
@@ -8100,13 +8101,13 @@ wxvx:
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>[2026-07-15T15:10:43]     INFO Validating config against internal schema: ecflow
-[2026-07-15T15:10:43]     INFO Schema validation succeeded for ecFlow config
-[2026-07-15T15:10:43]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key
-[2026-07-15T15:10:44]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt
-[2026-07-15T15:10:44]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem
-[2026-07-15T15:11:13]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl
-[2026-07-15T15:11:13]     INFO Server started on port 18883
+<pre>[2026-07-16T22:52:47]     INFO Validating config against internal schema: ecflow
+[2026-07-16T22:52:47]     INFO Schema validation succeeded for ecFlow config
+[2026-07-16T22:52:47]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key
+[2026-07-16T22:52:47]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt
+[2026-07-16T22:52:47]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem
+[2026-07-16T22:53:19]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl
+[2026-07-16T22:53:19]     INFO Server started on port 4912
 </pre>
 </div>
 </div>
@@ -8145,6 +8146,8 @@ wxvx:
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre>export ECF_HOST=%ECF_HOST%
+export ECF_JOB=%ECF_JOB%
+export ECF_JOBOUT=%ECF_JOBOUT%
 export ECF_NAME=%ECF_NAME%
 export ECF_PASS=%ECF_PASS%
 export ECF_PORT=%ECF_PORT%
@@ -8190,7 +8193,7 @@ export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/en
 <pre><span class="ansi-bold">{</span>
   <span class="ansi-blue-intense-fg ansi-bold">"ECF_HOME"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow"</span><span class="ansi-bold">,</span>
   <span class="ansi-blue-intense-fg ansi-bold">"ECF_HOST"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"uecflow01"</span><span class="ansi-bold">,</span>
-  <span class="ansi-blue-intense-fg ansi-bold">"ECF_PORT"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"18883"</span><span class="ansi-bold">,</span>
+  <span class="ansi-blue-intense-fg ansi-bold">"ECF_PORT"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"4912"</span><span class="ansi-bold">,</span>
   <span class="ansi-blue-intense-fg ansi-bold">"ECF_SSL"</span><span class="ansi-bold">:</span> <span class="ansi-green-fg">"1"</span>
 <span class="ansi-bold">}</span>
 </pre>
@@ -8235,7 +8238,7 @@ export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/en
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre>ECF_HOME: /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow
 ECF_HOST: uecflow01
-ECF_PORT: 18883
+ECF_PORT: 4912
 ECF_SSL: 1
 </pre>
 </div>
@@ -8274,7 +8277,7 @@ ECF_SSL: 1
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>ping server(uecflow01:18883) succeeded in 00:00:00.004949  ~4 milliseconds
+<pre>ping server(uecflow01:4912) succeeded in 00:00:00.004491  ~4 milliseconds
 </pre>
 </div>
 </div>
@@ -8322,13 +8325,53 @@ ecflow_client<span class="w"> </span>--stats<span class="w"> </span><span class=
 </div>
 </div>
 </div>
+<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell" id="cell-id=be5fa58c-6645-4520-bec5-f2f5cafc25d9">
+<div class="jp-Cell-inputWrapper" tabindex="0">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
+</div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
+<p>Now the server is ready to be loaded with a suite definition, provided by the <code>ecflow.suitedef</code> block in <code>config.yaml</code>. The config requires a <code>CYCLE</code> environment variable, which we set here to one we expect to be complete:</p>
+</div>
+</div>
+</div>
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=7dbf031e-2908-4645-8c09-3e6030f849fe">
+<div class="jp-Cell-inputWrapper" tabindex="0">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In [12]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+<div class="cm-editor cm-s-jupyter">
+<div class="highlight hl-bash"><pre><span></span><span class="nv">ts</span><span class="o">=</span><span class="k">$(</span>date<span class="w"> </span>-u<span class="w"> </span>+%s<span class="k">)</span>
+<span class="nb">export</span><span class="w"> </span><span class="nv">CYCLE</span><span class="o">=</span><span class="k">$(</span>date<span class="w"> </span>-ud@<span class="k">$((</span><span class="w"> </span><span class="nv">ts</span><span class="w"> </span><span class="o">-</span><span class="w"> </span><span class="nv">ts</span><span class="w"> </span><span class="o">%</span><span class="w"> </span><span class="m">21600</span><span class="w"> </span><span class="o">-</span><span class="w"> </span><span class="m">86400</span><span class="w"> </span><span class="k">))</span><span class="w"> </span>+%Y-%m-%dT%H:%M:%S<span class="k">)</span>
+<span class="nb">echo</span><span class="w"> </span><span class="nv">$CYCLE</span>
+</pre></div>
+</div>
+</div>
+</div>
+</div>
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+<div class="jp-OutputArea jp-Cell-outputArea">
+<div class="jp-OutputArea-child">
+<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
+<pre>2026-07-15T18:00:00
+</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
 <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell" id="cell-id=b4dadc02-c0cf-4430-8009-d7b921c7927c">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<p>Now the server is ready to be loaded with a suite definition, provided by the <code>ecflow.suitedef</code> block in <code>config.yaml</code>. The <code>uw ecflow realize</code> command creates a <code>suite.def</code> file in the directory specified by <code>--output-dir</code> and, under the directory specified by <code>--scripts-dir</code>, any <code>ecf</code> scripts defined by <code>script</code> blocks in the suite definition:</p>
+<p>The <code>uw ecflow realize</code> command creates a <code>suite.def</code> file in the directory specified by <code>--output-dir</code> and, under the directory specified by <code>--scripts-dir</code>, any <code>ecf</code> scripts defined by <code>script</code> blocks in the suite definition:</p>
 </div>
 </div>
 </div>
@@ -8337,7 +8380,7 @@ ecflow_client<span class="w"> </span>--stats<span class="w"> </span><span class=
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [12]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [13]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>uw<span class="w"> </span>ecflow<span class="w"> </span>realize<span class="w"> </span>-c<span class="w"> </span>config.yaml<span class="w"> </span>--output-dir<span class="o">=</span><span class="nv">$BASEDIR</span><span class="w"> </span>--scripts-dir<span class="o">=</span><span class="nv">$BASEDIR</span>
@@ -8353,8 +8396,8 @@ ecflow_client<span class="w"> </span>--stats<span class="w"> </span><span class=
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>[2026-07-15T15:11:59]     INFO Validating config against internal schema: ecflow
-[2026-07-15T15:11:59]     INFO Schema validation succeeded for ecFlow config
+<pre>[2026-07-16T22:53:22]     INFO Validating config against internal schema: ecflow
+[2026-07-16T22:53:22]     INFO Schema validation succeeded for ecFlow config
 </pre>
 </div>
 </div>
@@ -8376,7 +8419,7 @@ ecflow_client<span class="w"> </span>--stats<span class="w"> </span><span class=
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [13]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [14]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>cat<span class="w"> </span>suite.def
@@ -8426,7 +8469,7 @@ endsuite
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [14]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [15]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>tree<span class="w"> </span>vx
@@ -8469,7 +8512,7 @@ endsuite
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [15]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [16]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>cat<span class="w"> </span>vx/fetch_truth.ecf
@@ -8492,7 +8535,7 @@ endsuite
 %include server.h
 
 init $$
-test -f gfs.t12z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260714/12/atmos/gfs.t12z.pgrb2.1p00.f006
+test -f gfs.t18z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f006
 
 %manual
 Fetch GRIB truth data
@@ -8518,7 +8561,7 @@ Fetch GRIB truth data
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [16]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [17]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>cat<span class="w"> </span>common.h
@@ -8575,7 +8618,7 @@ set -euxo pipefail
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [17]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [18]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>cat<span class="w"> </span>vx/extract_grids.ecf
@@ -8598,6 +8641,7 @@ set -euxo pipefail
 %include server.h
 
 init $$
+export CYCLE="2026-07-15 18:00:00"
 uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx &gt;/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml
 wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids
 
@@ -8625,7 +8669,7 @@ Extract forecast and truth grids
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [18]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [19]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>cat<span class="w"> </span>vx/verification.ecf
@@ -8680,7 +8724,7 @@ Perform verification
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [19]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [20]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>ecflow_client<span class="w"> </span>--load<span class="o">=</span>suite.def
@@ -8705,7 +8749,7 @@ Perform verification
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [20]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [21]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>ecflow_client<span class="w"> </span>--get
@@ -8755,7 +8799,7 @@ endsuite
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [21]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [22]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>ecflow_client<span class="w"> </span>--begin<span class="o">=</span>vx
@@ -8780,7 +8824,7 @@ endsuite
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [22]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [23]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span><span class="k">while</span><span class="w"> </span>true<span class="p">;</span><span class="w"> </span><span class="k">do</span>
@@ -8805,8 +8849,8 @@ endsuite
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>  fetch_truth: complete
-extract_grids: active
+<pre>  fetch_truth: active
+extract_grids: queued
 verification:  queued
   fetch_truth: complete
 extract_grids: active
@@ -8815,11 +8859,11 @@ verification:  queued
 extract_grids: active
 verification:  queued
   fetch_truth: complete
-extract_grids: active
-verification:  queued
+extract_grids: complete
+verification:  active
   fetch_truth: complete
-extract_grids: active
-verification:  queued
+extract_grids: complete
+verification:  active
   fetch_truth: complete
 extract_grids: complete
 verification:  active
@@ -8858,7 +8902,7 @@ verification:  complete
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [23]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [24]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>ls<span class="w"> </span>-l<span class="w"> </span><span class="nv">$ECF_HOST</span>.<span class="nv">$ECF_PORT</span>.*
@@ -8874,9 +8918,7 @@ verification:  complete
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>-rw-r--r-- 1 Paul.Madden gsd-hpcs 1977 Jul 15 15:29 uecflow01.18883.ecf.check
--rw-r--r-- 1 Paul.Madden gsd-hpcs 1495 Jul 15 15:13 uecflow01.18883.ecf.check.b
--rw-r--r-- 1 Paul.Madden gsd-hpcs 4515 Jul 15 16:05 uecflow01.18883.ecf.log
+<pre>-rw-r--r-- 1 Paul.Madden gsd-hpcs 4411 Jul 16 22:54 uecflow01.4912.ecf.log
 </pre>
 </div>
 </div>
@@ -8898,7 +8940,7 @@ verification:  complete
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [24]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [25]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>tree<span class="w"> </span>vx
@@ -8922,27 +8964,27 @@ verification:  complete
 ├── fetch_truth.ecf
 ├── <span class="ansi-green-intense-fg ansi-bold">fetch_truth.job1</span>
 ├── <span class="ansi-blue-intense-fg ansi-bold">forecast</span>
-│   └── <span class="ansi-blue-intense-fg ansi-bold">20260714</span>
-│       └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
+│   └── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
+│       └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
 │           └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
 │               ├── 2t-heightAboveGround-0002.grib2
-│               └── gfs.t12z.pgrb2.1p00.f006.ecidx
+│               └── gfs.t18z.pgrb2.1p00.f006.ecidx
 ├── <span class="ansi-blue-intense-fg ansi-bold">run</span>
 │   └── <span class="ansi-blue-intense-fg ansi-bold">stats</span>
-│       └── <span class="ansi-blue-intense-fg ansi-bold">20260714</span>
-│           └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
+│       └── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
+│           └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
 │               └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
-│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V_cnt.txt
-│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.config
-│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.log
-│                   ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.sh</span>
-│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.stat
+│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt
+│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config
+│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log
+│                   ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh</span>
+│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat
 ├── <span class="ansi-blue-intense-fg ansi-bold">truth</span>
-│   └── <span class="ansi-blue-intense-fg ansi-bold">20260714</span>
-│       └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
+│   └── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
+│       └── <span class="ansi-blue-intense-fg ansi-bold">00</span>
 │           └── <span class="ansi-blue-intense-fg ansi-bold">000</span>
 │               ├── 2t-heightAboveGround-0002.grib2
-│               └── gfs.t12z.pgrb2.1p00.f000.idx
+│               └── gfs.t18z.pgrb2.1p00.f000.idx
 ├── verification.ecf
 ├── <span class="ansi-green-intense-fg ansi-bold">verification.job1</span>
 └── verification.out
@@ -8971,7 +9013,7 @@ verification:  complete
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [25]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [26]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>cat<span class="w"> </span>vx/extract_grids.job1
@@ -9011,13 +9053,16 @@ init() {
 set -euxo pipefail
 
 export ECF_HOST=uecflow01
+export ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1
+export ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1
 export ECF_NAME=/vx/extract_grids
-export ECF_PASS=RQCmQzdA
-export ECF_PORT=18883
+export ECF_PASS=QUvRh64X
+export ECF_PORT=4912
 export ECF_TRYNO=1
 export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:$PATH
 
 init $$
+export CYCLE="2026-07-15 18:00:00"
 uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx &gt;/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml
 wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids
 </pre>
@@ -9041,7 +9086,7 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [26]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [27]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>cat<span class="w"> </span>vx/extract_grids.1
@@ -9059,42 +9104,48 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre>+ export ECF_HOST=uecflow01
 + ECF_HOST=uecflow01
++ export ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1
++ ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1
++ export ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1
++ ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1
 + export ECF_NAME=/vx/extract_grids
 + ECF_NAME=/vx/extract_grids
-+ export ECF_PASS=RQCmQzdA
-+ ECF_PASS=RQCmQzdA
-+ export ECF_PORT=18883
-+ ECF_PORT=18883
++ export ECF_PASS=QUvRh64X
++ ECF_PASS=QUvRh64X
++ export ECF_PORT=4912
++ ECF_PORT=4912
 + export ECF_TRYNO=1
 + ECF_TRYNO=1
 + export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin
 + PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin
-+ init 718641
-+ export ECF_RID=718641
-+ ECF_RID=718641
-+ ecflow_client --ssl --init=718641
++ init 422501
++ export ECF_RID=422501
++ ECF_RID=422501
++ ecflow_client --ssl --init=422501
++ export 'CYCLE=2026-07-15 18:00:00'
++ CYCLE='2026-07-15 18:00:00'
 + uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx
 + wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids
-[2026-07-15T16:04:44]     INFO Schema validation succeeded for config
-[2026-07-15T16:04:44]     INFO Preparing task graph for 'grids'
-[2026-07-15T16:04:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260714 12Z 006: Executing
-[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260714 12Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx
-[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260714 12Z 006: Ready
-[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Executing
-[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260714/12/atmos/gfs.t12z.pgrb2.1p00.f000.idx
-[2026-07-15T16:04:48]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx
-[2026-07-15T16:04:48]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Ready
-[2026-07-15T16:04:48]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/2t-heightAboveGround-0002.grib2: Executing
-[2026-07-15T16:04:48]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/2t-heightAboveGround-0002.grib2: Ready
-[2026-07-15T16:04:48]     INFO GRIB index data at 20260714 18Z 000: Executing
-[2026-07-15T16:04:48]     INFO GRIB index data at 20260714 18Z 000: Ready
-[2026-07-15T16:04:48]     INFO Forecast grids for GFSFCST: Ready
-[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Executing
-[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260714/12/atmos/gfs.t12z.pgrb2.1p00.f000 bytes=34264183-34312870
-[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2
-[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Ready
-[2026-07-15T16:04:48]     INFO Truth grids for GFS: Ready
-[2026-07-15T16:04:48]     INFO Grids: Ready
+[2026-07-16T22:53:42]     INFO Schema validation succeeded for config
+[2026-07-16T22:53:42]     INFO Preparing task graph for 'grids'
+[2026-07-16T22:53:42]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Executing
+[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx
+[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Ready
+[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Executing
+[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000.idx
+[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx
+[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Ready
+[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Executing
+[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Ready
+[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Executing
+[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Ready
+[2026-07-16T22:53:45]     INFO Forecast grids for GFSFCST: Ready
+[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Executing
+[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000 bytes=34705919-34754296
+[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2
+[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Ready
+[2026-07-16T22:53:45]     INFO Truth grids for GFS: Ready
+[2026-07-16T22:53:45]     INFO Grids: Ready
 + complete
 + ecflow_client --ssl --complete
 </pre>
@@ -9129,7 +9180,7 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [27]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [28]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>tree<span class="w"> </span>vx/forecast/
@@ -9146,11 +9197,11 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre><span class="ansi-blue-intense-fg ansi-bold">vx/forecast/</span>
-└── <span class="ansi-blue-intense-fg ansi-bold">20260714</span>
-    └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
+└── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
+    └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
         └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
             ├── 2t-heightAboveGround-0002.grib2
-            └── gfs.t12z.pgrb2.1p00.f006.ecidx
+            └── gfs.t18z.pgrb2.1p00.f006.ecidx
 
 4 directories, 2 files
 </pre>
@@ -9174,7 +9225,7 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [28]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [29]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>tree<span class="w"> </span>vx/truth/
@@ -9191,11 +9242,11 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre><span class="ansi-blue-intense-fg ansi-bold">vx/truth/</span>
-└── <span class="ansi-blue-intense-fg ansi-bold">20260714</span>
-    └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
+└── <span class="ansi-blue-intense-fg ansi-bold">20260716</span>
+    └── <span class="ansi-blue-intense-fg ansi-bold">00</span>
         └── <span class="ansi-blue-intense-fg ansi-bold">000</span>
             ├── 2t-heightAboveGround-0002.grib2
-            └── gfs.t12z.pgrb2.1p00.f000.idx
+            └── gfs.t18z.pgrb2.1p00.f000.idx
 
 4 directories, 2 files
 </pre>
@@ -9219,7 +9270,7 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [29]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [30]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span>tree<span class="w"> </span>vx/run/
@@ -9237,14 +9288,14 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre><span class="ansi-blue-intense-fg ansi-bold">vx/run/</span>
 └── <span class="ansi-blue-intense-fg ansi-bold">stats</span>
-    └── <span class="ansi-blue-intense-fg ansi-bold">20260714</span>
-        └── <span class="ansi-blue-intense-fg ansi-bold">12</span>
+    └── <span class="ansi-blue-intense-fg ansi-bold">20260715</span>
+        └── <span class="ansi-blue-intense-fg ansi-bold">18</span>
             └── <span class="ansi-blue-intense-fg ansi-bold">006</span>
-                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V_cnt.txt
-                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.config
-                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.log
-                ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.sh</span>
-                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.stat
+                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt
+                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config
+                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log
+                ├── <span class="ansi-green-intense-fg ansi-bold">grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh</span>
+                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat
 
 5 directories, 5 files
 </pre>
@@ -9268,7 +9319,7 @@ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t g
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [30]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [31]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-bash"><pre><span></span><span class="nb">kill</span><span class="w"> </span>-INT<span class="w"> </span>%1

--- a/notebooks/ecflow/config.yaml
+++ b/notebooks/ecflow/config.yaml
@@ -1,6 +1,6 @@
 app:
   basedir: '{{ "BASEDIR" | env }}'
-  cycle: '{{ "CYCLE" | env }}'
+  cycle: !datetime '{{ "CYCLE" | env }}'
   fcst:
     fn: gfs.t{{ app.hh }}z.pgrb2.1p00.f{{ "%03d" % app.leadtime }}
     url: '{{ app.prefix }}/{{ app.fcst.fn }}'
@@ -18,6 +18,7 @@ ecflow:
         script:
           body: |
             init $$
+            export CYCLE="{{ app.cycle }}"
             uw config realize -i {{ app.basedir }}/config.yaml --key-path wxvx >{{ app.basedir }}/vx.yaml
             wxvx -c {{ app.basedir }}/vx.yaml -t grids
           includes:

--- a/notebooks/ecflow/config.yaml
+++ b/notebooks/ecflow/config.yaml
@@ -1,6 +1,6 @@
 app:
   basedir: '{{ "BASEDIR" | env }}'
-  cycle: 2026-07-14T12:00:00
+  cycle: '{{ "CYCLE" | env }}'
   fcst:
     fn: gfs.t{{ app.hh }}z.pgrb2.1p00.f{{ "%03d" % app.leadtime }}
     url: '{{ app.prefix }}/{{ app.fcst.fn }}'

--- a/notebooks/ecflow/ecflow.ipynb
+++ b/notebooks/ecflow/ecflow.ipynb
@@ -195,7 +195,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1] 421986\n"
+      "[1] 885735\n"
      ]
     }
    ],
@@ -226,7 +226,7 @@
    "id": "849a1082-767f-409f-abdd-68dab1c4ea60",
    "metadata": {},
    "source": [
-    "View `server.log` and note that there were no errors, and the the server is using a random available TCP port.\n",
+    "View `server.log`. Note that there were no errors, and that the server is using a random available TCP port.\n",
     "\n",
     "Also note that, since `~/.ecflowrc/ssl` did not already contain the SSL certificate files required for secure communication with the ecFlow server, these were generated."
    ]
@@ -241,13 +241,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2026-07-16T22:52:47]     INFO Validating config against internal schema: ecflow\n",
-      "[2026-07-16T22:52:47]     INFO Schema validation succeeded for ecFlow config\n",
-      "[2026-07-16T22:52:47]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key\n",
-      "[2026-07-16T22:52:47]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt\n",
-      "[2026-07-16T22:52:47]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem\n",
-      "[2026-07-16T22:53:19]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl\n",
-      "[2026-07-16T22:53:19]     INFO Server started on port 4912\n"
+      "[2026-07-17T14:34:50]     INFO Validating config against internal schema: ecflow\n",
+      "[2026-07-17T14:34:50]     INFO Schema validation succeeded for ecFlow config\n",
+      "[2026-07-17T14:34:50]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key\n",
+      "[2026-07-17T14:34:50]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt\n",
+      "[2026-07-17T14:34:50]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem\n",
+      "[2026-07-17T14:34:51]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl\n",
+      "[2026-07-17T14:34:51]     INFO Server started on port 4822\n"
      ]
     }
    ],
@@ -309,7 +309,7 @@
       "\u001b[1;39m{\u001b[0m\n",
       "  \u001b[1;34m\"ECF_HOME\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
       "  \u001b[1;34m\"ECF_HOST\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"uecflow01\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
-      "  \u001b[1;34m\"ECF_PORT\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"4912\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
+      "  \u001b[1;34m\"ECF_PORT\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"4822\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
       "  \u001b[1;34m\"ECF_SSL\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"1\"\u001b[0m\n",
       "\u001b[1;39m}\u001b[0m\n"
      ]
@@ -339,7 +339,7 @@
      "text": [
       "ECF_HOME: /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow\n",
       "ECF_HOST: uecflow01\n",
-      "ECF_PORT: 4912\n",
+      "ECF_PORT: 4822\n",
       "ECF_SSL: 1\n"
      ]
     }
@@ -369,7 +369,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ping server(uecflow01:4912) succeeded in 00:00:00.004491  ~4 milliseconds\n"
+      "ping server(uecflow01:4822) succeeded in 00:00:00.012204  ~12 milliseconds\n"
      ]
     }
    ],
@@ -424,7 +424,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-07-15T18:00:00\n"
+      "2026-07-16T12:00:00\n"
      ]
     }
    ],
@@ -452,8 +452,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2026-07-16T22:53:22]     INFO Validating config against internal schema: ecflow\n",
-      "[2026-07-16T22:53:22]     INFO Schema validation succeeded for ecFlow config\n"
+      "[2026-07-17T14:34:54]     INFO Validating config against internal schema: ecflow\n",
+      "[2026-07-17T14:34:55]     INFO Schema validation succeeded for ecFlow config\n"
      ]
     }
    ],
@@ -555,7 +555,7 @@
       "%include server.h\n",
       "\n",
       "init $$\n",
-      "test -f gfs.t18z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f006\n",
+      "test -f gfs.t12z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260716/12/atmos/gfs.t12z.pgrb2.1p00.f006\n",
       "\n",
       "%manual\n",
       "Fetch GRIB truth data\n",
@@ -637,7 +637,7 @@
       "%include server.h\n",
       "\n",
       "init $$\n",
-      "export CYCLE=\"2026-07-15 18:00:00\"\n",
+      "export CYCLE=\"2026-07-16 12:00:00\"\n",
       "uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx >/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml\n",
       "wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids\n",
       "\n",
@@ -793,15 +793,6 @@
       "extract_grids: active\n",
       "verification:  queued\n",
       "  fetch_truth: complete\n",
-      "extract_grids: active\n",
-      "verification:  queued\n",
-      "  fetch_truth: complete\n",
-      "extract_grids: complete\n",
-      "verification:  active\n",
-      "  fetch_truth: complete\n",
-      "extract_grids: complete\n",
-      "verification:  active\n",
-      "  fetch_truth: complete\n",
       "extract_grids: complete\n",
       "verification:  active\n",
       "  fetch_truth: complete\n",
@@ -849,7 +840,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r-- 1 Paul.Madden gsd-hpcs 4411 Jul 16 22:54 uecflow01.4912.ecf.log\n"
+      "-rw-r--r-- 1 Paul.Madden gsd-hpcs 3691 Jul 17 14:35 uecflow01.4822.ecf.log\n"
      ]
     }
    ],
@@ -883,27 +874,27 @@
       "├── fetch_truth.ecf\n",
       "├── \u001b[01;32mfetch_truth.job1\u001b[0m\n",
       "├── \u001b[01;34mforecast\u001b[0m\n",
-      "│   └── \u001b[01;34m20260715\u001b[0m\n",
-      "│       └── \u001b[01;34m18\u001b[0m\n",
+      "│   └── \u001b[01;34m20260716\u001b[0m\n",
+      "│       └── \u001b[01;34m12\u001b[0m\n",
       "│           └── \u001b[01;34m006\u001b[0m\n",
       "│               ├── 2t-heightAboveGround-0002.grib2\n",
-      "│               └── gfs.t18z.pgrb2.1p00.f006.ecidx\n",
+      "│               └── gfs.t12z.pgrb2.1p00.f006.ecidx\n",
       "├── \u001b[01;34mrun\u001b[0m\n",
       "│   └── \u001b[01;34mstats\u001b[0m\n",
-      "│       └── \u001b[01;34m20260715\u001b[0m\n",
-      "│           └── \u001b[01;34m18\u001b[0m\n",
+      "│       └── \u001b[01;34m20260716\u001b[0m\n",
+      "│           └── \u001b[01;34m12\u001b[0m\n",
       "│               └── \u001b[01;34m006\u001b[0m\n",
-      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt\n",
-      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config\n",
-      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log\n",
-      "│                   ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh\u001b[0m\n",
-      "│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat\n",
+      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V_cnt.txt\n",
+      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.config\n",
+      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.log\n",
+      "│                   ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.sh\u001b[0m\n",
+      "│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.stat\n",
       "├── \u001b[01;34mtruth\u001b[0m\n",
       "│   └── \u001b[01;34m20260716\u001b[0m\n",
-      "│       └── \u001b[01;34m00\u001b[0m\n",
+      "│       └── \u001b[01;34m18\u001b[0m\n",
       "│           └── \u001b[01;34m000\u001b[0m\n",
       "│               ├── 2t-heightAboveGround-0002.grib2\n",
-      "│               └── gfs.t18z.pgrb2.1p00.f000.idx\n",
+      "│               └── gfs.t12z.pgrb2.1p00.f000.idx\n",
       "├── verification.ecf\n",
       "├── \u001b[01;32mverification.job1\u001b[0m\n",
       "└── verification.out\n",
@@ -925,7 +916,7 @@
     "\n",
     "Let's examine the files created for the `extract_grids` task as an example.\n",
     "\n",
-    "The file `extract_grids.job1` is the concatenation of the header file `common.h`, the header file `server.h`, and the value of `ecflow.suitedef.suite_vs.task_extract_grids.script.body` from `config.yaml`. Here it is:"
+    "The file `extract_grids.job1` is the concatenation of the header file `common.h`, the header file `server.h`, and the value of `ecflow.suitedef.suite_vx.task_extract_grids.script.body` from `config.yaml`. Here it is:"
    ]
   },
   {
@@ -965,13 +956,13 @@
       "export ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1\n",
       "export ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1\n",
       "export ECF_NAME=/vx/extract_grids\n",
-      "export ECF_PASS=QUvRh64X\n",
-      "export ECF_PORT=4912\n",
+      "export ECF_PASS=cVaK4CxG\n",
+      "export ECF_PORT=4822\n",
       "export ECF_TRYNO=1\n",
       "export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:$PATH\n",
       "\n",
       "init $$\n",
-      "export CYCLE=\"2026-07-15 18:00:00\"\n",
+      "export CYCLE=\"2026-07-16 12:00:00\"\n",
       "uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx >/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml\n",
       "wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids\n"
      ]
@@ -1007,42 +998,42 @@
       "+ ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1\n",
       "+ export ECF_NAME=/vx/extract_grids\n",
       "+ ECF_NAME=/vx/extract_grids\n",
-      "+ export ECF_PASS=QUvRh64X\n",
-      "+ ECF_PASS=QUvRh64X\n",
-      "+ export ECF_PORT=4912\n",
-      "+ ECF_PORT=4912\n",
+      "+ export ECF_PASS=cVaK4CxG\n",
+      "+ ECF_PASS=cVaK4CxG\n",
+      "+ export ECF_PORT=4822\n",
+      "+ ECF_PORT=4822\n",
       "+ export ECF_TRYNO=1\n",
       "+ ECF_TRYNO=1\n",
       "+ export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin\n",
       "+ PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin\n",
-      "+ init 422501\n",
-      "+ export ECF_RID=422501\n",
-      "+ ECF_RID=422501\n",
-      "+ ecflow_client --ssl --init=422501\n",
-      "+ export 'CYCLE=2026-07-15 18:00:00'\n",
-      "+ CYCLE='2026-07-15 18:00:00'\n",
+      "+ init 885788\n",
+      "+ export ECF_RID=885788\n",
+      "+ ECF_RID=885788\n",
+      "+ ecflow_client --ssl --init=885788\n",
+      "+ export 'CYCLE=2026-07-16 12:00:00'\n",
+      "+ CYCLE='2026-07-16 12:00:00'\n",
       "+ uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx\n",
       "+ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids\n",
-      "[2026-07-16T22:53:42]     INFO Schema validation succeeded for config\n",
-      "[2026-07-16T22:53:42]     INFO Preparing task graph for 'grids'\n",
-      "[2026-07-16T22:53:42]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Executing\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Ready\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Executing\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000.idx\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Ready\n",
-      "[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Executing\n",
-      "[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Ready\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Executing\n",
-      "[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Ready\n",
-      "[2026-07-16T22:53:45]     INFO Forecast grids for GFSFCST: Ready\n",
-      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Executing\n",
-      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000 bytes=34705919-34754296\n",
-      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2\n",
-      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Ready\n",
-      "[2026-07-16T22:53:45]     INFO Truth grids for GFS: Ready\n",
-      "[2026-07-16T22:53:45]     INFO Grids: Ready\n",
+      "[2026-07-17T14:35:05]     INFO Schema validation succeeded for config\n",
+      "[2026-07-17T14:35:05]     INFO Preparing task graph for 'grids'\n",
+      "[2026-07-17T14:35:05]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260716 12Z 006: Executing\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260716 12Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260716 12Z 006: Ready\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Executing\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260716/12/atmos/gfs.t12z.pgrb2.1p00.f000.idx\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Ready\n",
+      "[2026-07-17T14:35:06]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/2t-heightAboveGround-0002.grib2: Executing\n",
+      "[2026-07-17T14:35:06]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260716/12/006/2t-heightAboveGround-0002.grib2: Ready\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index data at 20260716 18Z 000: Executing\n",
+      "[2026-07-17T14:35:06]     INFO GRIB index data at 20260716 18Z 000: Ready\n",
+      "[2026-07-17T14:35:06]     INFO Forecast grids for GFSFCST: Ready\n",
+      "[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Executing\n",
+      "[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260716/12/atmos/gfs.t12z.pgrb2.1p00.f000 bytes=34068933-34117172\n",
+      "[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2\n",
+      "[2026-07-17T14:35:06]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/18/000/2t-heightAboveGround-0002.grib2: Ready\n",
+      "[2026-07-17T14:35:06]     INFO Truth grids for GFS: Ready\n",
+      "[2026-07-17T14:35:06]     INFO Grids: Ready\n",
       "+ complete\n",
       "+ ecflow_client --ssl --complete\n"
      ]
@@ -1079,11 +1070,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[01;34mvx/forecast/\u001b[0m\n",
-      "└── \u001b[01;34m20260715\u001b[0m\n",
-      "    └── \u001b[01;34m18\u001b[0m\n",
+      "└── \u001b[01;34m20260716\u001b[0m\n",
+      "    └── \u001b[01;34m12\u001b[0m\n",
       "        └── \u001b[01;34m006\u001b[0m\n",
       "            ├── 2t-heightAboveGround-0002.grib2\n",
-      "            └── gfs.t18z.pgrb2.1p00.f006.ecidx\n",
+      "            └── gfs.t12z.pgrb2.1p00.f006.ecidx\n",
       "\n",
       "4 directories, 2 files\n"
      ]
@@ -1113,10 +1104,10 @@
      "text": [
       "\u001b[01;34mvx/truth/\u001b[0m\n",
       "└── \u001b[01;34m20260716\u001b[0m\n",
-      "    └── \u001b[01;34m00\u001b[0m\n",
+      "    └── \u001b[01;34m18\u001b[0m\n",
       "        └── \u001b[01;34m000\u001b[0m\n",
       "            ├── 2t-heightAboveGround-0002.grib2\n",
-      "            └── gfs.t18z.pgrb2.1p00.f000.idx\n",
+      "            └── gfs.t12z.pgrb2.1p00.f000.idx\n",
       "\n",
       "4 directories, 2 files\n"
      ]
@@ -1146,14 +1137,14 @@
      "text": [
       "\u001b[01;34mvx/run/\u001b[0m\n",
       "└── \u001b[01;34mstats\u001b[0m\n",
-      "    └── \u001b[01;34m20260715\u001b[0m\n",
-      "        └── \u001b[01;34m18\u001b[0m\n",
+      "    └── \u001b[01;34m20260716\u001b[0m\n",
+      "        └── \u001b[01;34m12\u001b[0m\n",
       "            └── \u001b[01;34m006\u001b[0m\n",
-      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt\n",
-      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config\n",
-      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log\n",
-      "                ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh\u001b[0m\n",
-      "                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat\n",
+      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V_cnt.txt\n",
+      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.config\n",
+      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.log\n",
+      "                ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.sh\u001b[0m\n",
+      "                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_180000V.stat\n",
       "\n",
       "5 directories, 5 files\n"
      ]

--- a/notebooks/ecflow/ecflow.ipynb
+++ b/notebooks/ecflow/ecflow.ipynb
@@ -60,7 +60,7 @@
      "text": [
       "app:\n",
       "  basedir: '{{ \"BASEDIR\" | env }}'\n",
-      "  cycle: 2026-07-14T12:00:00\n",
+      "  cycle: !datetime '{{ \"CYCLE\" | env }}'\n",
       "  fcst:\n",
       "    fn: gfs.t{{ app.hh }}z.pgrb2.1p00.f{{ \"%03d\" % app.leadtime }}\n",
       "    url: '{{ app.prefix }}/{{ app.fcst.fn }}'\n",
@@ -78,6 +78,7 @@
       "        script:\n",
       "          body: |\n",
       "            init $$\n",
+      "            export CYCLE=\"{{ app.cycle }}\"\n",
       "            uw config realize -i {{ app.basedir }}/config.yaml --key-path wxvx >{{ app.basedir }}/vx.yaml\n",
       "            wxvx -c {{ app.basedir }}/vx.yaml -t grids\n",
       "          includes:\n",
@@ -194,7 +195,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1] 658054\n"
+      "[1] 421986\n"
      ]
     }
    ],
@@ -240,13 +241,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2026-07-15T15:10:43]     INFO Validating config against internal schema: ecflow\n",
-      "[2026-07-15T15:10:43]     INFO Schema validation succeeded for ecFlow config\n",
-      "[2026-07-15T15:10:43]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key\n",
-      "[2026-07-15T15:10:44]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt\n",
-      "[2026-07-15T15:10:44]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem\n",
-      "[2026-07-15T15:11:13]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl\n",
-      "[2026-07-15T15:11:13]     INFO Server started on port 18883\n"
+      "[2026-07-16T22:52:47]     INFO Validating config against internal schema: ecflow\n",
+      "[2026-07-16T22:52:47]     INFO Schema validation succeeded for ecFlow config\n",
+      "[2026-07-16T22:52:47]     INFO Generating SSL private key: /home/Paul.Madden/.ecflowrc/ssl/server.key\n",
+      "[2026-07-16T22:52:47]     INFO Generating SSL certificate: /home/Paul.Madden/.ecflowrc/ssl/server.crt\n",
+      "[2026-07-16T22:52:47]     INFO Generating DH parameters: /home/Paul.Madden/.ecflowrc/ssl/dh2048.pem\n",
+      "[2026-07-16T22:53:19]     INFO SSL certificate files written to /home/Paul.Madden/.ecflowrc/ssl\n",
+      "[2026-07-16T22:53:19]     INFO Server started on port 4912\n"
      ]
     }
    ],
@@ -273,6 +274,8 @@
      "output_type": "stream",
      "text": [
       "export ECF_HOST=%ECF_HOST%\n",
+      "export ECF_JOB=%ECF_JOB%\n",
+      "export ECF_JOBOUT=%ECF_JOBOUT%\n",
       "export ECF_NAME=%ECF_NAME%\n",
       "export ECF_PASS=%ECF_PASS%\n",
       "export ECF_PORT=%ECF_PORT%\n",
@@ -306,7 +309,7 @@
       "\u001b[1;39m{\u001b[0m\n",
       "  \u001b[1;34m\"ECF_HOME\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
       "  \u001b[1;34m\"ECF_HOST\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"uecflow01\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
-      "  \u001b[1;34m\"ECF_PORT\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"18883\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
+      "  \u001b[1;34m\"ECF_PORT\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"4912\"\u001b[0m\u001b[1;39m,\u001b[0m\n",
       "  \u001b[1;34m\"ECF_SSL\"\u001b[0m\u001b[1;39m:\u001b[0m \u001b[0;32m\"1\"\u001b[0m\n",
       "\u001b[1;39m}\u001b[0m\n"
      ]
@@ -336,7 +339,7 @@
      "text": [
       "ECF_HOME: /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow\n",
       "ECF_HOST: uecflow01\n",
-      "ECF_PORT: 18883\n",
+      "ECF_PORT: 4912\n",
       "ECF_SSL: 1\n"
      ]
     }
@@ -366,7 +369,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ping server(uecflow01:18883) succeeded in 00:00:00.004949  ~4 milliseconds\n"
+      "ping server(uecflow01:4912) succeeded in 00:00:00.004491  ~4 milliseconds\n"
      ]
     }
    ],
@@ -405,15 +408,43 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4dadc02-c0cf-4430-8009-d7b921c7927c",
+   "id": "be5fa58c-6645-4520-bec5-f2f5cafc25d9",
    "metadata": {},
    "source": [
-    "Now the server is ready to be loaded with a suite definition, provided by the `ecflow.suitedef` block in `config.yaml`. The `uw ecflow realize` command creates a `suite.def` file in the directory specified by `--output-dir` and, under the directory specified by `--scripts-dir`, any `ecf` scripts defined by `script` blocks in the suite definition:"
+    "Now the server is ready to be loaded with a suite definition, provided by the `ecflow.suitedef` block in `config.yaml`. The config requires a `CYCLE` environment variable, which we set here to one we expect to be complete:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "7dbf031e-2908-4645-8c09-3e6030f849fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2026-07-15T18:00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "ts=$(date -u +%s)\n",
+    "export CYCLE=$(date -ud@$(( ts - ts % 21600 - 86400 )) +%Y-%m-%dT%H:%M:%S)\n",
+    "echo $CYCLE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4dadc02-c0cf-4430-8009-d7b921c7927c",
+   "metadata": {},
+   "source": [
+    "The `uw ecflow realize` command creates a `suite.def` file in the directory specified by `--output-dir` and, under the directory specified by `--scripts-dir`, any `ecf` scripts defined by `script` blocks in the suite definition:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "371d3072-d25a-45ae-8ba4-a787314c9272",
    "metadata": {},
    "outputs": [
@@ -421,8 +452,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2026-07-15T15:11:59]     INFO Validating config against internal schema: ecflow\n",
-      "[2026-07-15T15:11:59]     INFO Schema validation succeeded for ecFlow config\n"
+      "[2026-07-16T22:53:22]     INFO Validating config against internal schema: ecflow\n",
+      "[2026-07-16T22:53:22]     INFO Schema validation succeeded for ecFlow config\n"
      ]
     }
    ],
@@ -440,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "dee04af7-eda3-4dc4-b51c-60b6cf8a86f1",
    "metadata": {},
    "outputs": [
@@ -478,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "ad02961f-0912-4bab-9a97-e8bd3380c745",
    "metadata": {},
    "outputs": [
@@ -509,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "754b6296-a037-4fb2-ba03-382320dfddc5",
    "metadata": {},
    "outputs": [
@@ -524,7 +555,7 @@
       "%include server.h\n",
       "\n",
       "init $$\n",
-      "test -f gfs.t12z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260714/12/atmos/gfs.t12z.pgrb2.1p00.f006\n",
+      "test -f gfs.t18z.pgrb2.1p00.f006 || wget --quiet https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f006\n",
       "\n",
       "%manual\n",
       "Fetch GRIB truth data\n",
@@ -546,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "b1e3941e-099f-4ab9-9ee1-4ada0ea40723",
    "metadata": {},
    "outputs": [
@@ -591,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "8a5adb72-2669-43ba-8622-162d864c097e",
    "metadata": {},
    "outputs": [
@@ -606,6 +637,7 @@
       "%include server.h\n",
       "\n",
       "init $$\n",
+      "export CYCLE=\"2026-07-15 18:00:00\"\n",
       "uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx >/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml\n",
       "wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids\n",
       "\n",
@@ -629,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "0006b57c-b075-442b-a3e2-e49c8fe58ee4",
    "metadata": {},
    "outputs": [
@@ -672,7 +704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "432a669a-274d-4ba4-9bfb-e25b5629edd5",
    "metadata": {},
    "outputs": [],
@@ -690,7 +722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "44af7314-77f1-4e86-8094-8ee856d6d161",
    "metadata": {},
    "outputs": [
@@ -728,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "a556510d-25cf-4a40-b787-697f591a570e",
    "metadata": {},
    "outputs": [],
@@ -746,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "0157f2a1-ebec-4596-bb79-c220ea784339",
    "metadata": {},
    "outputs": [
@@ -754,8 +786,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  fetch_truth: complete\n",
-      "extract_grids: active\n",
+      "  fetch_truth: active\n",
+      "extract_grids: queued\n",
       "verification:  queued\n",
       "  fetch_truth: complete\n",
       "extract_grids: active\n",
@@ -764,11 +796,11 @@
       "extract_grids: active\n",
       "verification:  queued\n",
       "  fetch_truth: complete\n",
-      "extract_grids: active\n",
-      "verification:  queued\n",
+      "extract_grids: complete\n",
+      "verification:  active\n",
       "  fetch_truth: complete\n",
-      "extract_grids: active\n",
-      "verification:  queued\n",
+      "extract_grids: complete\n",
+      "verification:  active\n",
       "  fetch_truth: complete\n",
       "extract_grids: complete\n",
       "verification:  active\n",
@@ -809,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "3095a7eb-391f-4b52-9f35-47cdd24ac986",
    "metadata": {},
    "outputs": [
@@ -817,9 +849,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r-- 1 Paul.Madden gsd-hpcs 1977 Jul 15 15:29 uecflow01.18883.ecf.check\n",
-      "-rw-r--r-- 1 Paul.Madden gsd-hpcs 1495 Jul 15 15:13 uecflow01.18883.ecf.check.b\n",
-      "-rw-r--r-- 1 Paul.Madden gsd-hpcs 4515 Jul 15 16:05 uecflow01.18883.ecf.log\n"
+      "-rw-r--r-- 1 Paul.Madden gsd-hpcs 4411 Jul 16 22:54 uecflow01.4912.ecf.log\n"
      ]
     }
    ],
@@ -837,7 +867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "7b21d04d-c753-47aa-9718-971f3d31323c",
    "metadata": {},
    "outputs": [
@@ -853,27 +883,27 @@
       "├── fetch_truth.ecf\n",
       "├── \u001b[01;32mfetch_truth.job1\u001b[0m\n",
       "├── \u001b[01;34mforecast\u001b[0m\n",
-      "│   └── \u001b[01;34m20260714\u001b[0m\n",
-      "│       └── \u001b[01;34m12\u001b[0m\n",
+      "│   └── \u001b[01;34m20260715\u001b[0m\n",
+      "│       └── \u001b[01;34m18\u001b[0m\n",
       "│           └── \u001b[01;34m006\u001b[0m\n",
       "│               ├── 2t-heightAboveGround-0002.grib2\n",
-      "│               └── gfs.t12z.pgrb2.1p00.f006.ecidx\n",
+      "│               └── gfs.t18z.pgrb2.1p00.f006.ecidx\n",
       "├── \u001b[01;34mrun\u001b[0m\n",
       "│   └── \u001b[01;34mstats\u001b[0m\n",
-      "│       └── \u001b[01;34m20260714\u001b[0m\n",
-      "│           └── \u001b[01;34m12\u001b[0m\n",
+      "│       └── \u001b[01;34m20260715\u001b[0m\n",
+      "│           └── \u001b[01;34m18\u001b[0m\n",
       "│               └── \u001b[01;34m006\u001b[0m\n",
-      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V_cnt.txt\n",
-      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.config\n",
-      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.log\n",
-      "│                   ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.sh\u001b[0m\n",
-      "│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.stat\n",
+      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt\n",
+      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config\n",
+      "│                   ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log\n",
+      "│                   ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh\u001b[0m\n",
+      "│                   └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat\n",
       "├── \u001b[01;34mtruth\u001b[0m\n",
-      "│   └── \u001b[01;34m20260714\u001b[0m\n",
-      "│       └── \u001b[01;34m18\u001b[0m\n",
+      "│   └── \u001b[01;34m20260716\u001b[0m\n",
+      "│       └── \u001b[01;34m00\u001b[0m\n",
       "│           └── \u001b[01;34m000\u001b[0m\n",
       "│               ├── 2t-heightAboveGround-0002.grib2\n",
-      "│               └── gfs.t12z.pgrb2.1p00.f000.idx\n",
+      "│               └── gfs.t18z.pgrb2.1p00.f000.idx\n",
       "├── verification.ecf\n",
       "├── \u001b[01;32mverification.job1\u001b[0m\n",
       "└── verification.out\n",
@@ -900,7 +930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "128527e3-b69b-4a96-a396-f208cb58d170",
    "metadata": {},
    "outputs": [
@@ -932,13 +962,16 @@
       "set -euxo pipefail\n",
       "\n",
       "export ECF_HOST=uecflow01\n",
+      "export ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1\n",
+      "export ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1\n",
       "export ECF_NAME=/vx/extract_grids\n",
-      "export ECF_PASS=RQCmQzdA\n",
-      "export ECF_PORT=18883\n",
+      "export ECF_PASS=QUvRh64X\n",
+      "export ECF_PORT=4912\n",
       "export ECF_TRYNO=1\n",
       "export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:$PATH\n",
       "\n",
       "init $$\n",
+      "export CYCLE=\"2026-07-15 18:00:00\"\n",
       "uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx >/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml\n",
       "wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids\n"
      ]
@@ -958,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "324d3c80-c948-42b7-ae63-954b0cc5a9c9",
    "metadata": {},
    "outputs": [
@@ -968,42 +1001,48 @@
      "text": [
       "+ export ECF_HOST=uecflow01\n",
       "+ ECF_HOST=uecflow01\n",
+      "+ export ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1\n",
+      "+ ECF_JOB=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.job1\n",
+      "+ export ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1\n",
+      "+ ECF_JOBOUT=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/extract_grids.1\n",
       "+ export ECF_NAME=/vx/extract_grids\n",
       "+ ECF_NAME=/vx/extract_grids\n",
-      "+ export ECF_PASS=RQCmQzdA\n",
-      "+ ECF_PASS=RQCmQzdA\n",
-      "+ export ECF_PORT=18883\n",
-      "+ ECF_PORT=18883\n",
+      "+ export ECF_PASS=QUvRh64X\n",
+      "+ ECF_PASS=QUvRh64X\n",
+      "+ export ECF_PORT=4912\n",
+      "+ ECF_PORT=4912\n",
       "+ export ECF_TRYNO=1\n",
       "+ ECF_TRYNO=1\n",
       "+ export PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin\n",
       "+ PATH=/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin/:/scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/conda/envs/demo/bin:/home/Paul.Madden/.local/bin:/usr/local/slurm/default/bin:/usr/local/slurm/default/sbin:/home/Paul.Madden/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/apps/hpss/bin:/apps/bin:/apps/local/bin\n",
-      "+ init 718641\n",
-      "+ export ECF_RID=718641\n",
-      "+ ECF_RID=718641\n",
-      "+ ecflow_client --ssl --init=718641\n",
+      "+ init 422501\n",
+      "+ export ECF_RID=422501\n",
+      "+ ECF_RID=422501\n",
+      "+ ecflow_client --ssl --init=422501\n",
+      "+ export 'CYCLE=2026-07-15 18:00:00'\n",
+      "+ CYCLE='2026-07-15 18:00:00'\n",
       "+ uw config realize -i /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/config.yaml --key-path wxvx\n",
       "+ wxvx -c /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx.yaml -t grids\n",
-      "[2026-07-15T16:04:44]     INFO Schema validation succeeded for config\n",
-      "[2026-07-15T16:04:44]     INFO Preparing task graph for 'grids'\n",
-      "[2026-07-15T16:04:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260714 12Z 006: Executing\n",
-      "[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260714 12Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx\n",
-      "[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/gfs.t12z.pgrb2.1p00.f006.ecidx at 20260714 12Z 006: Ready\n",
-      "[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Executing\n",
-      "[2026-07-15T16:04:47]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260714/12/atmos/gfs.t12z.pgrb2.1p00.f000.idx\n",
-      "[2026-07-15T16:04:48]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx\n",
-      "[2026-07-15T16:04:48]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/gfs.t12z.pgrb2.1p00.f000.idx: Ready\n",
-      "[2026-07-15T16:04:48]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/2t-heightAboveGround-0002.grib2: Executing\n",
-      "[2026-07-15T16:04:48]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260714/12/006/2t-heightAboveGround-0002.grib2: Ready\n",
-      "[2026-07-15T16:04:48]     INFO GRIB index data at 20260714 18Z 000: Executing\n",
-      "[2026-07-15T16:04:48]     INFO GRIB index data at 20260714 18Z 000: Ready\n",
-      "[2026-07-15T16:04:48]     INFO Forecast grids for GFSFCST: Ready\n",
-      "[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Executing\n",
-      "[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260714/12/atmos/gfs.t12z.pgrb2.1p00.f000 bytes=34264183-34312870\n",
-      "[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2\n",
-      "[2026-07-15T16:04:48]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260714/18/000/2t-heightAboveGround-0002.grib2: Ready\n",
-      "[2026-07-15T16:04:48]     INFO Truth grids for GFS: Ready\n",
-      "[2026-07-15T16:04:48]     INFO Grids: Ready\n",
+      "[2026-07-16T22:53:42]     INFO Schema validation succeeded for config\n",
+      "[2026-07-16T22:53:42]     INFO Preparing task graph for 'grids'\n",
+      "[2026-07-16T22:53:42]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Executing\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/gfs.t18z.pgrb2.1p00.f006.ecidx at 20260715 18Z 006: Ready\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Executing\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000.idx\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index file /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/gfs.t18z.pgrb2.1p00.f000.idx: Ready\n",
+      "[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Executing\n",
+      "[2026-07-16T22:53:45]     INFO Forecast grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/forecast/20260715/18/006/2t-heightAboveGround-0002.grib2: Ready\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Executing\n",
+      "[2026-07-16T22:53:45]     INFO GRIB index data at 20260716 00Z 000: Ready\n",
+      "[2026-07-16T22:53:45]     INFO Forecast grids for GFSFCST: Ready\n",
+      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Executing\n",
+      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Fetching https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20260715/18/atmos/gfs.t18z.pgrb2.1p00.f000 bytes=34705919-34754296\n",
+      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Wrote /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2\n",
+      "[2026-07-16T22:53:45]     INFO Truth grid /scratch4/BMC/gsd-hpcs/Paul.Madden/uwtools/notebooks/ecflow/vx/truth/20260716/00/000/2t-heightAboveGround-0002.grib2: Ready\n",
+      "[2026-07-16T22:53:45]     INFO Truth grids for GFS: Ready\n",
+      "[2026-07-16T22:53:45]     INFO Grids: Ready\n",
       "+ complete\n",
       "+ ecflow_client --ssl --complete\n"
      ]
@@ -1031,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "3f37fab2-f4ae-4780-a5a4-18e097721b2c",
    "metadata": {},
    "outputs": [
@@ -1040,11 +1079,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[01;34mvx/forecast/\u001b[0m\n",
-      "└── \u001b[01;34m20260714\u001b[0m\n",
-      "    └── \u001b[01;34m12\u001b[0m\n",
+      "└── \u001b[01;34m20260715\u001b[0m\n",
+      "    └── \u001b[01;34m18\u001b[0m\n",
       "        └── \u001b[01;34m006\u001b[0m\n",
       "            ├── 2t-heightAboveGround-0002.grib2\n",
-      "            └── gfs.t12z.pgrb2.1p00.f006.ecidx\n",
+      "            └── gfs.t18z.pgrb2.1p00.f006.ecidx\n",
       "\n",
       "4 directories, 2 files\n"
      ]
@@ -1064,7 +1103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "deca53c6-3df9-428e-8e93-b56fa2aa3979",
    "metadata": {},
    "outputs": [
@@ -1073,11 +1112,11 @@
      "output_type": "stream",
      "text": [
       "\u001b[01;34mvx/truth/\u001b[0m\n",
-      "└── \u001b[01;34m20260714\u001b[0m\n",
-      "    └── \u001b[01;34m18\u001b[0m\n",
+      "└── \u001b[01;34m20260716\u001b[0m\n",
+      "    └── \u001b[01;34m00\u001b[0m\n",
       "        └── \u001b[01;34m000\u001b[0m\n",
       "            ├── 2t-heightAboveGround-0002.grib2\n",
-      "            └── gfs.t12z.pgrb2.1p00.f000.idx\n",
+      "            └── gfs.t18z.pgrb2.1p00.f000.idx\n",
       "\n",
       "4 directories, 2 files\n"
      ]
@@ -1097,7 +1136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "a5b14b7f-06de-4cdd-85ed-525160b2ecb3",
    "metadata": {},
    "outputs": [
@@ -1107,14 +1146,14 @@
      "text": [
       "\u001b[01;34mvx/run/\u001b[0m\n",
       "└── \u001b[01;34mstats\u001b[0m\n",
-      "    └── \u001b[01;34m20260714\u001b[0m\n",
-      "        └── \u001b[01;34m12\u001b[0m\n",
+      "    └── \u001b[01;34m20260715\u001b[0m\n",
+      "        └── \u001b[01;34m18\u001b[0m\n",
       "            └── \u001b[01;34m006\u001b[0m\n",
-      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V_cnt.txt\n",
-      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.config\n",
-      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.log\n",
-      "                ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.sh\u001b[0m\n",
-      "                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260714_180000V.stat\n",
+      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V_cnt.txt\n",
+      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.config\n",
+      "                ├── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.log\n",
+      "                ├── \u001b[01;32mgrid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.sh\u001b[0m\n",
+      "                └── grid_stat_gfsfcst_2t_heightAboveGround_0002_060000L_20260716_000000V.stat\n",
       "\n",
       "5 directories, 5 files\n"
      ]
@@ -1134,7 +1173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "id": "429eb1c5-325e-4db2-9bef-f02309351453",
    "metadata": {},
    "outputs": [

--- a/notebooks/ecflow/start
+++ b/notebooks/ecflow/start
@@ -1,6 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S bash -eu
 
-set -eu
 if [[ -d conda/ ]]; then
   source conda/etc/profile.d/conda.sh
 else
@@ -9,8 +8,16 @@ else
   bash $fn -bfp conda
   rm -v $fn
   source conda/etc/profile.d/conda.sh
-  conda create -y -n demo -c local -c oar-gsl -c ufs-community bash_kernel jq jupyterlab tree uwtools=2.18 wget wxvx=0.7
-fi    
+  cmd="conda create -y -n demo bash_kernel jq jupyterlab tree oar-gsl::wxvx"
+  if [[ -v $PRERELEASE ]]; then
+    $cmd
+    conda install -y conda-build
+    reporoot=$(git rev-parse --show-toplevel)
+    make -C $reporoot package
+    conda install --name demo local::uwtools
+  else
+    $cmd ufs-community::uwtools
+  fi    
 conda activate demo
 python -m bash_kernel.install
 export BASEDIR=$PWD

--- a/notebooks/ecflow/start
+++ b/notebooks/ecflow/start
@@ -17,7 +17,7 @@ else
     ufs-community::uwtools
   )
   conda create -y -n demo ${packages[*]}
-  if [[ -v $PRERELEASE ]]; then
+  if [[ -v DEVMODE ]]; then
     conda install -y conda-build
     make -C $(git rev-parse --show-toplevel) package
     conda install --name demo local::uwtools

--- a/notebooks/ecflow/start
+++ b/notebooks/ecflow/start
@@ -8,16 +8,21 @@ else
   bash $fn -bfp conda
   rm -v $fn
   source conda/etc/profile.d/conda.sh
-  cmd="conda create -y -n demo bash_kernel jq jupyterlab tree oar-gsl::wxvx"
+  packages=(
+    bash_kernel
+    jq
+    jupyterlab
+    oar-gsl::wxvx
+    tree
+    ufs-community::uwtools
+  )
+  conda create -y -n demo ${packages[*]}
   if [[ -v $PRERELEASE ]]; then
-    $cmd
     conda install -y conda-build
-    reporoot=$(git rev-parse --show-toplevel)
-    make -C $reporoot package
+    make -C $(git rev-parse --show-toplevel) package
     conda install --name demo local::uwtools
-  else
-    $cmd ufs-community::uwtools
-  fi    
+  fi
+fi
 conda activate demo
 python -m bash_kernel.install
 export BASEDIR=$PWD

--- a/notebooks/ecflow/start
+++ b/notebooks/ecflow/start
@@ -20,7 +20,7 @@ else
   if [[ -v DEVMODE ]]; then
     conda install -y conda-build
     make -C $(git rev-parse --show-toplevel) package
-    conda install --name demo local::uwtools
+    conda install -y -n demo local::uwtools
   fi
 fi
 conda activate demo

--- a/notebooks/ecflow/start-devmode
+++ b/notebooks/ecflow/start-devmode
@@ -1,0 +1,3 @@
+#!/usr/bin/env -S bash -eu
+
+DEVMODE=1 ./start

--- a/src/uwtools/ecflow.py
+++ b/src/uwtools/ecflow.py
@@ -485,7 +485,15 @@ def _server_start(env: dict[str, str], port: int | None) -> None:
                 log.error(line)
 
     def post(proc: Popen) -> None:
-        keys = (STR.ECF_HOST, STR.ECF_NAME, STR.ECF_PASS, STR.ECF_PORT, STR.ECF_TRYNO)
+        keys = (
+            STR.ECF_HOST,
+            STR.ECF_JOB,
+            STR.ECF_JOBOUT,
+            STR.ECF_NAME,
+            STR.ECF_PASS,
+            STR.ECF_PORT,
+            STR.ECF_TRYNO,
+        )
         lines = [f"export {k}=%{k}%" for k in keys]
         lines.append("export PATH=%s/bin/:$PATH" % os.environ["CONDA_PREFIX"])
         Path(env[STR.ECF_HOME], "server.h").write_text("\n".join(lines) + "\n")

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -67,6 +67,8 @@ class _STR(_ValsMatchKeys):
 
     ECF_HOME: str = _
     ECF_HOST: str = _
+    ECF_JOB: str = _
+    ECF_JOBOUT: str = _
     ECF_LOG: str = _
     ECF_NAME: str = _
     ECF_PASS: str = _

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -896,6 +896,8 @@ def test_ecflow__server_start__fixed_port_ssl(tmp_path):
     assert header.is_file()
     expected = """
     export ECF_HOST=%ECF_HOST%
+    export ECF_JOB=%ECF_JOB%
+    export ECF_JOBOUT=%ECF_JOBOUT%
     export ECF_NAME=%ECF_NAME%
     export ECF_PASS=%ECF_PASS%
     export ECF_PORT=%ECF_PORT%


### PR DESCRIPTION
**Synopsis**

- Add `ECF_JOB` and `ECF_JOBOUT` to the `server.h` provided by `uw ecflow server`.
- Re-render the ecFlow demo notebook and HTML page.
- Provide an option to the demo notebook's `start` script to create devmode environment that installs `uwtools` from the current repo, rather than a released version, supporting preparation of an up-to-date notebook prior to release.
- Have `make` under `docs/` use 4 parallel workers, to avoid consuming 100% of the cores on the system where `make docs` is running.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
