### PR TITLE
Tie CLI exit status to driver readiness

### DIFF
--- a/docs/sections/user_guide/cli/drivers/cdeps/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/cdeps/run-help.out
@@ -1,6 +1,6 @@
 usage: uw cdeps atm --cycle CYCLE [-h] [--version] [--config-file PATH]
                     [--dry-run] [--graph-file PATH] [--key-path KEY[.KEY...]]
-                    [--schema-file PATH] [--quiet] [--verbose]
+                    [--partial] [--schema-file PATH] [--quiet] [--verbose]
 
 The data atmosphere configuration with all required content
 
@@ -21,6 +21,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/chgres_cube/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/chgres_cube/run-help.out
@@ -1,7 +1,8 @@
 usage: uw chgres_cube run --cycle CYCLE --leadtime LEADTIME [-h] [--version]
                           [--config-file PATH] [--batch] [--dry-run]
                           [--graph-file PATH] [--key-path KEY[.KEY...]]
-                          [--schema-file PATH] [--quiet] [--verbose]
+                          [--partial] [--schema-file PATH] [--quiet]
+                          [--verbose]
 
 A run
 
@@ -26,6 +27,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/enkf/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/enkf/run-help.out
@@ -1,7 +1,7 @@
 usage: uw enkf run --cycle CYCLE [-h] [--version] [--config-file PATH]
                    [--batch] [--dry-run] [--graph-file PATH]
