### PR TITLE
Atomic improvements and null driver executable

### DIFF
--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -376,10 +376,7 @@ class Driver(Assets):
         if self.config[STR.execution][STR.executable] is None:
             msg = "Drivers not specifying 'executable' must override the run() method"
             raise UWNotImplementedError(msg)
-        if self._batch:
-            yield self._run_via_batch_submission()
-        else:
-            yield self._run_via_local_execution()
+        yield self._run_via_batch_submission() if self._batch else self._run_via_local_execution()
 
     @task
     def runscript(self):

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -379,7 +379,8 @@ class Driver(Assets):
             else:
                 yield self._run_via_local_execution()
         else:
-            yield None
+            msg = "Drivers not specifying 'executable' must override the run() method"
+            raise UWNotImplementedError(msg)
 
     @task
     def runscript(self):

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -376,8 +376,8 @@ class Driver(Assets):
         taskname = self.taskname(STR.run)
         yield taskname
         if self.config[STR.execution][STR.executable] is None:
-            msg = "%s: Drivers with no 'executable' must implement a custom run() method" % taskname
-            yield blocker(msg)
+            msg = "%s must define 'executable' or implement custom run() method"
+            yield blocker(msg % self.__class__.__name__)
         yield self._run_via_batch_submission() if self._batch else self._run_via_local_execution()
 
     @task

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -373,7 +373,13 @@ class Driver(Assets):
         A run.
         """
         yield self.taskname(STR.run)
-        yield self._run_via_batch_submission() if self._batch else self._run_via_local_execution()
+        if self.config.get(STR.execution, {}).get(STR.executable):
+            if self._batch:
+                yield self._run_via_batch_submission()
+            else:
+                yield self._run_via_local_execution()
+        else:
+            yield None
 
     @task
     def runscript(self):

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -31,7 +31,7 @@ from uwtools.scheduler import JobScheduler
 from uwtools.strings import STR
 from uwtools.utils.file import writable
 from uwtools.utils.processing import run_shell_cmd
-from uwtools.utils.tasks import blocker
+from uwtools.utils.tasks import poison
 
 if TYPE_CHECKING:
     from datetime import datetime, timedelta
@@ -376,7 +376,7 @@ class Driver(Assets):
         yield self.taskname(STR.run)
         if self.config[STR.execution][STR.executable] is None:
             msg = "%s must define 'executable' or implement custom run() method"
-            yield blocker(msg % self.__class__.__name__)
+            yield poison(msg % self.__class__.__name__)
         yield self._run_via_batch_submission() if self._batch else self._run_via_local_execution()
 
     @task

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -373,14 +373,13 @@ class Driver(Assets):
         A run.
         """
         yield self.taskname(STR.run)
-        if self.config.get(STR.execution, {}).get(STR.executable):
-            if self._batch:
-                yield self._run_via_batch_submission()
-            else:
-                yield self._run_via_local_execution()
-        else:
+        if self.config[STR.execution][STR.executable] is None:
             msg = "Drivers not specifying 'executable' must override the run() method"
             raise UWNotImplementedError(msg)
