### PR TITLE
Always log errors in run_shell_cmd()

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -11,7 +11,7 @@ run_tests() {
   set -x
   git clean -dfx
   pip install --editable src # sets new Python version in entry-point scripts
-  make test && make test-nb
+  make test && make notebooks && make test-nb
   status=$?
   set +x
   conda deactivate

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -11,7 +11,7 @@ run_tests() {
   set -x
   git clean -dfx
   pip install --editable src # sets new Python version in entry-point scripts
-  make test && make notebooks && make test-nb
+  make test && make test-nb
   status=$?
   set +x
   conda deactivate

--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -38,9 +38,9 @@ def test_utils_processing_run_shell_cmd__failure(caplog, logged, quiet):
     check = lambda msg: not logged(msg) if quiet else logged
     assert check("Running:")
     assert check("  %s" % cmd)
-    assert check("Failed with status: 2")
-    assert check("Output:")
-    assert check("  expr: division by zero")
+    assert logged("Failed with status: 2")
+    assert logged("Output:")
+    assert logged("  expr: division by zero")
 
 
 @mark.parametrize("executable", ["/bin/bash", None])

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -83,13 +83,10 @@ def run_shell_cmd(
     if callback:
         callback(proc)
     output, _ = proc.communicate()  # blocking call
-    if proc.returncode == 0:
-        success = True
-    else:
-        if not quiet:
-            log.error("%sFailed with status: %s", pre, proc.returncode)
-            logfunc = log.error
-        success = False
+    success = proc.returncode == 0
+    if not success:
+        logfunc = log.error  # log remaining messages as errors
+        logfunc("%sFailed with status: %s", pre, proc.returncode)
     if output and (log_output or not success):
         logfunc("%sOutput:", pre)
         for line in output.strip().split("\n"):


### PR DESCRIPTION
**Synopsis**

Prior to a recent revamp of `uwtools.utils.processing.run_shell_cmd()`, errors resulting from a failed shell command were always logged, even when `quiet=True` was specified. The revamp inadvertently (?) changed this, leading to behavior like

```
$ uw rocoto iterate --cycle 2026-08-17T12 --database rocoto.db --workflow rocoto.xml --task foo
[2026-08-17T17:57:22]     INFO Iterating workflow
$
```

when the `rocoto` system module is not loaded such that `rocotorun` is not available. The error is displayed only if the `--verbose` flag is specified:

```
$ uw rocoto iterate --cycle 2026-08-17T12 --database rocoto.db --workflow rocoto.xml --task foo --verbose
[2026-08-17T17:57:47]    DEBUG Command: uw rocoto iterate --cycle 2026-08-17T12 --database rocoto.db --workflow rocoto.xml --task foo --verbose
[2026-08-17T17:57:47]     INFO Iterating workflow
[2026-08-17T17:57:47]    DEBUG Running: rocotorun -d rocoto.db -w rocoto.xml
[2026-08-17T17:57:47]    DEBUG Output:
[2026-08-17T17:57:47]    DEBUG   /bin/sh: line 1: rocotorun: command not found
$
```

But users should not have to specify `--verbose` to see an error like this.

This PR updates `run_shell_cmd()` so that the error behavior above is now

```
$ uw rocoto iterate --cycle 2026-08-17T12 --database rocoto.db --workflow rocoto.xml --task foo
[2026-08-17T18:29:37]     INFO Iterating workflow
[2026-08-17T18:29:37]    ERROR Failed with status: 127
[2026-08-17T18:29:37]    ERROR Output:
[2026-08-17T18:29:37]    ERROR   /bin/sh: line 1: rocotorun: command not found
$
```

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
