### PR TITLE
Updates for AIGFS work

### DIFF
--- a/src/uwtools/api/utils.py
+++ b/src/uwtools/api/utils.py
@@ -2,6 +2,7 @@
 API access to utility functions.
 """
 
+from uwtools.utils.file import atomic
 from uwtools.utils.processing import run_shell_cmd
 
-__all__ = ["run_shell_cmd"]
+__all__ = ["atomic", "run_shell_cmd"]

--- a/src/uwtools/tests/api/test_utils.py
+++ b/src/uwtools/tests/api/test_utils.py
@@ -1,0 +1,11 @@
+from uwtools.api import utils
+from uwtools.utils.file import atomic
+from uwtools.utils.processing import run_shell_cmd
+
+
+def test_api_utils_atomic():
+    assert utils.atomic is atomic
+
+
+def test_api_utils_run_shell_cmd():
+    assert utils.run_shell_cmd is run_shell_cmd

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -45,6 +45,18 @@ def test__stdinproxy():
         assert file._stdinproxy().read() == msg1  # <-- the NEW message
 
 
+def test_atomic(tmp_path):
+    path = tmp_path / "foo"
+    with file.atomic(path) as f:
+        assert f == path.with_suffix(".tmp")
+        assert not f.is_file()
+        f.touch()
+        assert f.is_file()
+        assert not path.is_file()
+    assert not f.is_file()
+    assert path.is_file()
+
+
 @mark.parametrize(
     ("ext", "file_type"),
     {

--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -69,12 +69,12 @@ def test_utils_processing_run_shell_cmd__success(
     elif log_output:
         pre = f"[{taskname}] " if taskname else ""
         expected = """
-        %sRunning: %s
-          in directory
-            %s
-          with environment
-            FOO=bar
-        %sOutput:
-        %s  hello bar
-        """ % (pre, cmd, rundir, pre, pre)
+        {pre}Running: {cmd}
+        {pre}  in directory
+        {pre}    {rundir}
+        {pre}  with environment
+        {pre}    FOO=bar
+        {pre}Output:
+        {pre}  hello bar
+        """.format(pre=pre, cmd=cmd, rundir=rundir)
         assert uwcaplog.text.strip() == dedent(expected).strip()

--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -76,5 +76,5 @@ def test_utils_processing_run_shell_cmd__success(
             FOO=bar
         %sOutput:
         %s  hello bar
-        """ % (pre, cmd, tmp_path, pre, pre)
+        """ % (pre, cmd, rundir, pre, pre)
         assert uwcaplog.text.strip() == dedent(expected).strip()

--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -50,12 +50,13 @@ def test_utils_processing_run_shell_cmd__failure(caplog, logged, quiet):
 def test_utils_processing_run_shell_cmd__success(
     executable, log_output, quiet, taskname, tmp_path, uwcaplog
 ):
+    rundir = tmp_path / "run"
     cmd = "echo hello $FOO"
     if quiet:
         log.setLevel(logging.INFO)
     success, _ = processing.run_shell_cmd(
         cmd=cmd,
-        cwd=tmp_path,
+        cwd=rundir,
         env={"FOO": "bar"},
         log_output=log_output,
         taskname=taskname,

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -16,7 +16,7 @@ from uwtools.logging import log
 from uwtools.strings import FORMAT
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterator
 
 
 class StdinProxy:
@@ -43,6 +43,21 @@ class StdinProxy:
 @cache
 def _stdinproxy() -> StdinProxy:
     return StdinProxy()
+
+
+@contextmanager
+def atomic(path: Path) -> Iterator[Path]:
+    """
+    Yields a path to a temporary file, finally renaming that file to ``path``.
+
+    :param path: The final path.
+    :yields: The path to a temporary file.
+    :yieldtype: Path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = Path("%s.tmp" % path)
+    yield tmp
+    tmp.rename(path)
 
 
 def get_config_format(path: str | Path | None, desc: str | None = None) -> str:

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -59,14 +59,14 @@ def run_shell_cmd(
     logfunc = log.debug if quiet else log.info
     logfunc("%sRunning: %s", pre, cmd)
     if cwd:
-        logfunc("  in directory")
-        logfunc("    %s", cwd)
+        logfunc("%s  in directory", pre)
+        logfunc("%s    %s", pre, cwd)
         cwd = Path(cwd)
         cwd.mkdir(parents=True, exist_ok=True)
     if env:
-        logfunc("  with environment")
+        logfunc("%s  with environment", pre)
         for k in sorted(env):
-            logfunc("    %s=%s", k, env[k])
+            logfunc("%s    %s=%s", pre, k, env[k])
     kwargs: dict = dict(
         cwd=cwd,
         encoding="utf=8",

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -4,6 +4,7 @@ Utilities for interacting with external processes.
 
 from __future__ import annotations
 
+from pathlib import Path
 from subprocess import PIPE, STDOUT, Popen
 from typing import TYPE_CHECKING
 
@@ -11,7 +12,6 @@ from uwtools.logging import INDENT, log
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 
 def run_shell_cmd(
@@ -61,6 +61,8 @@ def run_shell_cmd(
     if cwd:
         logfunc("  in directory")
         logfunc("    %s", cwd)
+        cwd = Path(cwd)
+        cwd.mkdir(parents=True, exist_ok=True)
     if env:
         logfunc("  with environment")
         for k in sorted(env):


### PR DESCRIPTION
**Synopsis**

Working on AIGFS, I noticed a possibility for three improvements:

1. When calling `uwtools.api.utils.run_shell_cmd()`, the directory specified by `cwd` must already exist. As of this PR, and as in general in `uwtools`, the required directory is created if it does not already exist.
2. Also in `uwtools.api.utils.run_shell_cmd()`, when `taskname` is provided, it was being prepended for only _some_ of the log messages. This PR corrects that. See below for example bad output.
3. The `atomic()` context manager is borrowed from `wxvx`, added to `uwtools.utils.file`, and exposed via the API. See the corresponding unit test for an example use case.

Here's some output from some AIGFS testing I was doing:

```
[2026-07-29T04:38:20]     INFO [GRIB index /tmp/aigfs/out/fstab.idx] Running: wgrib2 -s /etc/fstab >/tmp/aigfs/out/fstab.idx.tmp && mv /tmp/aigfs/out/fstab.idx.tmp /tmp/aigfs/out/fstab.idx
[2026-07-29T04:38:20]     INFO   in directory
[2026-07-29T04:38:20]     INFO     /tmp/aigfs/out
[2026-07-29T04:38:20]    ERROR [GRIB index /tmp/aigfs/out/fstab.idx] Failed with status: 127
[2026-07-29T04:38:20]    ERROR [GRIB index /tmp/aigfs/out/fstab.idx] Output:
[2026-07-29T04:38:20]    ERROR [GRIB index /tmp/aigfs/out/fstab.idx]   wgrib2: symbol lookup error: wgrib2: undefined symbol: g2c_enc_aec
```
Never mind the error, but note that the second and third log messages anomalously are not prefixed with the taskname.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
