### PR TITLE
Remove last-tested-version notices from notebooks.

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -11,7 +11,7 @@ run_tests() {
   set -x
   git clean -dfx
   pip install --editable src # sets new Python version in entry-point scripts
-  make test && make test-nb
+  make test && make notebooks && make test-nb
   status=$?
   set +x
   conda deactivate


### PR DESCRIPTION
**Synopsis**

Now that we've got automated testing for the notebooks, the last-tested-version notices are probably less useful than they were initially, and yet less since we are not updating them regularly. This PR removes them 

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)
- [x] Notebooks

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