+        if self._batch:
+            yield self._run_via_batch_submission()
+        else:
+            yield self._run_via_local_execution()
 
     @task
     def runscript(self):

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -374,7 +374,7 @@ class Driver(Assets):
         A run.
         """
         yield self.taskname(STR.run)
-        if self.config[STR.execution][STR.executable] is None:
+        if self.config[STR.execution][STR.executable] is None:  # e.g. from a YAML null
             msg = "%s must define 'executable' or implement custom run() method"
             yield poison(msg % self.__class__.__name__)
         yield self._run_via_batch_submission() if self._batch else self._run_via_local_execution()

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -373,8 +373,7 @@ class Driver(Assets):
         """
         A run.
         """
-        taskname = self.taskname(STR.run)
-        yield taskname
+        yield self.taskname(STR.run)
         if self.config[STR.execution][STR.executable] is None:
             msg = "%s must define 'executable' or implement custom run() method"
             yield blocker(msg % self.__class__.__name__)

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -31,6 +31,7 @@ from uwtools.scheduler import JobScheduler
 from uwtools.strings import STR
 from uwtools.utils.file import writable
 from uwtools.utils.processing import run_shell_cmd
+from uwtools.utils.tasks import blocker
 
 if TYPE_CHECKING:
     from datetime import datetime, timedelta
@@ -372,10 +373,11 @@ class Driver(Assets):
         """
         A run.
         """
-        yield self.taskname(STR.run)
+        taskname = self.taskname(STR.run)
+        yield taskname
         if self.config[STR.execution][STR.executable] is None:
-            msg = "Drivers not specifying 'executable' must override the run() method"
-            raise UWNotImplementedError(msg)
+            msg = "%s: Drivers with no 'executable' must implement a custom run() method" % taskname
+            yield blocker(msg)
         yield self._run_via_batch_submission() if self._batch else self._run_via_local_execution()
 
     @task

--- a/src/uwtools/resources/jsonschema/execution-parallel.jsonschema
+++ b/src/uwtools/resources/jsonschema/execution-parallel.jsonschema
@@ -11,7 +11,10 @@
       "type": "array"
     },
     "executable": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "incantation": {
       "type": "string"

--- a/src/uwtools/resources/jsonschema/execution-serial.jsonschema
+++ b/src/uwtools/resources/jsonschema/execution-serial.jsonschema
@@ -11,7 +11,10 @@
       "type": "array"
     },
     "executable": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "incantation": {
       "type": "string"

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -443,11 +443,12 @@ def test_Driver_output_not_implemented(cls, config, utc):
 @mark.parametrize("batch", [True, False])
 def test_Driver_run(batch, driverobj, node):
     driverobj._batch = batch
+    executable = Path(driverobj.config["execution"]["executable"])
+    executable.touch()
     with (
         patch.object(driverobj, "_run_via_batch_submission", return_value=node) as rvbs,
         patch.object(driverobj, "_run_via_local_execution", return_value=node) as rvle,
     ):
-        Path(driverobj._config["execution"]["executable"]).touch()
         driverobj.run()
         if batch:
             rvbs.assert_called_once_with()

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -441,19 +441,29 @@ def test_Driver_output_not_implemented(cls, config, utc):
 
 
 @mark.parametrize("batch", [True, False])
-def test_Driver_run(batch, driverobj, node):
+@mark.parametrize("executable", [True, False])
+def test_Driver_run(batch, driverobj, executable, node):
     driverobj._batch = batch
-    executable = Path(driverobj.config["execution"]["executable"])
-    executable.touch()
-    with patch.object(driverobj, "_run_via_batch_submission", return_value=node) as rvbs:
-        with patch.object(driverobj, "_run_via_local_execution", return_value=node) as rvle:
-            driverobj.run()
+    execution = driverobj._config["execution"]
+    if executable:
+        Path(execution["executable"]).touch()
+    else:
+        execution["executable"] = None
+    with (
+        patch.object(driverobj, "_run_via_batch_submission", return_value=node) as rvbs,
+        patch.object(driverobj, "_run_via_local_execution", return_value=node) as rvle,
+    ):
+        driverobj.run()
+    if executable:
         if batch:
             rvbs.assert_called_once_with()
             rvle.assert_not_called()
         else:
             rvbs.assert_not_called()
             rvle.assert_called_once_with()
+    else:
+        rvbs.assert_not_called()
+        rvle.assert_not_called()
 
 
 @mark.parametrize(

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -441,27 +441,31 @@ def test_Driver_output_not_implemented(cls, config, utc):
 
 
 @mark.parametrize("batch", [True, False])
-@mark.parametrize("executable", [True, False])
-def test_Driver_run(batch, driverobj, executable, node):
+def test_Driver_run(batch, driverobj, node):
     driverobj._batch = batch
-    execution = driverobj._config["execution"]
-    if executable:
-        Path(execution["executable"]).touch()
-    else:
-        execution["executable"] = None
     with (
         patch.object(driverobj, "_run_via_batch_submission", return_value=node) as rvbs,
         patch.object(driverobj, "_run_via_local_execution", return_value=node) as rvle,
     ):
+        Path(driverobj._config["execution"]["executable"]).touch()
         driverobj.run()
-    if executable:
         if batch:
             rvbs.assert_called_once_with()
             rvle.assert_not_called()
         else:
             rvbs.assert_not_called()
             rvle.assert_called_once_with()
-    else:
+
+
+def test_Driver_run__no_executable(driverobj, node):
+    driverobj._config["execution"]["executable"] = None
+    with (
+        patch.object(driverobj, "_run_via_batch_submission", return_value=node) as rvbs,
+        patch.object(driverobj, "_run_via_local_execution", return_value=node) as rvle,
+    ):
+        with raises(UWNotImplementedError) as e:
+            driverobj.run()
+        assert str(e.value) == "Drivers not specifying 'executable' must override the run() method"
         rvbs.assert_not_called()
         rvle.assert_not_called()
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -458,15 +458,17 @@ def test_Driver_run(batch, driverobj, node):
             rvle.assert_called_once_with()
 
 
-def test_Driver_run__no_executable(driverobj, node):
+def test_Driver_run__no_executable(driverobj, node, uwcaplog):
     driverobj._config["execution"]["executable"] = None
+    # Replace driverobj's run() with Driver's, as if it was never overriden:
+    driverobj.run = driver.Driver.run.__get__(driverobj)
     with (
         patch.object(driverobj, "_run_via_batch_submission", return_value=node) as rvbs,
         patch.object(driverobj, "_run_via_local_execution", return_value=node) as rvle,
     ):
-        with raises(UWNotImplementedError) as e:
-            driverobj.run()
-        assert str(e.value) == "Drivers not specifying 'executable' must override the run() method"
+        node = driverobj.run()
+        assert not node.ready
+        assert "Drivers with no 'executable' must implement a custom run() method" in uwcaplog.text
         rvbs.assert_not_called()
         rvle.assert_not_called()
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -459,16 +459,16 @@ def test_Driver_run(batch, driverobj, node):
 
 
 def test_Driver_run__no_executable(driverobj, node, uwcaplog):
-    driverobj._config["execution"]["executable"] = None
     # Replace driverobj's run() with Driver's, as if it was never overriden:
     driverobj.run = driver.Driver.run.__get__(driverobj)
+    driverobj._config["execution"]["executable"] = None
     with (
         patch.object(driverobj, "_run_via_batch_submission", return_value=node) as rvbs,
         patch.object(driverobj, "_run_via_local_execution", return_value=node) as rvle,
     ):
         node = driverobj.run()
         assert not node.ready
-        assert "Drivers with no 'executable' must implement a custom run() method" in uwcaplog.text
+        assert "must define 'executable' or implement custom run() method" in uwcaplog.text
         rvbs.assert_not_called()
         rvle.assert_not_called()
 

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1318,6 +1318,8 @@ def test_schema_execution_parallel():
     errors = schema_validator("execution-parallel")
     # Basic correctness:
     assert not errors(config)
+    # execution is required:
+    assert "'executable' is a required property" in errors({})
     # batchargs may optionally be specified:
     assert not errors({**config, **batchargs})
     # mpiargs may be optionally specified:
@@ -1370,6 +1372,8 @@ def test_schema_execution_serial():
     errors = schema_validator("execution-serial")
     # Basic correctness:
     assert not errors(config)
+    # execution is required:
+    assert "'executable' is a required property" in errors({})
     # batchargs may optionally be specified:
     assert not errors({**config, **batchargs})
     # All properties are ok:

--- a/src/uwtools/tests/test_schemas.py
+++ b/src/uwtools/tests/test_schemas.py
@@ -1310,7 +1310,7 @@ def test_schema_esg_grid_rundir(esg_grid_prop):
 # execution-parallel
 
 
-def test_schema_parallel_execution():
+def test_schema_execution_parallel():
     config = {"executable": "fv3"}
     batchargs = {"batchargs": {"queue": "string", "walltime": "string"}}
     mpiargs = {"mpiargs": ["--flag1", "--flag2"]}
@@ -1332,15 +1332,17 @@ def test_schema_parallel_execution():
     )
 
 
-def test_schema_parallel_execution_executable():
+def test_schema_execution_parallel__executable():
     errors = schema_validator("execution-parallel", "properties", "executable")
     # String value is ok:
     assert not errors("fv3.exe")
+    # Null value is ok:
+    assert not errors(None)
     # Anything else is not:
-    assert "42 is not of type 'string'\n" in errors(42)
+    assert "42 is not of type 'null', 'string'\n" in errors(42)
 
 
-def test_schema_parallel_execution_mpiargs():
+def test_schema_execution_parallel__mpiargs():
     errors = schema_validator("execution-parallel", "properties", "mpiargs")
     # Basic correctness:
     assert not errors(["string1", "string2"])
@@ -1350,7 +1352,7 @@ def test_schema_parallel_execution_mpiargs():
     assert "42 is not of type 'string'\n" in errors(["string1", 42])
 
 
-def test_schema_parallel_execution_threads():
+def test_schema_execution_parallel__threads():
     errors = schema_validator("execution-parallel", "properties", "threads")
     # threads must be non-negative, and an integer:
     assert not errors(1)
@@ -1374,6 +1376,16 @@ def test_schema_execution_serial():
     assert not errors({**config, **batchargs})
     # Additional properties are not allowed:
     assert "Additional properties are not allowed" in errors({**config, "foo": "bar"})
+
+
+def test_schema_execution_serial__executable():
+    errors = schema_validator("execution-serial", "properties", "executable")
+    # String value is ok:
+    assert not errors("fv3.exe")
+    # Null value is ok:
+    assert not errors(None)
+    # Anything else is not:
+    assert "42 is not of type 'null', 'string'\n" in errors(42)
 
 
 # files-to-stage

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -66,7 +66,7 @@ def test_atomic__fail(tmp_path, uwcaplog):
         assert not path.is_file()
     assert not tmp.is_file()
     assert not path.is_file()
-    assert "Atomically renaming %s -> %s" % (tmp, path) not in uwcaplog.text
+    assert "Skipping atomic rename: %s not found" % tmp in uwcaplog.text
 
 
 @mark.parametrize(

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -57,6 +57,18 @@ def test_atomic(tmp_path, uwcaplog):
     assert "Atomically renaming %s -> %s" % (tmp, path) in uwcaplog.text
 
 
+def test_atomic__fail(tmp_path, uwcaplog):
+    path = tmp_path / "foo"
+    with file.atomic(path) as tmp:
+        assert str(tmp).startswith(str(path))
+        assert not tmp.is_file()
+        # Avoid creating file.
+        assert not path.is_file()
+    assert not tmp.is_file()
+    assert not path.is_file()
+    assert "Atomically renaming %s -> %s" % (tmp, path) not in uwcaplog.text
+
+
 @mark.parametrize(
     ("ext", "file_type"),
     {

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -200,7 +200,8 @@ def test_utils_tasks_filecopy__simple(tmp_path):
     assert dst.is_file()
 
 
-def test_utils_tasks_filecopy_hsi(logged, ready_task, tmp_path):
+@mark.parametrize("success", [True, False])
+def test_utils_tasks_filecopy_hsi(logged, ready_task, success, tmp_path):
     src = "/path/to/src"
     dst = tmp_path / "dst"
     tmp = tmp_path / "tmp"
@@ -210,7 +211,8 @@ def test_utils_tasks_filecopy_hsi(logged, ready_task, tmp_path):
         patch.object(tasks, "run_shell_cmd") as run_shell_cmd,
     ):
         atomic.return_value.__enter__.return_value = tmp
-        run_shell_cmd.side_effect = lambda *_a, **_kw: (dst.touch(), (True, "msg1\nmsg2\n"))[1]
+        action = lambda: dst.touch() if success else dst.exists()
+        run_shell_cmd.side_effect = lambda *_a, **_k: (action(), (success, "msg1\nmsg2\n"))[1]
         tasks.filecopy_hsi(src=src, dst=Path(dst))
     existing_hpss.assert_called_once_with(src)
     atomic.assert_called_once_with(dst)
@@ -218,7 +220,10 @@ def test_utils_tasks_filecopy_hsi(logged, ready_task, tmp_path):
     run_shell_cmd.assert_called_once_with(f"hsi -q get '{tmp}' : '{src}'", taskname=taskname)
     assert logged(f"{taskname}: => msg1")
     assert logged(f"{taskname}: => msg2")
-    assert dst.exists()
+    if success:
+        assert dst.exists()
+    else:
+        assert not dst.exists()
 
 
 def test_utils_tasks_filecopy_htar(logged, ready_task, tmp_path):

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -23,6 +23,12 @@ def exists(x):
 # Tests
 
 
+def test_utils_tasks_blocker():
+    node = tasks.blocker(taskname="Unfulfilled requirement")
+    assert not node.ready
+    assert node.ref is None
+
+
 def test_utils_tasks_directory(tmp_path):
     p = tmp_path / "foo" / "bar"
     assert not p.is_dir()

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -23,12 +23,6 @@ def exists(x):
 # Tests
 
 
-def test_utils_tasks_blocker():
-    node = tasks.blocker(taskname="Unfulfilled requirement")
-    assert not node.ready
-    assert node.ref is None
-
-
 def test_utils_tasks_directory(tmp_path):
     p = tmp_path / "foo" / "bar"
     assert not p.is_dir()
@@ -329,6 +323,12 @@ def test_utils_tasks_link_target(tmp_path, wrapper):
     for x in [d, f, s]:
         assert tasks.link_target(path=wrapper(x)).ready
     assert not tasks.link_target(path=tmp_path / "foo").ready
+
+
+def test_utils_tasks_poison():
+    node = tasks.poison(taskname="Unfulfilled requirement")
+    assert not node.ready
+    assert node.ref is None
 
 
 def test_utils_tasks__local__path_fail():

--- a/src/uwtools/tests/utils/test_tasks.py
+++ b/src/uwtools/tests/utils/test_tasks.py
@@ -331,6 +331,12 @@ def test_utils_tasks_poison():
     assert node.ref is None
 
 
+def test_utils_tasks__bad_scheme():
+    with raises(UWConfigError) as e:
+        tasks._bad_scheme(path="foo://x/y/z", scheme="foo")
+    assert str(e.value) == "Scheme 'foo' in 'foo://x/y/z' not supported"
+
+
 def test_utils_tasks__local__path_fail():
     path = "foo://bucket/a/b"
     with patch.object(tasks, "_bad_scheme") as _bad_scheme:

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -56,7 +56,8 @@ def atomic(path: Path) -> Iterator[Path]:
     :yieldtype: Path.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    with NamedTemporaryFile(dir=path.parent, prefix="%s." % path.name) as ntf:
+    with NamedTemporaryFile(dir=path.parent, prefix="%s.tmp." % path.name) as ntf:
+        ntf.close()  # also deletes: some callers may balk at an existing file
         tmp = Path(ntf.name)
     yield tmp
     if tmp.is_file():

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -59,8 +59,9 @@ def atomic(path: Path) -> Iterator[Path]:
     with NamedTemporaryFile(dir=path.parent, prefix="%s." % path.name) as ntf:
         tmp = Path(ntf.name)
     yield tmp
-    log.debug("Atomically renaming %s -> %s", str(tmp), str(path))
-    tmp.rename(path)
+    if tmp.is_file():
+        log.debug("Atomically renaming %s -> %s", str(tmp), str(path))
+        tmp.rename(path)
 
 
 def get_config_format(path: str | Path | None, desc: str | None = None) -> str:

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -61,8 +61,10 @@ def atomic(path: Path) -> Iterator[Path]:
         tmp = Path(ntf.name)
     yield tmp
     if tmp.is_file():
-        log.debug("Atomically renaming %s -> %s", str(tmp), str(path))
+        log.debug("Atomically renaming %s -> %s", tmp, path)
         tmp.rename(path)
+    else:
+        log.debug("Skipping atomic rename: %s not found", tmp)
 
 
 def get_config_format(path: str | Path | None, desc: str | None = None) -> str:

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -141,7 +141,10 @@ def filecopy_hsi(src: str, dst: Path, check: bool = True):
     dst.parent.mkdir(parents=True, exist_ok=True)
     with atomic(dst) as tmp:
         cmd = f"{STR.hsi} -q get '{tmp}' : '{src}'"
-        _, output = run_shell_cmd(cmd, taskname=taskname)
+        success, output = run_shell_cmd(cmd, taskname=taskname)
+        if not success:
+            log.error("Failed to copy %s via HSI", src)
+            tmp.unlink(missing_ok=True)
     for line in output.strip().split("\n"):
         log.info("%s: => %s", taskname, line)
 

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -30,12 +30,6 @@ SCHEMES = ns(
 )
 
 
-@external
-def blocker(taskname: str):
-    yield taskname
-    yield Asset(None, lambda: False)
-
-
 @task
 def directory(path: Path):
     """
