### PR TITLE
Remove notebook version notice

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -11,7 +11,7 @@ run_tests() {
   set -x
   git clean -dfx
   pip install --editable src # sets new Python version in entry-point scripts
-  make test && make test-nb
+  make test && make notebooks && make test-nb
   status=$?
   set +x
   conda deactivate

--- a/notebooks/config.ipynb
+++ b/notebooks/config.ipynb
@@ -9,7 +9,6 @@
     "\n",
     "The `uwtools` API's `config` module provides functions to create and manipulate configuration files, objects, and dictionaries.\n",
     "\n",
-    "<div class=\"alert alert-warning\"><b>Note: </b>This notebook was tested using <code>uwtools</code> version 2.6.0.</div>\n",
     "<div class=\"alert alert-info\">For more information, please see the <a href=\"https://uwtools.readthedocs.io/en/2.5.0/sections/user_guide/api/config.html\">uwtools.api.config</a> Read the Docs page.</div>\n",
     "\n",
     "## Table of Contents\n",

--- a/notebooks/exp-config-cb.ipynb
+++ b/notebooks/exp-config-cb.ipynb
@@ -7,8 +7,6 @@
    "source": [
     "# Building and Validating an Experiment Configuration\n",
     "\n",
-    "<div class=\"alert alert-warning\"><b>Note: </b>This notebook was tested using <code>uwtools</code> version 2.6.0.</div>\n",
-    "\n",
     "This notebook demonstrates how to build up a configuration file for generating FV3 initial conditions (ICs) from a hierarchy of smaller, purpose-specific files; dereferencing Jinja2 expressions in the configuration; and validating the final configuration to check for potential errors. A larger, more complex experimental setup could be built up by applying similar techniques.\n",
     "<!--cell 0-->"
    ]

--- a/notebooks/fs.ipynb
+++ b/notebooks/fs.ipynb
@@ -9,7 +9,6 @@
     "\n",
     "The `uwtools` API's `fs` module provides functions to copy and link files as well as create directories. \n",
     "\n",
-    "<div class=\"alert alert-warning\"><b>Note: </b>This notebook was tested using <code>uwtools</code> version 2.6.0. </div>\n",
     "<div class=\"alert alert-info\">For more information, please see the <a href=\"https://uwtools.readthedocs.io/en/2.5.0/sections/user_guide/api/fs.html\">uwtools.api.fs</a> Read the Docs page.</div>\n",
     "\n",
     "## Table of Contents\n",

--- a/notebooks/rocoto.ipynb
+++ b/notebooks/rocoto.ipynb
@@ -9,7 +9,6 @@
     "\n",
     "The `uwtools` API's `rocoto` module provides functions to build and validate Rocoto workflows. For more information on the UW YAML language than what is discussed here, see the <a href=\"https://uwtools.readthedocs.io/en/main/sections/user_guide/yaml/rocoto.html\">Defining a Rocoto Workflow</a> page. For more on Rocoto XML documents, see the <a href=\"https://noaa-gsl.github.io/rocoto/\">Rocoto Documentation</a>.\n",
     "\n",
-    "<div class=\"alert alert-warning\"><b>Note: </b>This notebook was tested using <code>uwtools</code> version 2.6.0. </div>\n",
     "<div class=\"alert alert-info\">For more information, please see the <a href=\"https://uwtools.readthedocs.io/en/2.5.0/sections/user_guide/api/rocoto.html\">uwtools.api.rocoto</a> Read the Docs page.</div>\n",
     "\n",
     "## Table of Contents\n",

--- a/notebooks/template.ipynb
+++ b/notebooks/template.ipynb
@@ -9,7 +9,6 @@
     "\n",
     "The `uwtools` API's `template` module provides functions to render Jinja2 templates and to translate atparse templates to Jinja2.\n",
     "\n",
-    "<div class=\"alert alert-warning\"><b>Note: </b>This notebook was tested using <code>uwtools</code> version 2.6.0. </div>\n",
     "<div class=\"alert alert-info\">For more information, please see the <a href=\"https://uwtools.readthedocs.io/en/2.5.0/sections/user_guide/api/template.html\">uwtools.api.template</a> Read the Docs page.</div>\n",
     "\n",
     "## Table of Contents\n",


### PR DESCRIPTION
**Synopsis**

Now that we've got automated testing for the notebooks, the last-tested-version notices are probably less useful than they were initially, and yet less since we are not updating them regularly. This PR removes them

**Type**

- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)
- [x] Notebooks

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