-                   [--key-path KEY[.KEY...]] [--schema-file PATH] [--quiet]
-                   [--verbose]
+                   [--key-path KEY[.KEY...]] [--partial] [--schema-file PATH]
+                   [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/esg_grid/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/esg_grid/run-help.out
@@ -1,7 +1,7 @@
 usage: uw esg_grid run [-h] [--version] [--config-file PATH] [--batch]
                        [--dry-run] [--graph-file PATH]
-                       [--key-path KEY[.KEY...]] [--schema-file PATH]
-                       [--quiet] [--verbose]
+                       [--key-path KEY[.KEY...]] [--partial]
+                       [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -20,6 +20,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/filter_topo/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/filter_topo/run-help.out
@@ -1,7 +1,7 @@
 usage: uw filter_topo run [-h] [--version] [--config-file PATH] [--batch]
                           [--dry-run] [--graph-file PATH]
-                          [--key-path KEY[.KEY...]] [--schema-file PATH]
-                          [--quiet] [--verbose]
+                          [--key-path KEY[.KEY...]] [--partial]
+                          [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -20,6 +20,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/fv3/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/fv3/run-help.out
@@ -1,7 +1,7 @@
 usage: uw fv3 run --cycle CYCLE [-h] [--version] [--config-file PATH]
                   [--batch] [--dry-run] [--graph-file PATH]
-                  [--key-path KEY[.KEY...]] [--schema-file PATH] [--quiet]
-                  [--verbose]
+                  [--key-path KEY[.KEY...]] [--partial] [--schema-file PATH]
+                  [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/global_equiv_resol/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/global_equiv_resol/run-help.out
@@ -1,6 +1,6 @@
 usage: uw global_equiv_resol run [-h] [--version] [--config-file PATH]
                                  [--batch] [--dry-run] [--graph-file PATH]
-                                 [--key-path KEY[.KEY...]]
+                                 [--key-path KEY[.KEY...]] [--partial]
                                  [--schema-file PATH] [--quiet] [--verbose]
 
 A run
@@ -20,6 +20,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/gsi/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/gsi/run-help.out
@@ -1,7 +1,7 @@
 usage: uw gsi run --cycle CYCLE [-h] [--version] [--config-file PATH]
                   [--batch] [--dry-run] [--graph-file PATH]
-                  [--key-path KEY[.KEY...]] [--schema-file PATH] [--quiet]
-                  [--verbose]
+                  [--key-path KEY[.KEY...]] [--partial] [--schema-file PATH]
+                  [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/ioda/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/ioda/run-help.out
@@ -1,7 +1,7 @@
 usage: uw ioda run --cycle CYCLE [-h] [--version] [--config-file PATH]
                    [--batch] [--dry-run] [--graph-file PATH]
-                   [--key-path KEY[.KEY...]] [--schema-file PATH] [--quiet]
-                   [--verbose]
+                   [--key-path KEY[.KEY...]] [--partial] [--schema-file PATH]
+                   [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/jedi/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/jedi/run-help.out
@@ -1,7 +1,7 @@
 usage: uw jedi run --cycle CYCLE [-h] [--version] [--config-file PATH]
                    [--batch] [--dry-run] [--graph-file PATH]
-                   [--key-path KEY[.KEY...]] [--schema-file PATH] [--quiet]
-                   [--verbose]
+                   [--key-path KEY[.KEY...]] [--partial] [--schema-file PATH]
+                   [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/make_hgrid/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/make_hgrid/run-help.out
@@ -1,7 +1,7 @@
 usage: uw make_hgrid run [-h] [--version] [--config-file PATH] [--batch]
                          [--dry-run] [--graph-file PATH]
-                         [--key-path KEY[.KEY...]] [--schema-file PATH]
-                         [--quiet] [--verbose]
+                         [--key-path KEY[.KEY...]] [--partial]
+                         [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -20,6 +20,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/make_solo_mosaic/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/make_solo_mosaic/run-help.out
@@ -1,7 +1,7 @@
 usage: uw make_solo_mosaic run [-h] [--version] [--config-file PATH] [--batch]
                                [--dry-run] [--graph-file PATH]
-                               [--key-path KEY[.KEY...]] [--schema-file PATH]
-                               [--quiet] [--verbose]
+                               [--key-path KEY[.KEY...]] [--partial]
+                               [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -20,6 +20,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/mpas/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/mpas/run-help.out
@@ -1,7 +1,7 @@
 usage: uw mpas run --cycle CYCLE [-h] [--version] [--config-file PATH]
                    [--batch] [--dry-run] [--graph-file PATH]
-                   [--key-path KEY[.KEY...]] [--schema-file PATH] [--quiet]
-                   [--verbose]
+                   [--key-path KEY[.KEY...]] [--partial] [--schema-file PATH]
+                   [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/mpas_init/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/mpas_init/run-help.out
@@ -1,7 +1,7 @@
 usage: uw mpas_init run --cycle CYCLE [-h] [--version] [--config-file PATH]
                         [--batch] [--dry-run] [--graph-file PATH]
-                        [--key-path KEY[.KEY...]] [--schema-file PATH]
-                        [--quiet] [--verbose]
+                        [--key-path KEY[.KEY...]] [--partial]
+                        [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/mpassit/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/mpassit/run-help.out
@@ -1,7 +1,7 @@
 usage: uw mpassit run --cycle CYCLE --leadtime LEADTIME [-h] [--version]
                       [--config-file PATH] [--batch] [--dry-run]
                       [--graph-file PATH] [--key-path KEY[.KEY...]]
-                      [--schema-file PATH] [--quiet] [--verbose]
+                      [--partial] [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -26,6 +26,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/orog/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/orog/run-help.out
@@ -1,5 +1,5 @@
 usage: uw orog run [-h] [--version] [--config-file PATH] [--batch] [--dry-run]
-                   [--graph-file PATH] [--key-path KEY[.KEY...]]
+                   [--graph-file PATH] [--key-path KEY[.KEY...]] [--partial]
                    [--schema-file PATH] [--quiet] [--verbose]
 
 A run
@@ -19,6 +19,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/orog_gsl/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/orog_gsl/run-help.out
@@ -1,7 +1,7 @@
 usage: uw orog_gsl run [-h] [--version] [--config-file PATH] [--batch]
                        [--dry-run] [--graph-file PATH]
-                       [--key-path KEY[.KEY...]] [--schema-file PATH]
-                       [--quiet] [--verbose]
+                       [--key-path KEY[.KEY...]] [--partial]
+                       [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -20,6 +20,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/sfc_climo_gen/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/sfc_climo_gen/run-help.out
@@ -1,7 +1,7 @@
 usage: uw sfc_climo_gen run [-h] [--version] [--config-file PATH] [--batch]
                             [--dry-run] [--graph-file PATH]
-                            [--key-path KEY[.KEY...]] [--schema-file PATH]
-                            [--quiet] [--verbose]
+                            [--key-path KEY[.KEY...]] [--partial]
+                            [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -20,6 +20,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/shave/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/shave/run-help.out
@@ -1,6 +1,6 @@
 usage: uw shave run [-h] [--version] [--config-file PATH] [--batch]
                     [--dry-run] [--graph-file PATH] [--key-path KEY[.KEY...]]
-                    [--schema-file PATH] [--quiet] [--verbose]
+                    [--partial] [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -19,6 +19,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/ungrib/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/ungrib/run-help.out
@@ -1,7 +1,7 @@
 usage: uw ungrib run --cycle CYCLE [-h] [--version] [--config-file PATH]
                      [--batch] [--dry-run] [--graph-file PATH]
-                     [--key-path KEY[.KEY...]] [--schema-file PATH] [--quiet]
-                     [--verbose]
+                     [--key-path KEY[.KEY...]] [--partial]
+                     [--schema-file PATH] [--quiet] [--verbose]
 
 A run
 
@@ -24,6 +24,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/upp/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/upp/run-help.out
@@ -1,6 +1,6 @@
 usage: uw upp run --cycle CYCLE --leadtime LEADTIME [-h] [--version]
                   [--config-file PATH] [--batch] [--dry-run]
-                  [--graph-file PATH] [--key-path KEY[.KEY...]]
+                  [--graph-file PATH] [--key-path KEY[.KEY...]] [--partial]
                   [--schema-file PATH] [--quiet] [--verbose]
 
 A run
@@ -26,6 +26,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/drivers/upp_assets/run-help.out
+++ b/docs/sections/user_guide/cli/drivers/upp_assets/run-help.out
@@ -1,7 +1,7 @@
 usage: uw upp_assets provisioned_rundir --cycle CYCLE --leadtime LEADTIME [-h]
                                         [--version] [--config-file PATH]
                                         [--dry-run] [--graph-file PATH]
-                                        [--key-path KEY[.KEY...]]
+                                        [--key-path KEY[.KEY...]] [--partial]
                                         [--schema-file PATH] [--quiet]
                                         [--verbose]
 
@@ -26,6 +26,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --schema-file PATH
       Path to schema file to use for validation
   --quiet, -q

--- a/docs/sections/user_guide/cli/tools/execute/help.out
+++ b/docs/sections/user_guide/cli/tools/execute/help.out
@@ -1,8 +1,8 @@
 usage: uw execute --module MODULE --classname CLASSNAME [-h] [--version]
                   [--task TASK] [--config-file PATH] [--schema-file PATH]
                   [--cycle CYCLE] [--leadtime LEADTIME] [--batch] [--dry-run]
-                  [--graph-file PATH] [--key-path KEY[.KEY...]] [--quiet]
-                  [--verbose]
+                  [--graph-file PATH] [--key-path KEY[.KEY...]] [--partial]
+                  [--quiet] [--verbose]
 
 Execute external driver.
 
@@ -35,6 +35,8 @@ Optional arguments:
       Path to Graphviz DOT output [experimental]
   --key-path KEY[.KEY...]
       Dot-separated path of keys to driver config block
+  --partial
+      Treat partial execution as success
   --quiet, -q
       Print no logging messages
   --verbose, -v

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -121,7 +121,7 @@ def main() -> None:
         success = modes[mode](args)
         status = {
             True: Status.success,
-            False: Status.notready if mode in DRIVERS or mode == STR.execute else Status.failure,
+            False: Status.notready if mode in [*DRIVERS, STR.execute] else Status.failure,
         }
         sys.exit(status[success])
     except UWError as e:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -485,7 +485,11 @@ def _dispatch_execute(args: Args) -> bool:
         batch=args[STR.batch],
         stdin_ok=True,
     )
-    return False if node is None else True if args[STR.partial] else node.ready
+    if node is None:
+        return False
+    if args[STR.partial]:
+        return True
+    return node.ready
 
 
 # Mode fs
@@ -1520,7 +1524,9 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
     }
     kwargs.update({k: args.get(k) for k in [STR.batch, STR.cycle, STR.leadtime] if k in args})
     node = execute(**kwargs)
-    return True if args[STR.partial] else node.ready
+    if args[STR.partial]:
+        return True
+    return node.ready
 
 
 def _formatter(prog: str) -> HelpFormatter:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -461,6 +461,7 @@ def _add_subparser_execute(subparsers: Subparsers) -> ModeChecks:
     _add_arg_dry_run(optional)
     _add_arg_graph_file(optional)
     _add_arg_key_path(optional, helpmsg="Dot-separated path of keys to driver config block")
+    _add_arg_partial(optional)
     return {STR.execute: _add_args_verbosity(optional)}
 
 
@@ -1420,6 +1421,7 @@ def _add_subparser_for_driver_task(
         optional,
         helpmsg="Dot-separated path of keys to driver config block",
     )
+    _add_arg_partial(optional)
     _add_arg_schema_file(optional)
     return _add_args_verbosity(optional)
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from functools import partial
 from importlib import import_module
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import uwtools.api
 import uwtools.api.config
@@ -37,6 +37,9 @@ from uwtools.exceptions import (
 from uwtools.logging import log, setup_logging
 from uwtools.strings import FORMAT, STR
 from uwtools.utils.file import get_config_format, resource_path
+
+if TYPE_CHECKING:
+    from iotaa import Node
 
 FORMATS = FORMAT.extensions()
 LEADTIME_DESC = "hours[:minutes[:seconds]]"
@@ -481,7 +484,7 @@ def _dispatch_execute(args: Args) -> bool:
         batch=args[STR.batch],
         stdin_ok=True,
     )
-    return bool(node)
+    return False if node is None else node.ready
 
 
 # Mode fs
@@ -1495,7 +1498,7 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
         return True
     if not args.get(STR.action):
         _abort("No %s specified" % STR.task.upper())
-    execute: Callable[..., bool] = module.execute
+    execute: Callable[..., Node] = module.execute
     kwargs = {
         "task": args[STR.action],
         "config": args[STR.config_file],
@@ -1506,7 +1509,8 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
         "stdin_ok": True,
     }
     kwargs.update({k: args.get(k) for k in [STR.batch, STR.cycle, STR.leadtime] if k in args})
-    return execute(**kwargs)
+    node = execute(**kwargs)
+    return node.ready
 
 
 def _formatter(prog: str) -> HelpFormatter:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -42,11 +42,37 @@ from uwtools.utils.file import get_config_format, resource_path
 if TYPE_CHECKING:
     from iotaa import Node
 
+DRIVERS = [
+    STR.cdeps,
+    STR.chgres_cube,
+    STR.enkf,
+    STR.esg_grid,
+    STR.filter_topo,
+    STR.fv3,
+    STR.global_equiv_resol,
+    STR.gsi,
+    STR.ioda,
+    STR.jedi,
+    STR.make_hgrid,
+    STR.make_solo_mosaic,
+    STR.mpas,
+    STR.mpas_init,
+    STR.mpassit,
+    STR.orog,
+    STR.orog_gsl,
+    STR.schism,
+    STR.sfc_climo_gen,
+    STR.shave,
+    STR.ungrib,
+    STR.upp,
+    STR.upp_assets,
+    STR.ww3,
+]
+
 FORMATS = FORMAT.extensions()
 LEADTIME_DESC = "hours[:minutes[:seconds]]"
+STATUS = ns(success=0, failure=1, notready=3)
 TITLE_REQ_ARG = "Required arguments"
-
-STATUS = ns(success=0, failure=1)
 
 Args = dict[str, Any]
 ActionChecks = list[Callable[[Args], Args]]
@@ -83,36 +109,12 @@ def main() -> None:
             STR.ecflow: _dispatch_ecflow,
         }
         drivers: dict[str, Callable[..., bool]] = {
-            x: partial(_dispatch_to_driver, x)
-            for x in [
-                STR.cdeps,
-                STR.chgres_cube,
-                STR.enkf,
-                STR.esg_grid,
-                STR.filter_topo,
-                STR.fv3,
-                STR.global_equiv_resol,
-                STR.gsi,
-                STR.ioda,
-                STR.jedi,
-                STR.make_hgrid,
-                STR.make_solo_mosaic,
-                STR.mpas,
-                STR.mpas_init,
-                STR.mpassit,
-                STR.orog,
-                STR.orog_gsl,
-                STR.schism,
-                STR.sfc_climo_gen,
-                STR.shave,
-                STR.ungrib,
-                STR.upp,
-                STR.upp_assets,
-                STR.ww3,
-            ]
+            x: partial(_dispatch_to_driver, x) for x in DRIVERS
         }
         modes = {**tools, **drivers}
-        sys.exit(STATUS.success if modes[args[STR.mode]](args) else STATUS.failure)
+        mode = args[STR.mode]
+        success = modes[mode](args)
+        sys.exit(STATUS.success if success else STATUS.failure)
     except UWError as e:
         for line in str(e).split("\n"):
             log.error(line)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -13,10 +13,10 @@ from argparse import HelpFormatter
 from argparse import _ArgumentGroup as Group
 from argparse import _SubParsersAction as Subparsers
 from collections.abc import Callable
+from enum import IntEnum
 from functools import partial
 from importlib import import_module
 from pathlib import Path
-from types import SimpleNamespace as ns
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import uwtools.api
@@ -71,13 +71,18 @@ DRIVERS = [
 
 FORMATS = FORMAT.extensions()
 LEADTIME_DESC = "hours[:minutes[:seconds]]"
-STATUS = ns(success=0, failure=1, notready=3)
 TITLE_REQ_ARG = "Required arguments"
 
 Args = dict[str, Any]
 ActionChecks = list[Callable[[Args], Args]]
 ModeChecks = dict[str, ActionChecks]
 Checks = dict[str, ModeChecks]
+
+
+class Status(IntEnum):
+    success = 0
+    failure = 1
+    notready = 3
 
 
 def main() -> None:
@@ -114,14 +119,14 @@ def main() -> None:
         modes = {**tools, **drivers}
         mode = args[STR.mode]
         success = modes[mode](args)
-        status = {True: STATUS.success, False: STATUS.failure}
+        status = {True: Status.success, False: Status.failure}
         if mode in DRIVERS or mode == STR.execute:
-            status[False] = STATUS.notready
+            status[False] = Status.notready
         sys.exit(status[success])
     except UWError as e:
         for line in str(e).split("\n"):
             log.error(line)
-        sys.exit(STATUS.failure)
+        sys.exit(Status.failure)
 
 
 # Mode ecflow
@@ -1341,7 +1346,7 @@ def _abort(msg: str) -> NoReturn:
     :param msg: The message to print.
     """
     print(msg, file=sys.stderr)
-    sys.exit(STATUS.failure)
+    sys.exit(Status.failure)
 
 
 def _add_args_verbosity(group: Group) -> ActionChecks:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -1100,6 +1100,14 @@ def _add_arg_output_dir(group: Group, required: bool = False) -> None:
     )
 
 
+def _add_arg_partial(group: Group) -> None:
+    group.add_argument(
+        _switch(STR.partial),
+        action="store_true",
+        help="Treat partial execution as success",
+    )
+
+
 def _add_arg_port(group: Group) -> None:
     group.add_argument(
         _switch(STR.port),

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -114,7 +114,10 @@ def main() -> None:
         modes = {**tools, **drivers}
         mode = args[STR.mode]
         success = modes[mode](args)
-        sys.exit(STATUS.success if success else STATUS.failure)
+        status = {True: STATUS.success, False: STATUS.failure}
+        if mode in DRIVERS or mode == STR.execute:
+            status[False] = STATUS.notready
+        sys.exit(status[success])
     except UWError as e:
         for line in str(e).split("\n"):
             log.error(line)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -119,9 +119,10 @@ def main() -> None:
         modes = {**tools, **drivers}
         mode = args[STR.mode]
         success = modes[mode](args)
-        status = {True: Status.success, False: Status.failure}
-        if mode in DRIVERS or mode == STR.execute:
-            status[False] = Status.notready
+        status = {
+            True: Status.success,
+            False: Status.notready if mode in DRIVERS or mode == STR.execute else Status.failure,
+        }
         sys.exit(status[success])
     except UWError as e:
         for line in str(e).split("\n"):

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from functools import partial
 from importlib import import_module
 from pathlib import Path
+from types import SimpleNamespace as ns
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import uwtools.api
@@ -44,6 +45,8 @@ if TYPE_CHECKING:
 FORMATS = FORMAT.extensions()
 LEADTIME_DESC = "hours[:minutes[:seconds]]"
 TITLE_REQ_ARG = "Required arguments"
+
+STATUS = ns(success=0, failure=1)
 
 Args = dict[str, Any]
 ActionChecks = list[Callable[[Args], Args]]
@@ -109,11 +112,11 @@ def main() -> None:
             ]
         }
         modes = {**tools, **drivers}
-        sys.exit(0 if modes[args[STR.mode]](args) else 1)
+        sys.exit(STATUS.success if modes[args[STR.mode]](args) else STATUS.failure)
     except UWError as e:
         for line in str(e).split("\n"):
             log.error(line)
-        sys.exit(1)
+        sys.exit(STATUS.failure)
 
 
 # Mode ecflow
@@ -1333,7 +1336,7 @@ def _abort(msg: str) -> NoReturn:
     :param msg: The message to print.
     """
     print(msg, file=sys.stderr)
-    sys.exit(1)
+    sys.exit(STATUS.failure)
 
 
 def _add_args_verbosity(group: Group) -> ActionChecks:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -1510,13 +1510,13 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
         _abort("No %s specified" % STR.task.upper())
     execute: Callable[..., Node] = module.execute
     kwargs = {
-        "task": args[STR.action],
-        "config": args[STR.config_file],
-        "dry_run": args[STR.dry_run],
-        "graph_file": args[STR.graph_file],
-        "key_path": args[STR.key_path],
-        "schema_file": args[STR.schema_file],
-        "stdin_ok": True,
+        STR.task: args[STR.action],
+        STR.config: args[STR.config_file],
+        STR.dry_run: args[STR.dry_run],
+        STR.graph_file: args[STR.graph_file],
+        STR.key_path: args[STR.key_path],
+        STR.schema_file: args[STR.schema_file],
+        STR.stdin_ok: True,
     }
     kwargs.update({k: args.get(k) for k in [STR.batch, STR.cycle, STR.leadtime] if k in args})
     node = execute(**kwargs)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -485,7 +485,7 @@ def _dispatch_execute(args: Args) -> bool:
         batch=args[STR.batch],
         stdin_ok=True,
     )
-    return False if node is None else node.ready
+    return False if node is None else True if args[STR.partial] else node.ready
 
 
 # Mode fs
@@ -1520,7 +1520,7 @@ def _dispatch_to_driver(name: str, args: Args) -> bool:
     }
     kwargs.update({k: args.get(k) for k in [STR.batch, STR.cycle, STR.leadtime] if k in args})
     node = execute(**kwargs)
-    return node.ready
+    return True if args[STR.partial] else node.ready
 
 
 def _formatter(prog: str) -> HelpFormatter:

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -166,6 +166,7 @@ class _STR(_ValsMatchKeys):
     output_file: str = _
     output_format: str = _
     parent: str = _
+    partial: str = _
     path1: str = _
     path2: str = _
     platform: str = _

--- a/src/uwtools/strings.py
+++ b/src/uwtools/strings.py
@@ -195,6 +195,7 @@ class _STR(_ValsMatchKeys):
     show_schema: str = _
     stacksize: str = _
     start: str = _
+    stdin_ok: str = _
     stdout: str = _
     step: str = _
     string: str = _

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -202,7 +202,8 @@ def test_cli__add_subparser_template_translate(subparsers):
     assert subparsers.choices[STR.translate]
 
 
-def test_cli__dispatch_execute(utc):
+@mark.parametrize("partial", [False, True])
+def test_cli__dispatch_execute(partial, utc):
     cycle = utc()
     args: dict = {
         "module": "testdriver",
@@ -215,6 +216,7 @@ def test_cli__dispatch_execute(utc):
         "dry_run": False,
         "graph_file": None,
         "key_path": ["foo", "bar"],
+        "partial": partial,
         "task": "forty_two",
         "stdin_ok": True,
     }
@@ -818,7 +820,8 @@ def test_cli__dispatch_template_translate_no_optional():
 
 
 @mark.parametrize("hours", [0, 24, 168])
-def test_cli__dispatch_to_driver(hours, utc):
+@mark.parametrize("partial", [False, True])
+def test_cli__dispatch_to_driver(hours, partial, utc):
     cycle = utc()
     leadtime = timedelta(hours=hours)
     args: dict = {
@@ -830,6 +833,7 @@ def test_cli__dispatch_to_driver(hours, utc):
         "dry_run": False,
         "graph_file": None,
         "key_path": ["foo", "bar"],
+        "partial": partial,
         "schema_file": None,
         "show_schema": False,
         "stdin_ok": True,

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -202,8 +202,16 @@ def test_cli__add_subparser_template_translate(subparsers):
     assert subparsers.choices[STR.translate]
 
 
-@mark.parametrize("partial", [False, True])
-def test_cli__dispatch_execute(partial, utc):
+@mark.parametrize(
+    ("expected", "partial", "ready"),
+    [
+        (True, False, True),
+        (False, False, False),
+        (True, True, True),
+        (True, True, False),
+    ],
+)
+def test_cli__dispatch_execute(expected, partial, ready, utc):
     cycle = utc()
     args: dict = {
         "module": "testdriver",
@@ -221,7 +229,11 @@ def test_cli__dispatch_execute(partial, utc):
         "stdin_ok": True,
     }
     with patch.object(cli.uwtools.api.execute, "execute") as execute:
-        cli._dispatch_execute(args=args)
+        node = Mock()
+        node.ready = ready
+        execute.return_value = node
+        result = cli._dispatch_execute(args=args)
+        assert result == expected
         execute.assert_called_once_with(
             classname="TestDriver",
             module="testdriver",
@@ -236,6 +248,32 @@ def test_cli__dispatch_execute(partial, utc):
             batch=True,
             stdin_ok=True,
         )
+
+
+def test_cli__dispatch_execute_node_none(utc):
+    """
+    Test that _dispatch_execute returns False when node is None.
+    """
+    cycle = utc()
+    args: dict = {
+        "module": "testdriver",
+        "classname": "TestDriver",
+        "schema_file": "/path/to/testdriver.jsonschema",
+        "batch": True,
+        "config_file": "/path/to/config",
+        "cycle": cycle,
+        "leadtime": None,
+        "dry_run": False,
+        "graph_file": None,
+        "key_path": ["foo", "bar"],
+        "partial": False,
+        "task": "forty_two",
+        "stdin_ok": True,
+    }
+    with patch.object(cli.uwtools.api.execute, "execute") as execute:
+        execute.return_value = None
+        result = cli._dispatch_execute(args=args)
+        assert result is False
 
 
 @mark.parametrize(
@@ -820,8 +858,16 @@ def test_cli__dispatch_template_translate_no_optional():
 
 
 @mark.parametrize("hours", [0, 24, 168])
-@mark.parametrize("partial", [False, True])
-def test_cli__dispatch_to_driver(hours, partial, utc):
+@mark.parametrize(
+    ("expected", "partial", "node_ready"),
+    [
+        (True, False, True),
+        (False, False, False),
+        (True, True, True),
+        (True, True, False),
+    ],
+)
+def test_cli__dispatch_to_driver(expected, hours, partial, node_ready, utc):
     cycle = utc()
     leadtime = timedelta(hours=hours)
     args: dict = {
@@ -839,8 +885,12 @@ def test_cli__dispatch_to_driver(hours, partial, utc):
         "stdin_ok": True,
     }
     adriver = Mock()
+    node = Mock()
+    node.ready = node_ready
+    adriver.execute.return_value = node
     with patch.object(cli, "import_module", return_value=adriver):
-        cli._dispatch_to_driver(name="adriver", args=args)
+        result = cli._dispatch_to_driver(name="adriver", args=args)
+        assert result == expected
         adriver.execute.assert_called_once_with(
             batch=True,
             config="/path/to/config",

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -964,7 +964,7 @@ def test_cli_main_fail_dispatch(vals):
     assert e.value.code == exit_status
 
 
-@mark.parametrize("vals", [(True, cli.STATUS.success), (False, cli.STATUS.notready)])
+@mark.parametrize("vals", [(True, cli.Status.success), (False, cli.Status.notready)])
 def test_cli_main_fail_dispatch_execute(vals):
     success, status = vals
     raw_args = ["testing", STR.execute, "--module", "foo", "--classname", "Bar", "--task", "baz"]

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -964,6 +964,19 @@ def test_cli_main_fail_dispatch(vals):
     assert e.value.code == exit_status
 
 
+@mark.parametrize("vals", [(True, cli.STATUS.success), (False, cli.STATUS.notready)])
+def test_cli_main_fail_dispatch_execute(vals):
+    success, status = vals
+    raw_args = ["testing", STR.execute, "--module", "foo", "--classname", "Bar", "--task", "baz"]
+    with (
+        patch.object(sys, "argv", raw_args),
+        patch.object(cli, "_dispatch_execute", return_value=success),
+        raises(SystemExit) as e,
+    ):
+        cli.main()
+    assert e.value.code == status
+
+
 def test_cli_main_fail_exception_abort():
     # Mock setup_logging() to raise a UWError in main() before logging is configured, which triggers
     # a call to _abort().

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -81,6 +81,17 @@ def test_cli__abort(capsys):
     assert msg in capsys.readouterr().err
 
 
+def test_cli__add_arg_partial():
+    parser = Parser()
+    group = parser.add_argument_group()
+    cli._add_arg_partial(group)
+    # Verify the argument was added by parsing with and without the flag
+    args = parser.parse_args([])
+    assert args.partial is False
+    args = parser.parse_args(["--partial"])
+    assert args.partial is True
+
+
 def test_cli__add_subparser_config(subparsers):
     cli._add_subparser_config(subparsers)
     assert actions(subparsers.choices[STR.config]) == [

--- a/src/uwtools/tests/utils/test_api.py
+++ b/src/uwtools/tests/utils/test_api.py
@@ -2,6 +2,7 @@ import datetime as dt
 from pathlib import Path
 from unittest.mock import patch
 
+from iotaa import Node
 from pytest import fixture, mark, raises
 
 from uwtools.exceptions import UWError
@@ -102,6 +103,8 @@ def test__execute(execute_kwargs, hours, supply_graph_file, tmp_path, utc):
         "graph_file": graph_file if supply_graph_file else None,
     }
     assert not graph_file.is_file()
-    assert api._execute(**kwargs) is True
+    node = api._execute(**kwargs)
+    assert isinstance(node, Node)
+    assert node.ready is True
     if supply_graph_file:
         assert graph_file.is_file()

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -182,7 +182,7 @@ def _execute(
     :param key_path: Path of keys to config block to use.
     :param schema_file: The JSON Schema file to use for validation.
     :param stdin_ok: OK to read from stdin?
-    :return: The root Node of the ioaa task graph.
+    :return: The task-graph root Node.
     """
     kwargs = dict(
         config=ensure_data_source(str2path(config), stdin_ok),

--- a/src/uwtools/utils/api.py
+++ b/src/uwtools/utils/api.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     import datetime as dt
     from collections.abc import Callable
 
+    from iotaa import Node
+
     from uwtools.config.support import YAMLKey
     from uwtools.drivers.driver import DriverT
 
@@ -43,7 +45,7 @@ def make_execute(
     driver_class: DriverT,
     with_cycle: bool | None = False,
     with_leadtime: bool | None = False,
-) -> Callable[..., bool]:
+) -> Callable[..., Node]:
     """
     Return a function that executes tasks for the given driver.
 
@@ -61,7 +63,7 @@ def make_execute(
         key_path: list[YAMLKey] | None = None,
         schema_file: Path | str | None = None,
         stdin_ok: bool = False,
-    ) -> bool:
+    ) -> Node:
         return _execute(
             driver_class=driver_class,
             task=task,
@@ -86,7 +88,7 @@ def make_execute(
         key_path: list[YAMLKey] | None = None,
         schema_file: Path | str | None = None,
         stdin_ok: bool = False,
-    ) -> bool:
+    ) -> Node:
         return _execute(
             driver_class=driver_class,
             task=task,
@@ -112,7 +114,7 @@ def make_execute(
         key_path: list[YAMLKey] | None = None,
         schema_file: Path | str | None = None,
         stdin_ok: bool = False,
-    ) -> bool:
+    ) -> Node:
         return _execute(
             driver_class=driver_class,
             task=task,
@@ -162,7 +164,7 @@ def _execute(
     key_path: list[YAMLKey] | None = None,
     schema_file: Path | str | None = None,
     stdin_ok: bool = False,
-) -> bool:
+) -> Node:
     """
     Execute a task.
 
@@ -180,7 +182,7 @@ def _execute(
     :param key_path: Path of keys to config block to use.
     :param schema_file: The JSON Schema file to use for validation.
     :param stdin_ok: OK to read from stdin?
-    :return: True if task completes without raising an exception.
+    :return: The root Node of the ioaa task graph.
     """
     kwargs = dict(
         config=ensure_data_source(str2path(config), stdin_ok),
@@ -195,7 +197,7 @@ def _execute(
     function_scope_locals = locals()
     kwargs.update({arg: function_scope_locals.get(arg) for arg in accepted_args})
     obj = driver_class(**kwargs)
-    node = getattr(obj, task)(dry_run=dry_run)
+    node: Node = getattr(obj, task)(dry_run=dry_run)
     if graph_file:
         Path(graph_file).write_text(f"{node.graph}\n")
-    return True
+    return node


### PR DESCRIPTION
**Synopsis**

- For both internal and external drivers, set CLI exit status based on driver behavior: 0 when the invoked driver task is ready or when it is not yet ready but partial progress is acceptable (see below); 1 when it has definitively failed; or 3 when it has not failed but it not yet ready. (The rationale for not using 2 can be found [here](https://tldp.org/LDP/abs/html/exitcodes.html#FTN.AEN23629).)
- Add a `--partial` flag to `uw execute` and `uw <driver>` modes to state that partial task-graph completion during driver invocation is not an error. The default behavior is now to exit with error (2) status if the task is not ready after invocation.
- Update the docs, which account for the vast majority of the changed files.

Quick demo, given

`foo.py`
```
from iotaa import Asset, collection, external
from uwtools.api.driver import DriverTimeInvariant
from uwtools.exceptions import UWError


class Foo(DriverTimeInvariant):

    @external
    def no(self):
        # raise UWError("FAIL")
        yield "No"
        yield Asset(None, lambda: False)

    @collection
    def provisioned_rundir(self):
        yield "rundir"
        yield self.no()

    @classmethod
    def driver_name(cls) -> str:
        return "foo"
```

`foo.jsonschema`
```
{"type": "object"}
```

`foo.yaml`
```
foo:
  execution:
    executable: /bin/true
  rundir: /tmp
```

Default behavior:
```
$ uw execute --module foo.py --classname Foo --task run --config-file foo.yaml ; echo $?
[2026-07-17T23:26:20]     INFO Schema validation succeeded for foo config
[2026-07-17T23:26:20]     INFO Validating config against internal schema: platform
[2026-07-17T23:26:20]     INFO Schema validation succeeded for platform config
[2026-07-17T23:26:20]  WARNING No: Not ready [external asset]
[2026-07-17T23:26:20]  WARNING rundir: Not ready
[2026-07-17T23:26:20]  WARNING rundir: Requires:
[2026-07-17T23:26:20]  WARNING rundir: ✖ No
[2026-07-17T23:26:20]  WARNING foo run via local execution: Not ready
[2026-07-17T23:26:20]  WARNING foo run via local execution: Requires:
[2026-07-17T23:26:20]  WARNING foo run via local execution: ✖ rundir
[2026-07-17T23:26:20]  WARNING foo run: Not ready
[2026-07-17T23:26:20]  WARNING foo run: Requires:
[2026-07-17T23:26:20]  WARNING foo run: ✖ foo run via local execution
3
```

With `--partial`
```
$ uw execute --module foo.py --classname Foo --task run --config-file foo.yaml --partial ; echo $?
[2026-07-17T23:26:50]     INFO Schema validation succeeded for foo config
[2026-07-17T23:26:50]     INFO Validating config against internal schema: platform
[2026-07-17T23:26:50]     INFO Schema validation succeeded for platform config
[2026-07-17T23:26:50]  WARNING No: Not ready [external asset]
[2026-07-17T23:26:50]  WARNING rundir: Not ready
[2026-07-17T23:26:50]  WARNING rundir: Requires:
[2026-07-17T23:26:50]  WARNING rundir: ✖ No
[2026-07-17T23:26:50]  WARNING foo run via local execution: Not ready
[2026-07-17T23:26:50]  WARNING foo run via local execution: Requires:
[2026-07-17T23:26:50]  WARNING foo run via local execution: ✖ rundir
[2026-07-17T23:26:50]  WARNING foo run: Not ready
[2026-07-17T23:26:50]  WARNING foo run: Requires:
[2026-07-17T23:26:50]  WARNING foo run: ✖ foo run via local execution
0
```

With the `raise` in the code uncommented to synthesize a true error:
```
$ uw execute --module foo.py --classname Foo --task run --config-file foo.yaml --partial ; echo $?
[2026-07-17T23:27:30]     INFO Schema validation succeeded for foo config
[2026-07-17T23:27:30]     INFO Validating config against internal schema: platform
[2026-07-17T23:27:30]     INFO Schema validation succeeded for platform config
[2026-07-17T23:27:30]    ERROR FAIL
1
```

**Type**

- [x] Documentation
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a breaking change (changes existing functionality)

The API interface for internal drivers now return a `Node` object (on which e.g. `.ready` can be queried) instead of a `bool`, as was already the case with external drivers. Also, the CLI status codes are changing. These both constitute breaking changes.

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