@@ -254,6 +248,25 @@ def hardlink(
             raise UWError("Could not hardlink %s -> %s" % (dst, src)) from e
 
 
+@external
+def link_target(path: Path | str):
+    """
+    An existing file, link, or directory.
+
+    :param path: Path to the file, link, or directory.
+    :param context: Optional additional context for the file.
+    """
+    path = _local_path(path)
+    yield "Target %s" % path
+    yield Asset(path, path.exists)
+
+
+@external
+def poison(taskname: str):
+    yield taskname
+    yield Asset(None, lambda: False)
+
+
 @task
 def symlink(target: Path | str, linkname: Path | str, check: bool = True):
     """
@@ -271,19 +284,6 @@ def symlink(target: Path | str, linkname: Path | str, check: bool = True):
     src = target if target.is_absolute() else os.path.relpath(target, linkname.parent)
     dst = linkname
     Path(dst).symlink_to(src)
-
-
-@external
-def link_target(path: Path | str):
-    """
-    An existing file, link, or directory.
-
-    :param path: Path to the file, link, or directory.
-    :param context: Optional additional context for the file.
-    """
-    path = _local_path(path)
-    yield "Target %s" % path
-    yield Asset(path, path.exists)
 
 
 # Private helpers

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -30,6 +30,12 @@ SCHEMES = ns(
 )
 
 
+@external
+def blocker(taskname: str):
+    yield taskname
+    yield Asset(taskname, lambda: False)
+
+
 @task
 def directory(path: Path):
     """

--- a/src/uwtools/utils/tasks.py
+++ b/src/uwtools/utils/tasks.py
@@ -33,7 +33,7 @@ SCHEMES = ns(
 @external
 def blocker(taskname: str):
     yield taskname
-    yield Asset(taskname, lambda: False)
+    yield Asset(None, lambda: False)
 
 
 @task


### PR DESCRIPTION
**Synopsis**

1. Support `null` as a value for `executable` in driver configs, to support all-Python drivers.
2. Give the `atomic` context manager a way to avoid creating the final file at all.

In re: item 1, there are reasons for requiring a `null` value instead of just omitting the key:

- In the case of `<driver>.execution.executable`, `executable` is the only required key in the `execution:` block, so making it optional would make the whole `execution:` block potentially also optional. We could consider that, but:
- Having a `null` value signals intent, while a missing `executable` key (or a missing `execution:` block) looks potentially like an omission.
- There are other places where a `null` value might be useful in the future to signal that certain behavior is unwanted. Currently, the `uwtools` mechanism for this is the `!remove` tag, but this must potentially be repeated many times in an override config if the same optional value (e.g. `account` under many task subblocks in a Rocoto block) should be suppressed. Compare to a case where one might set `user.account` to a real account name in a base config and have many `account: '{{ user.account }}'` references to it in Rocoto blocks. In this case, an override config would only need to override the single `user.account` value, setting it to `null`. Of course, supporting Python code would need to take appropriate action when seeing a `null` value in supported contexts -- as is done in this PR for `executable: null`. So allowing `executable: null` here is a proof-of-concept exercise (as well as potentially improving a real use case in `uw-aigfs`, but that's a separate PR).

**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
