### PR TITLE
Constrain schema references to package resources

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -89,6 +89,7 @@ ignore = [
 "uwtools/tests/*" = [
   "ANN001",  # missing-type-function-argument
   "N802",    # invalid-function-name
+  "N806",    # non-lowercase-variable-in-function
   "PT013",   # pytest-incorrect-pytest-import
   "SLF001",  # private-member-access
 ]

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -296,6 +296,7 @@ def _deref_render(val: str, context: dict, local: dict | None = None) -> str:
     :return: The rendered value (potentially unchanged).
     """
     if not any(marker in val for marker in ("{{", "{%", "{#")):
+        deref_debug("Rendered", val)
         return val
     env = _register_filters(Environment(undefined=StrictUndefined))
     template = env.from_string(val)

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -74,7 +74,7 @@ def internal_schema_file(schema_name: str) -> Path:
 
     :param schema_name: Name of uwtools schema to validate the config against.
     """
-    return resource_path("jsonschema") / f"{schema_name}.jsonschema"
+    return resource_path(f"jsonschema/{schema_name}.jsonschema")
 
 
 def validate(schema: dict, desc: str, config: JSONValueT) -> bool:

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -194,9 +194,7 @@ def _registry() -> Registry:
 
     # See https://github.com/python-jsonschema/referencing/issues/61 about typing issues.
 
-    def retrieve(uri: str) -> Resource:
-        return Resource(contents=_schema(uri), specification=DRAFT202012)  # type: ignore[call-arg]
-
+    retrieve = lambda uri: Resource(contents=_schema(uri), specification=DRAFT202012)  # type: ignore[call-arg]
     return Registry(retrieve=retrieve)  # type: ignore[call-arg]
 
 
@@ -206,7 +204,6 @@ def _resolver(schema: dict) -> RefResolver:
 
     :param schema: A schema potentially containing $ref keys.
     """
-
     return cast(RefResolver, RefResolver.from_schema(schema, handlers={"urn": _schema}))
 
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -212,7 +212,7 @@ def _resolver(schema: dict) -> RefResolver:
 
     def retrieve(uri: str) -> dict:
         name = uri.rsplit(":", maxsplit=1)[-1]
-        path = resource_path("jsonschema") / f"{name}.jsonschema"
+        path = resource_path(f"jsonschema/{name}.jsonschema")
         text = path.read_text()
         return cast(dict, json.loads(text))
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -195,10 +195,7 @@ def _registry() -> Registry:
     # See https://github.com/python-jsonschema/referencing/issues/61 about typing issues.
 
     def retrieve(uri: str) -> Resource:
-        name = uri.rsplit(":", maxsplit=1)[-1]
-        path = resource_path(f"jsonschema/{name}.jsonschema")
-        text = path.read_text()
-        return Resource(contents=json.loads(text), specification=DRAFT202012)  # type: ignore[call-arg]
+        return Resource(contents=_schema(uri), specification=DRAFT202012)  # type: ignore[call-arg]
 
     return Registry(retrieve=retrieve)  # type: ignore[call-arg]
 
@@ -211,12 +208,16 @@ def _resolver(schema: dict) -> RefResolver:
     """
 
     def retrieve(uri: str) -> dict:
-        name = uri.rsplit(":", maxsplit=1)[-1]
-        path = resource_path(f"jsonschema/{name}.jsonschema")
-        text = path.read_text()
-        return cast(dict, json.loads(text))
+        return _schema(uri)
 
     return cast(RefResolver, RefResolver.from_schema(schema, handlers={"urn": retrieve}))
+
+
+def _schema(uri: str) -> dict:
+    name = uri.rsplit(":", maxsplit=1)[-1]
+    path = resource_path(f"jsonschema/{name}.jsonschema")
+    text = path.read_text()
+    return cast(dict, json.loads(text))
 
 
 def _validation_errors(config: JSONValueT, schema: dict) -> list[ValidationError]:

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -197,8 +197,8 @@ def _registry() -> Registry:
     def retrieve(uri: str) -> Resource:
         name = uri.rsplit(":", maxsplit=1)[-1]
         path = resource_path(f"jsonschema/{name}.jsonschema")
-        text = json.loads(path.read_text())
-        return Resource(contents=text, specification=DRAFT202012)  # type: ignore[call-arg]
+        text = path.read_text()
+        return Resource(contents=json.loads(text), specification=DRAFT202012)  # type: ignore[call-arg]
 
     return Registry(retrieve=retrieve)  # type: ignore[call-arg]
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -207,10 +207,7 @@ def _resolver(schema: dict) -> RefResolver:
     :param schema: A schema potentially containing $ref keys.
     """
 
-    def retrieve(uri: str) -> dict:
-        return _schema(uri)
-
-    return cast(RefResolver, RefResolver.from_schema(schema, handlers={"urn": retrieve}))
+    return cast(RefResolver, RefResolver.from_schema(schema, handlers={"urn": _schema}))
 
 
 def _schema(uri: str) -> dict:

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -14,7 +14,7 @@ from jsonschema import Draft202012Validator, RefResolver, validators
 
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.support import UWYAMLGlob
-from uwtools.exceptions import UWConfigError
+from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import INDENT, log
 from uwtools.utils.file import resource_path
 
@@ -209,7 +209,10 @@ def _resolver(schema: dict) -> RefResolver:
 
 def _schema(uri: str) -> dict:
     name = uri.rsplit(":", maxsplit=1)[-1]
+    root = resource_path()
     path = resource_path(f"jsonschema/{name}.jsonschema")
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise UWError("Invalid schema URI: %s" % uri)
     text = path.read_text()
     return cast(dict, json.loads(text))
 

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -209,9 +209,9 @@ def _resolver(schema: dict) -> RefResolver:
 
 def _schema(uri: str) -> dict:
     name = uri.rsplit(":", maxsplit=1)[-1]
-    root = resource_path()
+    schemaroot = resource_path("jsonschema")
     path = resource_path(f"jsonschema/{name}.jsonschema")
-    if not path.resolve().is_relative_to(root.resolve()):
+    if not path.resolve().is_relative_to(schemaroot.resolve()):
         raise UWError("Invalid schema URI: %s" % uri)
     text = path.read_text()
     return cast(dict, json.loads(text))

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -317,24 +317,11 @@ def test_config_validator__registry(tmp_path):
     resource_path.assert_called_once_with("jsonschema/foo-bar.jsonschema")
 
 
-@mark.parametrize("caller", ["registry", "resolver"])
-def test_config_validator__registry__retrieve__no_exfil(caller):
-    # The retrieve() function is nested, so use a mocked call to retrieve it:
-    if caller == "registry":
-        validator._registry.cache_clear()
-        with patch.object(validator, "Registry") as Registry:
-            validator._registry()
-            retrieve = Registry.call_args.kwargs["retrieve"]
-        validator._registry.cache_clear()
-    else:  # caller is "resolver"
-        with patch.object(validator.RefResolver, "from_schema") as from_schema:
-            validator._resolver({})
-            retrieve = from_schema.call_args.kwargs["handlers"]["urn"]
-    # Now test that relative paths cannot be used to exfiltrate:
+def test_config_validator__schema__no_exfil():
     suffix = "../../exfiltrated.jsonschema"
     uri = f"urn:uwtools:{suffix}"
     with raises(UWError) as e:
-        retrieve(uri=uri)
+        validator._schema(uri=uri)
     expected = f"Resource reference 'jsonschema/{suffix}.jsonschema' is outside package resources"
     assert str(e.value) == expected
 

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -11,10 +11,11 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from pytest import fixture, mark, raises
+from referencing.exceptions import Unretrievable
 
 from uwtools.config import validator
 from uwtools.config.formats.yaml import YAMLConfig
-from uwtools.exceptions import UWConfigError
+from uwtools.exceptions import UWConfigError, UWError
 from uwtools.logging import log
 
 # Fixtures
@@ -315,6 +316,35 @@ def test_config_validator__registry(tmp_path):
         r = validator._registry()
         assert r.get_or_retrieve("urn:uwtools:foo-bar").value.contents == d
     resource_path.assert_called_once_with("jsonschema/foo-bar.jsonschema")
+
+
+@mark.parametrize(
+    ("retriever", "ref_tail", "error"),
+    [
+        ("registry", "relative", Unretrievable),
+        ("registry", "absolute", Unretrievable),
+        ("resolver", "relative", UWError),
+        ("resolver", "absolute", FileNotFoundError),
+    ],
+)
+def test_config_validator__retrieve__blocks_traversal(retriever, ref_tail, error, tmp_path):
+    outside = tmp_path / "outside.jsonschema"
+    outside.write_text(json.dumps({"exfiltrated": True}))
+    schema_name = outside.with_suffix("")
+    if ref_tail == "relative":
+        rootless_schema_name = Path(*schema_name.resolve().parts[1:])
+        levels_to_root = [".."] * len(validator.resource_path("jsonschema").resolve().parts)
+        schema_name = Path(*levels_to_root) / rootless_schema_name
+    uri = f"urn:uwtools:{schema_name}"
+    if retriever == "registry":
+        validator._registry.cache_clear()
+        with raises(error):
+            validator._registry().get_or_retrieve(uri)
+    else:
+        retrieve = validator._resolver({}).handlers["urn"]
+        with raises(error):
+            retrieve(uri)
+    validator._registry.cache_clear()
 
 
 @mark.parametrize("msg", [validator.JSONSCHEMA_MSG_REGISTRY_NO_KWARG, "other"])

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -11,7 +11,6 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from pytest import fixture, mark, raises
-from referencing.exceptions import Unretrievable
 
 from uwtools.config import validator
 from uwtools.config.formats.yaml import YAMLConfig
@@ -318,33 +317,30 @@ def test_config_validator__registry(tmp_path):
     resource_path.assert_called_once_with("jsonschema/foo-bar.jsonschema")
 
 
-@mark.parametrize(
-    ("retriever", "ref_tail", "error"),
-    [
-        ("registry", "relative", Unretrievable),
-        ("registry", "absolute", Unretrievable),
-        ("resolver", "relative", UWError),
-        ("resolver", "absolute", FileNotFoundError),
-    ],
-)
-def test_config_validator__retrieve__blocks_traversal(retriever, ref_tail, error, tmp_path):
-    outside = tmp_path / "outside.jsonschema"
-    outside.write_text(json.dumps({"exfiltrated": True}))
-    schema_name = outside.with_suffix("")
-    if ref_tail == "relative":
-        rootless_schema_name = Path(*schema_name.resolve().parts[1:])
-        levels_to_root = [".."] * len(validator.resource_path("jsonschema").resolve().parts)
-        schema_name = Path(*levels_to_root) / rootless_schema_name
-    uri = f"urn:uwtools:{schema_name}"
-    if retriever == "registry":
-        validator._registry.cache_clear()
-        with raises(error):
-            validator._registry().get_or_retrieve(uri)
-    else:
-        retrieve = validator._resolver({}).handlers["urn"]
-        with raises(error):
-            retrieve(uri)
+def test_config_validator__registry__retrieve__no_exfil():
     validator._registry.cache_clear()
+    with patch.object(validator, "Registry") as Registry:
+        validator._registry()
+        retrieve = Registry.call_args.kwargs["retrieve"]
+    suffix = "../../exfiltrated.jsonschema"
+    uri = f"urn:uwtools:{suffix}"
+    with raises(UWError) as e:
+        retrieve(uri=uri)
+    expected = f"Resource reference 'jsonschema/{suffix}.jsonschema' is outside package resources"
+    assert str(e.value) == expected
+    validator._registry.cache_clear()
+
+
+def test_config_validator__resolver__retrieve__no_exfil():
+    with patch.object(validator.RefResolver, "from_schema") as from_schema:
+        validator._resolver({})
+        retrieve = from_schema.call_args.kwargs["handlers"]["urn"]
+    suffix = "../../exfiltrated.jsonschema"
+    uri = f"urn:uwtools:{suffix}"
+    with raises(UWError) as e:
+        retrieve(uri=uri)
+    expected = f"Resource reference 'jsonschema/{suffix}.jsonschema' is outside package resources"
+    assert str(e.value) == expected
 
 
 @mark.parametrize("msg", [validator.JSONSCHEMA_MSG_REGISTRY_NO_KWARG, "other"])

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -342,12 +342,14 @@ def test_config_validator__validation_errors__pass(config, pre_4_18_jsonschema, 
         ref_schema = tmp_path / "ref.jsonschema"
         ref_schema.write_text(json.dumps({"type": "number"}))
         schema["properties"]["number"] = {"$ref": "urn:uwtools:ref"}
-        mock = partial(
-            mock_extend, validator.validators.extend, validator.JSONSCHEMA_MSG_REGISTRY_NO_KWARG
+        extend = partial(
+            mock_extend,
+            validator.validators.extend,
+            validator.JSONSCHEMA_MSG_REGISTRY_NO_KWARG,
         )
         with (
-            patch.object(validator, "resource_path", return_value=tmp_path),
-            patch.object(validator.validators, "extend", mock),
+            patch.object(validator, "resource_path", return_value=ref_schema),
+            patch.object(validator.validators, "extend", extend),
         ):
             assert not validator._validation_errors(config, schema)
     else:

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -314,7 +314,7 @@ def test_config_validator__registry(tmp_path):
     with patch.object(validator, "resource_path", return_value=path) as resource_path:
         r = validator._registry()
         assert r.get_or_retrieve("urn:uwtools:foo-bar").value.contents == d
-    resource_path.assert_called_once_with("jsonschema/foo-bar.jsonschema")
+    resource_path.assert_called_with("jsonschema/foo-bar.jsonschema")
 
 
 def test_config_validator__schema__no_exfil():

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -317,13 +317,18 @@ def test_config_validator__registry(tmp_path):
     resource_path.assert_called_with("jsonschema/foo-bar.jsonschema")
 
 
-def test_config_validator__schema__no_exfil():
-    suffix = "../../exfiltrated.jsonschema"
+@mark.parametrize("suffix", ["../exfiltrated.jsonschema", "../../exfiltrated.jsonschema"])
+def test_config_validator__schema__no_exfil(suffix):
     uri = f"urn:uwtools:{suffix}"
     with raises(UWError) as e:
         validator._schema(uri=uri)
-    expected = f"Resource reference 'jsonschema/{suffix}.jsonschema' is outside package resources"
-    assert str(e.value) == expected
+    if suffix.startswith("../.."):
+        # Reference is outside of resources altogether:
+        msg = f"Resource reference 'jsonschema/{suffix}.jsonschema' is outside package resources"
+    else:
+        # Reference is in resources, but outside jsonschema/:
+        msg = f"Invalid schema URI: {uri}"
+    assert str(e.value) == msg
 
 
 @mark.parametrize("msg", [validator.JSONSCHEMA_MSG_REGISTRY_NO_KWARG, "other"])

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -141,8 +141,10 @@ def test_config_validator_bundle(logged):
 
 
 def test_config_validator_internal_schema_file():
-    with patch.object(validator, "resource_path", return_value=Path("/foo/bar")):
-        assert validator.internal_schema_file("baz") == Path("/foo/bar/baz.jsonschema")
+    path = Path("/foo/bar/baz.jsonschema")
+    with patch.object(validator, "resource_path", return_value=path) as rp:
+        assert validator.internal_schema_file("baz") == path
+    rp.assert_called_once_with("jsonschema/baz.jsonschema")
 
 
 @mark.parametrize(
@@ -283,7 +285,7 @@ def test_config_validator_validate_check_config(config_data, config_path):
 
 def test_config_validator_validate_internal__no(logged, schema_file):
     with (
-        patch.object(validator, "resource_path", return_value=schema_file.parent),
+        patch.object(validator, "resource_path", return_value=schema_file),
         raises(UWConfigError) as e,
     ):
         validator.validate_internal(schema_name="a", desc="test", config_data={"color": "orange"})
@@ -293,7 +295,7 @@ def test_config_validator_validate_internal__no(logged, schema_file):
 
 
 def test_config_validator_validate_internal__ok(schema_file):
-    with patch.object(validator, "resource_path", return_value=schema_file.parent):
+    with patch.object(validator, "resource_path", return_value=schema_file):
         validator.validate_internal(schema_name="a", desc="test", config_data={"color": "blue"})
 
 

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -317,24 +317,20 @@ def test_config_validator__registry(tmp_path):
     resource_path.assert_called_once_with("jsonschema/foo-bar.jsonschema")
 
 
-def test_config_validator__registry__retrieve__no_exfil():
-    validator._registry.cache_clear()
-    with patch.object(validator, "Registry") as Registry:
-        validator._registry()
-        retrieve = Registry.call_args.kwargs["retrieve"]
-    suffix = "../../exfiltrated.jsonschema"
-    uri = f"urn:uwtools:{suffix}"
-    with raises(UWError) as e:
-        retrieve(uri=uri)
-    expected = f"Resource reference 'jsonschema/{suffix}.jsonschema' is outside package resources"
-    assert str(e.value) == expected
-    validator._registry.cache_clear()
-
-
-def test_config_validator__resolver__retrieve__no_exfil():
-    with patch.object(validator.RefResolver, "from_schema") as from_schema:
-        validator._resolver({})
-        retrieve = from_schema.call_args.kwargs["handlers"]["urn"]
+@mark.parametrize("caller", ["registry", "resolver"])
+def test_config_validator__registry__retrieve__no_exfil(caller):
+    # The retrieve() function is nested, so use a mocked call to retrieve it:
+    if caller == "registry":
+        validator._registry.cache_clear()
+        with patch.object(validator, "Registry") as Registry:
+            validator._registry()
+            retrieve = Registry.call_args.kwargs["retrieve"]
+        validator._registry.cache_clear()
+    else:  # caller is "resolver"
+        with patch.object(validator.RefResolver, "from_schema") as from_schema:
+            validator._resolver({})
+            retrieve = from_schema.call_args.kwargs["handlers"]["urn"]
+    # Now test that relative paths cannot be used to exfiltrate:
     suffix = "../../exfiltrated.jsonschema"
     uri = f"urn:uwtools:{suffix}"
     with raises(UWError) as e:

--- a/src/uwtools/tests/test_ecflow.py
+++ b/src/uwtools/tests/test_ecflow.py
@@ -795,7 +795,7 @@ class Test_ECFlowDef:  # noqa: N801
 @mark.parametrize("insecure", [True, False])
 def test_ecflow__client(insecure):
     portnum = 54321
-    with patch.object(ecflow, "Client") as Client:  # noqa: N806
+    with patch.object(ecflow, "Client") as Client:
         ecflow._client(port=portnum, insecure=insecure)
     Client.assert_called_once_with(socket.gethostname(), str(portnum))
     if insecure:

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -49,7 +49,7 @@ def validation_assets(tmp_path):
 
 
 def test_rocoto_iterate(rocoto_iterator_args):
-    with patch.object(rocoto, "_RocotoIterator") as _RocotoIterator:  # noqa: N806
+    with patch.object(rocoto, "_RocotoIterator") as _RocotoIterator:
         rocoto.iterate(**rocoto_iterator_args)
     _RocotoIterator.assert_called_once_with(*rocoto_iterator_args.values())
 

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from pytest import mark, raises
 
+from uwtools.exceptions import UWError
 from uwtools.strings import FORMAT
 from uwtools.utils import file
 
@@ -119,6 +120,14 @@ def test_readable_nofile():
 
 def test_resource_path():
     assert file.resource_path().is_dir()
+    assert file.resource_path("info.json").is_file()
+
+
+def test_resource_path__bad():
+    ref = "../exfiltrated.txt"
+    with raises(UWError) as e:
+        file.resource_path(ref)
+    assert str(e.value) == "Resource reference '%s' is outside package resources" % ref
 
 
 @mark.parametrize("val", [Path("/some/path"), {"foo": 42}])

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import IO, TYPE_CHECKING, Any
 
+from uwtools.exceptions import UWError
 from uwtools.logging import log
 from uwtools.strings import FORMAT
 
@@ -125,8 +126,12 @@ def resource_path(suffix: str = "") -> Path:
     :param suffix: A subpath relative to the location of the uwtools resource files. The prefix path
         to the resources files is known to Python and varies based on installation location.
     """
-    with resources.as_file(resources.files("uwtools.resources")) as prefix:
-        return prefix / suffix
+    root = resources.files("uwtools.resources")
+    with resources.as_file(root) as prefix:
+        path = prefix / suffix
+        if not path.resolve().is_relative_to(prefix.resolve()):
+            raise UWError("Resource reference '%s' is outside package resources" % suffix)
+    return path
 
 
 def str2path(val: Any) -> Any:

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -131,7 +131,7 @@ def resource_path(suffix: str = "") -> Path:
         path = prefix / suffix
         if not path.resolve().is_relative_to(prefix.resolve()):
             raise UWError("Resource reference '%s' is outside package resources" % suffix)
-    return path
+        return path
 
 
 def str2path(val: Any) -> Any:


### PR DESCRIPTION
**Synopsis**

A potential user pointed out the possibility of a kind of data exfiltration via `$ref` references to schema files that contain relative paths, e.g. a series of `..` path components that traverse the filesystem, out of the package-resources directory toward the root, then down to files in arbitrary directories.

This PR addresses this by checking that package-resource references, before they are returned to the caller, remain inside the package-resources directory.

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
- [x] Where helpful, I have written comments in this PR's _Files changed_ view to assist reviewers.
