### PR TITLE
Use atomic context handler for fs-mode copy operations

### DIFF
--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -45,16 +45,16 @@ def test__stdinproxy():
         assert file._stdinproxy().read() == msg1  # <-- the NEW message
 
 
-def test_atomic(tmp_path):
+def test_atomic(tmp_path, uwcaplog):
     path = tmp_path / "foo"
-    with file.atomic(path) as f:
-        assert f == path.with_suffix(".tmp")
-        assert not f.is_file()
-        f.touch()
-        assert f.is_file()
+    with file.atomic(path) as tmp:
+        assert str(tmp).startswith(str(path))
+        assert not tmp.is_file()
+        tmp.touch()
         assert not path.is_file()
-    assert not f.is_file()
+    assert not tmp.is_file()
     assert path.is_file()
+    assert "Atomically renaming %s -> %s" % (tmp, path) in uwcaplog.text
 
 
 @mark.parametrize(

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -123,13 +123,20 @@ def test_utils_tasks_filecopy__source_http(code, expected, src, tmp_path):
     [("/src/file", True), ("file:///src/file", True), ("foo://bucket/a/b", False)],
 )
 def test_utils_tasks_filecopy__source_local(src, ok):
-    dst = "/dst/file"
+    dst = Path("/dst/file")
+    tmp = Path("/dst/file.tmp")
     with patch.object(tasks.Path, "mkdir") as mkdir:
         if ok:
-            with patch.object(tasks, "file", exists), patch.object(tasks, "copy") as copy:
+            with (
+                patch.object(tasks, "atomic") as atomic,
+                patch.object(tasks, "copy") as copy,
+                patch.object(tasks, "file", exists),
+            ):
+                atomic.return_value.__enter__.return_value = tmp
                 tasks.filecopy(src=src, dst=dst)
+            atomic.assert_called_once_with(dst)
             mkdir.assert_called_once_with(parents=True, exist_ok=True)
-            copy.assert_called_once_with(Path("/src/file"), Path(dst))
+            copy.assert_called_once_with(Path("/src/file"), Path(tmp))
         else:
             with raises(UWConfigError) as e:
                 tasks.filecopy(src=src, dst=dst)
@@ -196,15 +203,19 @@ def test_utils_tasks_filecopy__simple(tmp_path):
 def test_utils_tasks_filecopy_hsi(logged, ready_task, tmp_path):
     src = "/path/to/src"
     dst = tmp_path / "dst"
+    tmp = tmp_path / "tmp"
     with (
-        patch.object(tasks, "run_shell_cmd") as run_shell_cmd,
+        patch.object(tasks, "atomic") as atomic,
         patch.object(tasks, "existing_hpss", wraps=ready_task) as existing_hpss,
+        patch.object(tasks, "run_shell_cmd") as run_shell_cmd,
     ):
+        atomic.return_value.__enter__.return_value = tmp
         run_shell_cmd.side_effect = lambda *_a, **_kw: (dst.touch(), (True, "msg1\nmsg2\n"))[1]
         tasks.filecopy_hsi(src=src, dst=Path(dst))
     existing_hpss.assert_called_once_with(src)
+    atomic.assert_called_once_with(dst)
     taskname = f"HSI {src} -> {dst}"
-    run_shell_cmd.assert_called_once_with(f"hsi -q get '{dst}' : '{src}'", taskname=taskname)
+    run_shell_cmd.assert_called_once_with(f"hsi -q get '{tmp}' : '{src}'", taskname=taskname)
     assert logged(f"{taskname}: => msg1")
     assert logged(f"{taskname}: => msg2")
     assert dst.exists()

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -10,6 +10,7 @@ from functools import cache
 from importlib import resources
 from io import StringIO
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import IO, TYPE_CHECKING, Any
 
 from uwtools.logging import log
@@ -55,8 +56,10 @@ def atomic(path: Path) -> Iterator[Path]:
     :yieldtype: Path.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = Path("%s.tmp" % path)
+    with NamedTemporaryFile(dir=path.parent, prefix="%s." % path.name) as ntf:
+        tmp = Path(ntf.name)
     yield tmp
+    log.debug("Atomically renaming %s -> %s", str(tmp), str(path))
     tmp.rename(path)
 
 

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -19,6 +19,7 @@ from iotaa import Asset, Node, external, task
 from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import log
 from uwtools.strings import STR
+from uwtools.utils.file import atomic
 from uwtools.utils.processing import run_shell_cmd
 
 SCHEMES = ns(
@@ -138,8 +139,9 @@ def filecopy_hsi(src: str, dst: Path, check: bool = True):
     yield Asset(Path(dst), Path(dst).is_file)
     yield existing_hpss(src) if check else None
     dst.parent.mkdir(parents=True, exist_ok=True)
-    cmd = f"{STR.hsi} -q get '{dst}' : '{src}'"
-    _, output = run_shell_cmd(cmd, taskname=taskname)
+    with atomic(dst) as tmp:
+        cmd = f"{STR.hsi} -q get '{tmp}' : '{src}'"
+        _, output = run_shell_cmd(cmd, taskname=taskname)
     for line in output.strip().split("\n"):
         log.info("%s: => %s", taskname, line)
 
@@ -184,7 +186,7 @@ def filecopy_http(url: str, dst: Path, check: bool = True):
     dst.parent.mkdir(parents=True, exist_ok=True)
     response = requests.get(url, allow_redirects=True, stream=True, timeout=3)
     if (code := response.status_code) == HTTPStatus.OK:
-        with dst.open(mode="wb") as f:
+        with atomic(dst) as tmp, tmp.open(mode="wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
     else:
@@ -204,7 +206,8 @@ def filecopy_local(src: Path, dst: Path, check: bool = True):
     yield Asset(Path(dst), Path(dst).is_file)
     yield file(src) if check else None
     dst.parent.mkdir(parents=True, exist_ok=True)
-    copy(src, dst)
+    with atomic(dst) as tmp:
+        copy(src, tmp)
 
 
 @task
@@ -233,7 +236,8 @@ def hardlink(
             Path(dst).symlink_to(src)
             log.info("Could not hardlink %s -> %s, symlinked instead" % (dst, src))
         elif fallback == STR.copy:
-            copy(src, dst)
+            with atomic(dst) as tmp:
+                copy(src, tmp)
             log.info("Could not hardlink %s -> %s, copied instead" % (dst, src))
         else:
             for line in str(e).split("\n"):


### PR DESCRIPTION
**Synopsis**

In tasks called by `fs`-mode copy operations, use the `atomic` context manager to initially write to temporary files, then atomically rename to final filenames. This helps avoid issues with batch-job timeouts, among other scenarios, that might leave partially-written files in place in a way that could cause corruption.

Also, update `atomic` to return a unique temporary filename. The previous version simply appended `.tmp` to the final filename, but this ignored the possibility that a file with that name might already exist, for whatever reason, which might clobber a wanted file or, in some use cases, incorrectly append to a previously partially written file.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
