### PR TITLE
ruff update

### DIFF
--- a/notebooks/pyproject.toml
+++ b/notebooks/pyproject.toml
@@ -10,6 +10,7 @@ ignore = [
   "ANN001",  # missing-type-function-argument
   "ANN201",  # missing-return-type-class-method
   "COM812",  # missing-trailing-comma
+  "CPY001",  # missing-copyright-notice
   "D100",    # undocumented-public-module
   "D103",    # undocumented-public-function
   "D104",    # undocumented-public-package

--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -24,7 +24,7 @@
       "python-dateutil >=2.9,<2.10",
       "pyyaml >=6.0,<6.1",
       "requests >=2.32,<2.35",
-      "ruff ==0.15.*",
+      "ruff ==0.16.*",
       "setuptools",
       "types-PyYAML",
       "types-jsonschema",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - pytest-randomly 3.15.*
     - pytest-xdist 3.8.*
     - python {{ pymin }}
-    - ruff 0.15.*
+    - ruff 0.16.*
     - types-PyYAML
     - types-jsonschema
     - types-python-dateutil

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -46,6 +46,7 @@ ignore = [
   "C408",    # unnecessary-collection-call
   "C901",    # complex-structure
   "COM812",  # missing-trailing-comma
+  "CPY001",  # missing-copyright-notice
   "D100",    # undocumented-public-module
   "D101",    # undocumented-public-class
   "D102",    # undocumented-public-method
@@ -69,6 +70,7 @@ ignore = [
   "FLY002",  # static-join-to-f-string
   "N813",    # camelcase-imported-as-lowercase
   "PLR0913", # too-many-arguments
+  "PLR0917", # too-many-positional-arguments
   "PLR2004", # magic-value-comparison
   "PT019",   # pytest-fixture-param-without-value
   "PTH207",  # glob


### PR DESCRIPTION
**Synopsis**

`ruff` 0.16.0 is a [significant update](https://astral.sh/blog/ruff-v0.16.0) including breaking changes, new rules, and more rules enabled by default. I thought it might be a good time to do an isolated update, and it turned out that I needed to change nearly nothing.

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
