### PR TITLE
Append to driver .out file instead of overwriting

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -426,7 +426,7 @@ class Driver(Assets):
         path = self.rundir / self._runscript_done_file
         yield Asset(path, path.is_file)
         yield self.provisioned_rundir()
-        cmd = "./{x} >{x}.out 2>&1".format(x=self._runscript_path.name)
+        cmd = "./{x} >>{x}.out 2>&1".format(x=self._runscript_path.name)
         run_shell_cmd(cmd=cmd, cwd=self.rundir, log_output=True)
 
     # Public methods

--- a/src/uwtools/drivers/ungrib.py
+++ b/src/uwtools/drivers/ungrib.py
@@ -15,7 +15,6 @@ from uwtools.drivers.driver import DriverCycleBased
 from uwtools.drivers.support import set_driver_docstring
 from uwtools.exceptions import UWConfigError
 from uwtools.strings import STR
-from uwtools.utils.processing import run_shell_cmd
 from uwtools.utils.tasks import file
 from uwtools.utils.time import to_datetime, to_iso8601, to_timedelta
 
@@ -96,17 +95,6 @@ class Ungrib(DriverCycleBased):
         yield file(path=infile)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.symlink_to(Path(self.config["vtable"]))
-
-    @task
-    def _run_via_local_execution(self):
-        """
-        A run executed directly on the local system.
-        """
-        yield self.taskname("run via local execution")
-        yield [Asset(path, path.is_file) for path in self.output["paths"]]
-        yield self.provisioned_rundir()
-        cmd = "{x} >{x}.out 2>&1".format(x=self._runscript_path)
-        run_shell_cmd(cmd=cmd, cwd=self.rundir, log_output=True)
 
     # Public helper methods
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -524,7 +524,7 @@ def test_Driver__run_via_local_execution(driverobj, node):
     ):
         driverobj._run_via_local_execution()
         run_shell_cmd.assert_called_once_with(
-            cmd="./{x} >{x}.out 2>&1".format(x=driverobj._runscript_path.name),
+            cmd="./{x} >>{x}.out 2>&1".format(x=driverobj._runscript_path.name),
             cwd=driverobj.rundir,
             log_output=True,
         )

--- a/src/uwtools/tests/drivers/test_ungrib.py
+++ b/src/uwtools/tests/drivers/test_ungrib.py
@@ -139,27 +139,6 @@ def test_Ungrib__gribfile(driverobj):
     assert dst.is_symlink()
 
 
-def test_Ungrib__run_via_local_execution(driverobj, node):
-    def make_output(*_args, **_kwargs):
-        for path in driverobj.output["paths"]:
-            path.touch()
-
-    with (
-        patch.object(driverobj, "provisioned_rundir", return_value=node) as provisioned_rundir,
-        patch.object(ungrib, "run_shell_cmd", side_effect=make_output) as run_shell_cmd,
-    ):
-        val = driverobj._run_via_local_execution()
-        assert val.ready
-        for path in val.ref:
-            assert path.exists()
-        run_shell_cmd.assert_called_once_with(
-            cmd="{x} >{x}.out 2>&1".format(x=driverobj._runscript_path),
-            cwd=driverobj.rundir,
-            log_output=True,
-        )
-        provisioned_rundir.assert_called_once_with()
-
-
 @mark.parametrize("val", ["06:00:00", "06:00", "06", "6", 6, timedelta(hours=6)])
 def test_Ungrib__step(driverobj, val):
     driverobj._config["step"] = val


### PR DESCRIPTION
**Synopsis**

Update driver logic to append to `runscript.<driver>.out` file instead of overwriting it, preserving the output from multiple invocations of the driver, should those occur. As an example:

Before:

```
$ rm -rf /tmp/ungrib/
$ uw ungrib run -c config.yaml --cycle 2026-02-19T00
...
[2026-08-27T19:29:04]     INFO Running: ./runscript.ungrib >runscript.ungrib.out 2>&1
[2026-08-27T19:29:04]     INFO   in directory
[2026-08-27T19:29:04]     INFO     /tmp/ungrib
[2026-08-27T19:29:12]     INFO 20260219 00Z ungrib run via local execution: Ready
[2026-08-27T19:29:12]     INFO 20260219 00Z ungrib run: Ready
$ cat /tmp/ungrib/runscript.ungrib.out | wc -l
85
$ rm /tmp/ungrib/runscript.ungrib.done 
$ uw ungrib run -c config.yaml --cycle 2026-02-19T00
...
[2026-08-27T19:29:57]     INFO Running: ./runscript.ungrib >runscript.ungrib.out 2>&1
[2026-08-27T19:29:57]     INFO   in directory
[2026-08-27T19:29:57]     INFO     /tmp/ungrib
[2026-08-27T19:30:03]     INFO 20260219 00Z ungrib run via local execution: Ready
[2026-08-27T19:30:03]     INFO 20260219 00Z ungrib run: Ready
$ cat /tmp/ungrib/runscript.ungrib.out | wc -l
85
```
Note that `runscript.ungrib.out` was overwritten by the second driver invocation.

After:

```
$ rm -rf /tmp/ungrib/
$ uw ungrib run -c config.yaml --cycle 2026-02-19T00
...
[2026-08-27T19:31:17]     INFO Running: ./runscript.ungrib >>runscript.ungrib.out 2>&1
[2026-08-27T19:31:17]     INFO   in directory
[2026-08-27T19:31:17]     INFO     /tmp/ungrib
[2026-08-27T19:31:23]     INFO 20260219 00Z ungrib run via local execution: Ready
[2026-08-27T19:31:23]     INFO 20260219 00Z ungrib run: Ready
$ cat /tmp/ungrib/runscript.ungrib.out | wc -l
85
$ rm /tmp/ungrib/runscript.ungrib.done
$ uw ungrib run -c config.yaml --cycle 2026-02-19T00
...
[2026-08-27T19:36:29]     INFO Running: ./runscript.ungrib >>runscript.ungrib.out 2>&1
[2026-08-27T19:36:29]     INFO   in directory
[2026-08-27T19:36:29]     INFO     /tmp/ungrib
[2026-08-27T19:36:35]     INFO 20260219 00Z ungrib run via local execution: Ready
[2026-08-27T19:36:35]     INFO 20260219 00Z ungrib run: Ready
$ cat /tmp/ungrib/runscript.ungrib.out | wc -l
170
```
Here `runscript.ungrib.out` was appended to by the second driver invocation.

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
