### PR TITLE
Publish `uwtools` releases to PyPI

### DIFF
--- a/.github/scripts/install-conda.sh
+++ b/.github/scripts/install-conda.sh
@@ -6,4 +6,4 @@ wget --no-verbose -O $installer $url
 bash $installer -bfp $CI_CONDA_DIR
 set +ux
 ci_conda_activate
-conda install --quiet --yes --channel maddenp --repodata-fn repodata.json anaconda-client condev jq
+conda install --quiet --yes --channel maddenp --repodata-fn repodata.json anaconda-client condev jq python-build

--- a/.github/scripts/pypi-package-build.sh
+++ b/.github/scripts/pypi-package-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+. $(dirname ${BASH_SOURCE[0]})/common.sh
+ci_conda_activate
+unset CONDEV_SHELL
+set -ux
+python -m build --no-isolation --wheel src

--- a/.github/scripts/pypi-package-build.sh
+++ b/.github/scripts/pypi-package-build.sh
@@ -3,5 +3,6 @@
 . $(dirname ${BASH_SOURCE[0]})/common.sh
 ci_conda_activate
 unset CONDEV_SHELL
+export PYPI_PROJECT_NAME=unified-workflow-tools
 set -ux
 python -m build --no-isolation --wheel src

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,12 +19,12 @@ jobs:
         run: .github/scripts/make-docs.sh
       - name: Format Check
         run: .github/scripts/format-check.sh
-      - name: Make PyPI Package
-        run: .github/scripts/pypi-package-build.sh
       - name: Make Package
         run: .github/scripts/make-package.sh
       - name: Publish
         run: .github/scripts/publish.sh
+      - name: Make PyPI Package
+        run: .github/scripts/pypi-package-build.sh
       - name: Publish PyPI Package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,13 @@ jobs:
         run: .github/scripts/make-docs.sh
       - name: Format Check
         run: .github/scripts/format-check.sh
+      - name: Make PyPI Package
+        run: .github/scripts/pypi-package-build.sh
       - name: Make Package
         run: .github/scripts/make-package.sh
       - name: Publish
         run: .github/scripts/publish.sh
+      - name: Publish PyPI Package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/dist/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Install conda

--- a/src/setup.py
+++ b/src/setup.py
@@ -24,6 +24,7 @@ recipe = Path(os.environ.get("RECIPE_DIR", "../recipe"))
 metasrc = recipe / "meta.json"
 meta = json.loads(metasrc.read_text())
 name_conda = meta["name"]
+name_dist = os.environ.get("PYPI_PROJECT_NAME", name_conda)
 name_py = name_conda.replace("-", "_")
 
 # Define basic setup configuration.
@@ -31,7 +32,7 @@ name_py = name_conda.replace("-", "_")
 kwargs = {
     "entry_points": {"console_scripts": ["uw = %s.cli:main" % name_py]},
     "include_package_data": True,
-    "name": name_conda,
+    "name": name_dist,
     "packages": find_packages(exclude=["%s.tests" % name_py], include=[name_py, "%s.*" % name_py]),
     "version": meta["version"],
 }


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**
- build a PyPI wheel as part of the release workflow 
- publish release wheels to PyPI using Trusted Publishing 
- add CI build tooling to create wheel 

Testing: I did a test on my fork ([see PR here](https://github.com/elcarpenterNOAA/workflow-tools/pull/5)) and successfully published a package to TesPyPI, which you can [try out here.](https://test.pypi.org/manage/project/uwtools/release/2.20.0/) I installed it locally, and confirmed it was working and that `ecflow` was excluded from `uw --help`.

Documentation still needs to be written, but I don't feel I'm in a position to write it until it actually exists on PyPI.

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
